### PR TITLE
Fix CRAN issue

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,11 @@
 
+## Resubmission
+
+This is a resubmission. In this version I have:
+
+* Changed automated references from "http://doi.org/" to "https://doi.org/" (to fix invalid URLs). 
+
+
 ## Test environments
 
 * local OS X install, R 4.0.5 
@@ -8,6 +15,7 @@
 * Ubuntu Linux 20.04.1 LTS, R-release, GCC 
 * Fedora Linux, R-devel, clang, gfortran 
 
+
 ## R CMD check results
 
 There were no ERRORs or WARNINGs.
@@ -15,7 +23,8 @@ There were no ERRORs or WARNINGs.
 There was one NOTE: The new maintainer name/contact info (Hansjoerg Neth <h.neth@uni.kn>) is correct, 
 as confirmed in email from previous maintainer (Nathaniel Phillips <nathaniel.d.phillips.is@gmail.com>) to CRAN (<cran-submissions@r-project.org>) on 2022-08-30, 18:27 CEST. See also <https://github.com/ndphillips/FFTrees/issues/70>. 
 
-The "(possibly) invalid URLs" are valid.
+The remaining "(possibly) invalid URLs" are valid.
+
 
 ## Downstream dependencies
 

--- a/vignettes/apa.csl
+++ b/vignettes/apa.csl
@@ -136,7 +136,7 @@
       <if type="thesis report" match="any">
         <choose>
           <if variable="DOI" match="any">
-            <text variable="DOI" prefix="http://doi.org/"/>
+            <text variable="DOI" prefix="https://doi.org/"/>
           </if>
           <else-if variable="archive" match="any">
             <group>
@@ -158,7 +158,7 @@
       <else>
         <choose>
           <if variable="DOI">
-            <text variable="DOI" prefix="http://doi.org/"/>
+            <text variable="DOI" prefix="https://doi.org/"/>
           </if>
           <else>
             <choose>


### PR DESCRIPTION
Preparing for CRAN resubmission:

* Changed automated references from "http://doi.org/" to "https://doi.org/" (to fix invalid URLs). 