### PR TITLE
Corrected spelling of depricated to deprecated

### DIFF
--- a/R/FFForest.R
+++ b/R/FFForest.R
@@ -15,7 +15,7 @@
 #' @param quiet logical. Should progress reports be printed?
 #' @param cpus integer. Number of cpus to use. Any value larger than 1 will initiate parallel calculations in snowfall.
 #' @param do.comp,do.lr,do.cart,do.rf,do.svm logical. See arguments in \code{FFTrees()}
-#' @param rank.method,hr.weight depricated arguments
+#' @param rank.method,hr.weight deprecated arguments
 #' @importFrom stats formula
 #' @importFrom parallel mclapply
 
@@ -77,18 +77,18 @@ FFForest <- function(formula = NULL,
   # train.p = .5
 
 
-# Check for depricated arguments
+# Check for deprecated arguments
 
 if(is.null(rank.method) == FALSE) {
 
-  warning("The argument rank.method is depricated. Use algorithm instead.")
+  warning("The argument rank.method is deprecated. Use algorithm instead.")
 
   algorithm <- rank.method
 
 }
 if(is.null(hr.weight) == FALSE) {
 
-    warning("The argument hr.weight is depricated. Use sens.weight instead.")
+    warning("The argument hr.weight is deprecated. Use sens.weight instead.")
 
     sens.weight <- hr.weight
 

--- a/R/FFTrees.R
+++ b/R/FFTrees.R
@@ -27,7 +27,7 @@
 #' @param do.comp,do.cart,do.lr,do.rf,do.svm logical. Should alternative algorithms be created for comparison? cart = regular (non-frugal) trees with \code{rpart}, lr = logistic regression with \code{glm}, rf = random forests with \code{randomForest}, svm = support vector machines with \code{e1071}. Setting \code{comp = FALSE} sets all these arguments to FALSE.
 #' @param store.data logical. Should training / test data be stored in the object? Default is FALSE.
 #' @param object FFTrees. An optional existing FFTrees object. When specified, no new trees are fitted and the existing trees are applied to \code{data} and \code{data.test}.
-#' @param rank.method,verbose,comp depricated arguments.
+#' @param rank.method,verbose,comp deprecated arguments.
 #' @param force logical. If TRUE, forces some parameters (like goal) to be as specified by the user even when the algorithm thinks those specifications don't make sense.
 #' @importFrom stats anova predict glm as.formula formula sd
 #' @return An \code{FFTrees} object with the following elements
@@ -158,11 +158,11 @@ FFTrees <- function(formula = NULL,
   # verbose = NULL
   # comp = NULL
 
-# Depricated arguments
+# Deprecated arguments
 {
   if(is.null(verbose) == FALSE) {
 
-    warning("The argument verbose is depricated. Use progress instead.")
+    warning("The argument verbose is deprecated. Use progress instead.")
 
     progress <- verbose
 
@@ -170,7 +170,7 @@ FFTrees <- function(formula = NULL,
 
   if(is.null(rank.method) == FALSE) {
 
-    warning("The argument rank.method is depricated. Use algorithm instead.")
+    warning("The argument rank.method is deprecated. Use algorithm instead.")
 
     algorithm <- rank.method
 
@@ -178,7 +178,7 @@ FFTrees <- function(formula = NULL,
 
   if(is.null(comp) == FALSE) {
 
-    warning("The argument comp is depricated. Use do.comp instead.")
+    warning("The argument comp is deprecated. Use do.comp instead.")
 
     do.comp <- comp
 
@@ -342,14 +342,14 @@ if(algorithm %in% valid.algorithms == FALSE) {
 
   if(algorithm == "m") {
 
-    message("Algorithm 'm' is depricated, using 'ifan' instead")
+    message("Algorithm 'm' is deprecated, using 'ifan' instead")
     algorithm <- "ifan"
 
   }
 
   if(algorithm == "c") {
 
-    message("Algorithm 'c' is depricated, using 'dfan' instead")
+    message("Algorithm 'c' is deprecated, using 'dfan' instead")
     algorithm <- "dfan"
 
     }

--- a/R/growFFTrees_function.R
+++ b/R/growFFTrees_function.R
@@ -15,8 +15,8 @@
 #' @param stopping.par numeric. A number indicating the parameter for the stopping rule. For stopping.rule == "levels", this is the number of levels. For stopping rule == "exemplars", this is the smallest percentage of examplars allowed in the last level.
 #' @param quiet logical. Should progress messages be shown?
 #' @param repeat.cues logical. Can cues occur multiple times within a tree?
-#' @param rank.method depricated arguments
-#' @param cue.accuracies depricated arguments
+#' @param rank.method deprecated arguments
+#' @param cue.accuracies deprecated arguments
 #' @param ... Currently ignored
 #' @importFrom stats anova predict glm as.formula var
 #' @return A list of length 4. tree.definitions contains definitions of the tree(s). tree.stats contains classification statistics for the tree(s). levelout shows which level in the tree(s) each exemplar is classified. Finally, decision shows the classification decision for each tree for each exemplar
@@ -83,10 +83,10 @@ grow.FFTrees <- function(formula,
 
 
 # #
-# Depricated arguments
+# Deprecated arguments
 if(is.null(rank.method) == FALSE) {
 
-  warning("The argument rank.method is depricated. Use algorithm instead.")
+  warning("The argument rank.method is deprecated. Use algorithm instead.")
 
   algorithm <- rank.method
 

--- a/R/plotFFTrees_function.R
+++ b/R/plotFFTrees_function.R
@@ -19,7 +19,7 @@
 #' @param n.per.icon Number of cases per icon
 #' @param which.tree deprecated argument, only for backwards compatibility, use \code{"tree"} instead.
 #' @param level.type string. How should bottom levels be drawn? Can be \code{"bar"} or \code{"line"}
-#' @param decision.names depricated arguments.
+#' @param decision.names deprecated arguments.
 #' @param ... Currently ignored.
 #' @importFrom stats anova predict formula model.frame
 #' @importFrom graphics text points abline legend mtext segments rect arrows axis par layout plot
@@ -115,7 +115,7 @@ if(what %in% c("cues", "tree", "roc") == FALSE) {
 
 if(is.null(decision.names) == FALSE) {
 
-  message("decision.names is depricated, use decision.lables instead")
+  message("decision.names is deprecated, use decision.lables instead")
 
   decision.labels <- decision.names
 }

--- a/R/predictFFTrees_function.R
+++ b/R/predictFFTrees_function.R
@@ -6,7 +6,7 @@
 #' @param type string. What should be predicted? Can be \code{"class"}, which returns a vector of class predictions, or \code{"prob"} which returns a matrix of class probabilities.
 #' @param method string. Method of calculating class probabilities. Either 'laplace', which applies the Laplace correction, or 'raw' which applies no correction.
 #' @param ... Additional arguments passed on to \code{predict()}
-#' @param sens.w,data depricated
+#' @param sens.w,data deprecated
 #' @return Either a logical vector of predictions, or a matrix of class probabilities.
 #' @export
 #' @examples
@@ -57,7 +57,7 @@ predict.FFTrees <- function(
 
   }
 
-  if(is.null(sens.w) == FALSE) {stop("sens.w is depricated and will be ignored.")}
+  if(is.null(sens.w) == FALSE) {stop("sens.w is deprecated and will be ignored.")}
 
   goal <- object$params$goal
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ plot(heart.fft,
 
 - Changed wording of statistics throughout package. `hr` (hit rate) and `far` (false alarm rate) are now `sens` for sensitivity, and `spec` for specificity (1 - false alarm rate)
 
-- The `rank.method` argument is now depricated. Use `algorithm` instead.
+- The `rank.method` argument is now deprecated. Use `algorithm` instead.
 
 - Added `stats` argument to `plot.FFTrees()`. When `stats = FALSE`, only the tree will be plotted without reference to any statistical output.
 

--- a/man/FFForest.Rd
+++ b/man/FFForest.Rd
@@ -37,7 +37,7 @@ FFForest(formula = NULL, data = NULL, data.test = NULL, max.levels = 5,
 
 \item{do.comp, do.lr, do.cart, do.rf, do.svm}{logical. See arguments in \code{FFTrees()}}
 
-\item{rank.method, hr.weight}{depricated arguments}
+\item{rank.method, hr.weight}{deprecated arguments}
 }
 \value{
 An object of class \code{FFForest} with the following elements...

--- a/man/FFTrees.Rd
+++ b/man/FFTrees.Rd
@@ -65,7 +65,7 @@ FFTrees(formula = NULL, data = NULL, data.test = NULL,
 
 \item{object}{FFTrees. An optional existing FFTrees object. When specified, no new trees are fitted and the existing trees are applied to \code{data} and \code{data.test}.}
 
-\item{rank.method, verbose, comp}{depricated arguments.}
+\item{rank.method, verbose, comp}{deprecated arguments.}
 
 \item{force}{logical. If TRUE, forces some parameters (like goal) to be as specified by the user even when the algorithm thinks those specifications don't make sense.}
 

--- a/man/grow.FFTrees.Rd
+++ b/man/grow.FFTrees.Rd
@@ -42,9 +42,9 @@ grow.FFTrees(formula, data, max.levels = NULL, algorithm = "ifan",
 
 \item{repeat.cues}{logical. Can cues occur multiple times within a tree?}
 
-\item{rank.method}{depricated arguments}
+\item{rank.method}{deprecated arguments}
 
-\item{cue.accuracies}{depricated arguments}
+\item{cue.accuracies}{deprecated arguments}
 
 \item{...}{Currently ignored}
 }

--- a/man/plot.FFTrees.Rd
+++ b/man/plot.FFTrees.Rd
@@ -50,7 +50,7 @@
 
 \item{level.type}{string. How should bottom levels be drawn? Can be \code{"bar"} or \code{"line"}}
 
-\item{decision.names}{depricated arguments.}
+\item{decision.names}{deprecated arguments.}
 
 \item{...}{Currently ignored.}
 }

--- a/man/predict.FFTrees.Rd
+++ b/man/predict.FFTrees.Rd
@@ -16,7 +16,7 @@
 
 \item{type}{string. What should be predicted? Can be \code{"class"}, which returns a vector of class predictions, or \code{"prob"} which returns a matrix of class probabilities.}
 
-\item{sens.w, data}{depricated}
+\item{sens.w, data}{deprecated}
 
 \item{method}{string. Method of calculating class probabilities. Either 'laplace', which applies the Laplace correction, or 'raw' which applies no correction.}
 


### PR DESCRIPTION
Hi, while reading the code for FFTrees I noticed that the work "deprecated" was misspelled as "depricated" I corrected the spelling. 

Thanks