### PR TITLE
Compute `wacc` for and include in stats of competing algorithms

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.7.0.9001
-Date: 2022-09-01
+Version: 1.7.0.9002
+Date: 2022-09-02
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.7 
 
-## 1.7.0.9000
+## 1.7.0.9002
 
 <!-- Development version: --> 
 
@@ -19,7 +19,7 @@ Changes since last release:
 
 ### Minor changes 
 
-- none yet.
+- Added `wacc` to measures computed for competing algorithms (using current `sens.w` value). 
 
 
 ### Details 
@@ -291,6 +291,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2022-08-31.] 
+[File `NEWS.md` last updated on 2022-09-02.] 
 
 <!-- eof. -->

--- a/R/fftrees_fitcomp.R
+++ b/R/fftrees_fitcomp.R
@@ -14,6 +14,7 @@
 fftrees_fitcomp <- function(x) {
 
   # Parameters: ------
+
   do.lr <- x$params$do.lr
   do.svm <- x$params$do.svm
   do.cart <- x$params$do.cart
@@ -32,7 +33,7 @@ fftrees_fitcomp <- function(x) {
   )
 
 
-  # FFTrees: ----
+  # A. FFTrees: ----
 
   x$competition$train <- x$trees$stats$train %>%
     dplyr::filter(tree == 1) %>%
@@ -47,17 +48,19 @@ fftrees_fitcomp <- function(x) {
   }
 
 
+  # B. Competition: ------
+
   if (do.lr | do.cart | do.rf | do.svm) {
     if (!x$params$quiet) {
       message("Fitting other algorithms for comparison (disable with do.comp = FALSE) ...")
     }
   }
 
-
-  # LR: ----
+  # - LR: ----
 
   {
     if (do.lr) {
+
       lr.acc <- comp_pred(
         formula = x$formula,
         data.train = x$data$train,
@@ -86,10 +89,11 @@ fftrees_fitcomp <- function(x) {
   }
 
 
-  # CART: ----
+  # - CART: ----
 
   {
     if (do.cart) {
+
       cart.acc <- comp_pred(
         formula = x$formula,
         data.train = x$data$train,
@@ -118,10 +122,11 @@ fftrees_fitcomp <- function(x) {
   }
 
 
-  # RF: ----
+  # - RF: ----
 
   {
     if (do.rf) {
+
       rf.acc <- comp_pred(
         formula = x$formula,
         data.train = x$data$train,
@@ -151,10 +156,11 @@ fftrees_fitcomp <- function(x) {
   }
 
 
-  # SVM: ----
+  # - SVM: ----
 
   {
     if (do.svm) {
+
       svm.acc <- comp_pred(
         formula = x$formula,
         data.train = x$data$train,

--- a/R/fftrees_fitcomp.R
+++ b/R/fftrees_fitcomp.R
@@ -15,21 +15,27 @@ fftrees_fitcomp <- function(x) {
 
   # Parameters: ------
 
-  do.lr <- x$params$do.lr
-  do.svm <- x$params$do.svm
+  do.lr   <- x$params$do.lr
+  do.svm  <- x$params$do.svm
   do.cart <- x$params$do.cart
-  do.rf <- x$params$do.rf
+  do.rf   <- x$params$do.rf
 
   if (x$params$do.comp == FALSE) {
-    do.lr <- FALSE
+    do.lr   <- FALSE
     do.cart <- FALSE
-    do.svm <- FALSE
-    do.rf <- FALSE
+    do.svm  <- FALSE
+    do.rf   <- FALSE
   }
 
-  my_cols <- c(
-    "algorithm", "n", "hi", "fa", "mi", "cr", "sens", "spec", "far",
-    "ppv", "npv", "acc", "bacc", "cost", "cost_decisions", "cost_cues"
+  sens.w <- x$params$sens.w  # required for wacc
+
+
+  # Set the measures/columns to select from stats (computed by classtable() helper): ----
+  my_cols <- c("algorithm",
+               "n", "hi", "fa", "mi", "cr",
+               "sens", "spec", "far", "ppv", "npv",
+               "acc", "bacc", "wacc",  # ToDo: Add dprime?
+               "cost", "cost_decisions", "cost_cues"
   )
 
 
@@ -56,6 +62,7 @@ fftrees_fitcomp <- function(x) {
     }
   }
 
+
   # - LR: ----
 
   {
@@ -66,7 +73,8 @@ fftrees_fitcomp <- function(x) {
         data.train = x$data$train,
         data.test = x$data$test,
         algorithm = "lr",
-        model = NULL
+        model = NULL,
+        sens.w = sens.w
       )
 
       lr.stats <- lr.acc$accuracy
@@ -99,7 +107,8 @@ fftrees_fitcomp <- function(x) {
         data.train = x$data$train,
         data.test = x$data$test,
         algorithm = "cart",
-        model = NULL
+        model = NULL,
+        sens.w = sens.w
       )
 
       cart.stats <- cart.acc$accuracy
@@ -132,7 +141,8 @@ fftrees_fitcomp <- function(x) {
         data.train = x$data$train,
         data.test = x$data$test,
         algorithm = "rf",
-        model = NULL
+        model = NULL,
+        sens.w = sens.w
       )
 
 
@@ -166,7 +176,8 @@ fftrees_fitcomp <- function(x) {
         data.train = x$data$train,
         data.test = x$data$test,
         algorithm = "svm",
-        model = NULL
+        model = NULL,
+        sens.w = sens.w
       )
 
       svm.stats <- svm.acc$accuracy

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -166,7 +166,7 @@ fftrees_grow_fan <- function(x,
       exit_current  <- exits_i[level_current]
       cases_remaining <- is.na(decision_v)
 
-      # Step 1: Determine cue for current level: ----
+      # Step 1: Determine cue for current level: ------
       {
         # ifan x$params$algorithm
         if (x$params$algorithm == "ifan") {
@@ -232,7 +232,7 @@ fftrees_grow_fan <- function(x,
         level_stats_i$exit[level_current] <- exit_current
       }
 
-      # Step 2: Determine how classifications would look if all remaining exemplars were classified: ----
+      # Step 2: Determine how classifications would look if all remaining exemplars were classified: ------
       {
 
         # Get decisions for current cue:
@@ -257,7 +257,8 @@ fftrees_grow_fan <- function(x,
         # Calculate asif_cm:
         asif_results <- classtable(
           prediction_v = asif.decision_v,
-          criterion_v = criterion_v
+          criterion_v  = criterion_v,
+          sens.w = x$params$sens.w
         )
 
 
@@ -268,10 +269,14 @@ fftrees_grow_fan <- function(x,
         # If ASIF classification is perfect, then stop:
         if (x$params$goal.chase != "cost") {
           if (dplyr::near(asif.stats[[x$params$goal.chase]][level_current], 1)) {
+
             grow.tree <- FALSE
           }
+
         } else {
+
           if (dplyr::near(asif.stats[[x$params$goal.chase]][level_current], 0)) {
+
             grow.tree <- FALSE
           }
         }
@@ -289,7 +294,7 @@ fftrees_grow_fan <- function(x,
         }
       }
 
-      # Step 3: Classify exemplars in current level: ----
+      # Step 3: Classify exemplars in current level: ------
       {
         if (dplyr::near(exit_current, 1) | dplyr::near(exit_current, .5)) {
           decide.1.index <- cases_remaining & cue.decisions == TRUE
@@ -317,7 +322,7 @@ fftrees_grow_fan <- function(x,
         outcomecost_v[cr_v == TRUE] <- x$params$cost.outcomes$cr
       }
 
-      # Step 4: Update results: ----
+      # Step 4: Update results: ------
       {
         cases_remaining <- is.na(decision_v)
 
@@ -345,7 +350,7 @@ fftrees_grow_fan <- function(x,
         level_stats_i[level_current, c("hi", "fa", "mi", "cr", "sens", "spec", "bacc", "acc", "wacc", "cost_decisions", "cost")] <- results_cum[, c("hi", "fa", "mi", "cr", "sens", "spec", "bacc", "acc", "wacc", "cost_decisions", "cost")]
       }
 
-      # Step 5: Continue growing tree? ----
+      # Step 5: Continue growing tree? ------
       {
         cases_remaining_n <- sum(cases_remaining)
 

--- a/R/helper.R
+++ b/R/helper.R
@@ -961,7 +961,7 @@ add_stats <- function(data,
 #' @param prediction_v logical. A logical vector of predictions.
 #' @param criterion_v logical. A logical vector of (TRUE) criterion values.
 #' @param sens.w numeric. Sensitivity weight parameter (from 0 to 1, for computing \code{wacc}).
-#' Default: \code{sens.w = 0.50} (but actual value to be passed by the calling function).
+#' Default: \code{sens.w = NULL} (to enforce that actual value is being passed by the calling function).
 #' @param cost.v list. An optional list of additional costs to be added to each case.
 #' @param correction numeric. Correction added to all counts for calculating \code{dprime}.
 #' @param cost.outcomes list. A list of length 4 with names 'hi', 'fa', 'mi', and 'cr' specifying
@@ -974,8 +974,8 @@ add_stats <- function(data,
 #' @importFrom caret confusionMatrix
 
 classtable <- function(prediction_v = NULL,
-                       criterion_v,
-                       sens.w = NULL,  # to be passed by calling function
+                       criterion_v  = NULL,
+                       sens.w = NULL,  # to be passed by calling function!
                        cost.v = NULL,
                        correction = .25,
                        cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0),

--- a/README.Rmd
+++ b/README.Rmd
@@ -136,7 +136,7 @@ plot(heart.fft,
      main = "Heart Disease")
 ```
 
-![A fast-and-frugal tree (FFT) predicting heart diseases for `test` data and its performance characteristics.](man/figures/README-example-heart-plot-1.png)
+![An FFT predicting heart disease for `test` data.](man/figures/README-example-heart-plot-1.png)
 
 **Figure\ 1**: A fast-and-frugal tree (FFT) predicting heart disease for `test` data and its performance characteristics.  
 
@@ -181,7 +181,7 @@ plot(my.fft,
      main = "My custom FFT")
 ```
 
-![An FFT predicting heart disease created from a verbal description.](man/figures/README-example-heart-verbal-1.png)
+![An FFT created from a verbal description.](man/figures/README-example-heart-verbal-1.png)
 
 **Figure\ 2**: An FFT predicting heart disease created from a verbal description.  
 
@@ -204,7 +204,7 @@ Retrieved from `r url_JDM_pdf`
 
 
 We encourage you to read the article to learn more about the history of FFTs and how the **FFTrees** package creates, visualizes, and evaluates them. 
-If you use **FFTrees** in your own work, please cite us and share your experiences (e.g., [on GitHub](`r url_pkg_issues`)) so we can continue developing the package. 
+When using **FFTrees** in your own work, please cite us and share your experiences (e.g., [on GitHub](`r url_pkg_issues`)) so we can continue developing the package. 
 
 <!-- Examples uses/publications (with links): -->
 

--- a/README.md
+++ b/README.md
@@ -182,9 +182,8 @@ evaluate their predictive performance on the `heart.test` data:
          data = "test",
          main = "Heart Disease")
 
-![A fast-and-frugal tree (FFT) predicting heart diseases for `test` data
-and its performance
-characteristics.](man/figures/README-example-heart-plot-1.png)
+![An FFT predicting heart disease for `test`
+data.](man/figures/README-example-heart-plot-1.png)
 
 **Figure 1**: A fast-and-frugal tree (FFT) predicting heart disease for
 `test` data and its performance characteristics.
@@ -242,7 +241,7 @@ These conditions can directly be supplied to the `my.tree` argument of
          data = "test",
          main = "My custom FFT")
 
-![An FFT predicting heart disease created from a verbal
+![An FFT created from a verbal
 description.](man/figures/README-example-heart-verbal-1.png)
 
 **Figure 2**: An FFT predicting heart disease created from a verbal
@@ -276,7 +275,7 @@ decision trees* (available in
 
 We encourage you to read the article to learn more about the history of
 FFTs and how the **FFTrees** package creates, visualizes, and evaluates
-them. If you use **FFTrees** in your own work, please cite us and share
+them. When using **FFTrees** in your own work, please cite us and share
 your experiences (e.g., [on
 GitHub](https://github.com/ndphillips/FFTrees/issues)) so we can
 continue developing the package.
@@ -323,6 +322,6 @@ for the full list):
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2022-09-01.\]
+\[File `README.Rmd` last updated on 2022-09-02.\]
 
 <!-- eof. -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.7.0.9001 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.7.0.9002 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Status badges: -->
 
@@ -195,7 +195,7 @@ data.](man/figures/README-example-heart-plot-1.png)
 
     # Compare predictive performance across algorithms: 
     heart.fft$competition$test
-    #> # A tibble: 5 × 16
+    #> # A tibble: 5 × 17
     #>   algorithm     n    hi    fa    mi    cr  sens  spec    far   ppv   npv   acc
     #>   <chr>     <int> <int> <int> <int> <int> <dbl> <dbl>  <dbl> <dbl> <dbl> <dbl>
     #> 1 fftrees     153    64    19     9    61 0.877 0.762 0.238  0.771 0.871 0.817
@@ -203,8 +203,8 @@ data.](man/figures/README-example-heart-plot-1.png)
     #> 3 cart        153    50    19    23    61 0.685 0.762 0.238  0.725 0.726 0.725
     #> 4 rf          153    59     8    14    72 0.808 0.9   0.1    0.881 0.837 0.856
     #> 5 svm         153    55     7    18    73 0.753 0.912 0.0875 0.887 0.802 0.837
-    #> # … with 4 more variables: bacc <dbl>, cost <dbl>, cost_decisions <dbl>,
-    #> #   cost_cues <dbl>
+    #> # … with 5 more variables: bacc <dbl>, wacc <dbl>, cost <dbl>,
+    #> #   cost_decisions <dbl>, cost_cues <dbl>
 
 <!-- FFTs by verbal description: -->
 

--- a/man/classtable.Rd
+++ b/man/classtable.Rd
@@ -6,8 +6,8 @@
 \usage{
 classtable(
   prediction_v = NULL,
-  criterion_v,
-  sens.w = 0.5,
+  criterion_v = NULL,
+  sens.w = NULL,
   cost.v = NULL,
   correction = 0.25,
   cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0),
@@ -20,7 +20,7 @@ classtable(
 \item{criterion_v}{logical. A logical vector of (TRUE) criterion values.}
 
 \item{sens.w}{numeric. Sensitivity weight parameter (from 0 to 1, for computing \code{wacc}).
-Default: \code{sens.w = .50}.}
+Default: \code{sens.w = NULL} (to enforce that actual value is being passed by the calling function).}
 
 \item{cost.v}{list. An optional list of additional costs to be added to each case.}
 
@@ -34,5 +34,8 @@ a false alarm and miss cost 10 and 20, respectively, while correct decisions hav
 \item{na_prediction_action}{What happens when no prediction is possible? (experimental).}
 }
 \description{
+The main input are 2 logical vectors of prediction and criterion values.
+}
+\details{
 The primary confusion matrix is computed by \code{\link{confusionMatrix}} of the \strong{caret} package.
 }

--- a/man/comp_pred.Rd
+++ b/man/comp_pred.Rd
@@ -10,26 +10,32 @@ comp_pred(
   data.test = NULL,
   algorithm = NULL,
   model = NULL,
+  sens.w = NULL,
   new.factors = "exclude"
 )
 }
 \arguments{
-\item{formula}{a formula}
+\item{formula}{A formula (ususally \code{x$formula}, for an \code{FFTrees} object \code{x}).}
 
-\item{data.train}{dataframe. A training dataset.}
+\item{data.train}{A training dataset (as data frame).}
 
-\item{data.test}{dataframe. A testing dataset.}
+\item{data.test}{A testing dataset (as data frame).}
 
-\item{algorithm}{string. An algorithm in the set
-"lr" -- logistic regression, "cart" -- decision trees, "rlr" -- regularized logistic regression,
-"svm" -- support vector machines, "rf" -- random forests}
+\item{algorithm}{character string. An algorithm in the set:
+"lr" -- logistic regression;
+"rlr" -- regularized logistic regression;
+"cart" -- decision trees;
+"svm" -- support vector machines;
+"rf" -- random forests.}
 
-\item{model}{model. An optional existing model applied to test data}
+\item{model}{model. An optional existing model, applied to the test data.}
+
+\item{sens.w}{Sensitivity weight parameter (from 0 to 1, required to compute \code{wacc}).}
 
 \item{new.factors}{string. What should be done if new factor values are discovered in the test set?
 "exclude" = exclude (i.e.; remove these cases), "base" = predict the base rate of the criterion.}
 }
 \description{
-\code{comp_pred} provides a wrapper for many classification algorithms --- such as CART (\code{rpart::rpart}),
+\code{comp_pred} provides the main wrapper for running alternative classification algorithms, such as CART (\code{rpart::rpart}),
 logistic regression (\code{glm}), support vector machines (\code{svm::svm}), and random forests (\code{randomForest::randomForest}).
 }


### PR DESCRIPTION
This set of commits computes and provides `wacc` for all competing algorithms (by passing current `sens.w` value from `fftrees_fitcomp()` to `comp_pred()` and from there to `classtable()` (which now uses a default of `sens.w = NULL` to enforce that current value is being passed from all calling functions).