### PR TITLE
Using data for providing new `data` (as df) in `print()` or `plot()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.7.0.9005
-Date: 2022-09-10
+Version: 1.7.0.9006
+Date: 2022-09-11
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.7.0.9004
-Date: 2022-09-09
+Version: 1.7.0.9005
+Date: 2022-09-10
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,5 +37,5 @@ License: CC0
 URL: https://CRAN.R-project.org/package=FFTrees, https://github.com/ndphillips/FFTrees/
 BugReports: https://github.com/ndphillips/FFTrees/issues
 VignetteBuilder: knitr
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Language: en-US

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.7 
 
-## 1.7.0.9005
+## 1.7.0.9006
 
 <!-- Development version: --> 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.7 
 
-## 1.7.0.9004
+## 1.7.0.9005
 
 <!-- Development version: --> 
 
@@ -14,6 +14,7 @@ Changes since last release:
 
 ### Major changes
 
+- Enabled applying a tree to new data when providing a data frame to `plot.FFTrees()` and `print.FFTrees()`. 
 - Added new plotting options to `plot.FFTrees()` (e.g., `what = 'all'` vs. `what = 'tree'` and `what = 'icontree'`). 
 
 
@@ -293,6 +294,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2022-09-09.] 
+[File `NEWS.md` last updated on 2022-09-11.] 
 
 <!-- eof. -->

--- a/R/plotFFTrees_function.R
+++ b/R/plotFFTrees_function.R
@@ -137,7 +137,7 @@
 
 plot.FFTrees <- function(x = NULL,
                          data = "train",
-                         what = "all",     # valid_what <- c("all", "cues", "tree", "roc")
+                         what = "all",  # valid_what <- c("all", "default",  "cues",  "tree", "icontree",  "roc")
                          tree = 1,
                          main = NULL,
                          cue.labels = NULL,
@@ -394,7 +394,7 @@ plot.FFTrees <- function(x = NULL,
     # data: ----
 
     # Note: data can be either a string "train"/"test"
-    #       OR an entire data frame (of new test data)!
+    #       OR an entire data frame (of new test data):
 
     if (inherits(data, "character")) {
 
@@ -404,6 +404,33 @@ plot.FFTrees <- function(x = NULL,
       if (!data %in% c("test", "train")){
         stop("The data to plot must be 'test' or 'train'.")
       }
+    }
+
+    if (inherits(data, "data.frame")) {
+
+      message("Applying FFTrees object x to new test data")
+
+      bang <- FALSE
+
+      if (bang){
+
+        x <- fftrees_apply(x, mydata = "test", newdata = data)
+
+        x <<- x  # to change global x?
+        # Problem: Assigns a global object "x", rather than the current FFTrees object.
+
+        message("Success, and assigned x to a global FFTrees object 'x'")
+
+      } else {
+
+        x <- fftrees_apply(x, mydata = "test", newdata = data)
+
+        message("Success, but re-assign 'x <- fftrees_apply(x, newdata = data)' to change global x")
+
+      }
+
+      data <- "test" # in rest of this function
+
     }
 
 
@@ -2458,7 +2485,8 @@ plot.FFTrees <- function(x = NULL,
 #   2. Remove ROC curve parts to a separate function, and
 #      handle what == "roc" as a special case (like what = "cues").
 
-# - Vignette FFTrees_plot.Rmd and some code checking for 'inherits(data, "data.frame")'
+# - Issue #91:
+#   Vignette FFTrees_plot.Rmd and some code checking for 'inherits(data, "data.frame")'
 #   suggests that data could be df, to which FFT is then applied.
 #   Applying and plotting in one step would be great, of course, (and should also be adopted for printing)
 #   but it presently does not work. (Suggestion: Use a 'newdata' argument for this purpose, as in predict().)

--- a/R/plotFFTrees_function.R
+++ b/R/plotFFTrees_function.R
@@ -491,18 +491,18 @@ plot.FFTrees <- function(x = NULL,
     }
 
     if (tree == "best.test" & is.null(x$tree$stats$test)) {
-      warning("You asked to plot the best 'test' tree, but there were no test data. I'll plot the best training tree instead...")
+      warning("You asked to plot the best 'test' tree, but there were no test data. Plotted the best tree for 'train' data instead...")
 
       tree <- "best.train"
     }
 
     if (is.numeric(tree) & (tree %in% 1:x$trees$n) == FALSE) {
-      stop(paste("You asked for a tree that does not exist. This object has", x$trees$n, "trees."))
+      stop(paste("You asked for a tree that does not exist. This object has", x$trees$n, "trees.", sep = " "))
     }
 
     if (inherits(data, "character")) {
       if (data == "test" & is.null(x$trees$stats$test)) {
-        stop("You asked to plot 'test' data, but there are no test data in the FFTrees object.")
+        stop("You asked to plot 'test' data, but there are no test data. Consider using data = 'train' instead...")
       }
     }
 
@@ -512,7 +512,7 @@ plot.FFTrees <- function(x = NULL,
     if (tree == "best.train") {
 
       if (data == "test"){
-        warning("You asked to plot the best training tree, but data was set to 'test'. I'll use 'train' data instead...")
+        warning("You asked to plot the 'best.train' tree, but data was set to 'test'. Plotted the best tree for 'train' data instead...")
         data <- "train"
         if (is.null(main)) { main <- "Data (Training)" }
       }
@@ -524,7 +524,7 @@ plot.FFTrees <- function(x = NULL,
     if (tree == "best.test") {
 
       if (data == "train"){
-        warning("You asked to plot the best test tree, but data was set to 'train'. I'll use 'test' data instead...")
+        warning("You asked to plot the 'best.test' tree, but data was set to 'train'. Plotted the best tree for 'test' data instead...")
         data <- "test"
         if (is.null(main)) { main <- "Data (Testing)" }
       }

--- a/R/plotFFTrees_function.R
+++ b/R/plotFFTrees_function.R
@@ -19,6 +19,7 @@
 #' can be customized by setting corresponding arguments.
 #'
 #' @param x An \code{FFTrees} object created by the \code{\link{FFTrees}} function.
+#'
 #' @param data The data in \code{x} to be plotted (as a string);
 #' must be either \code{'train'} (for fitting performance) or \code{'test'} (for prediction performance).
 #' By default, \code{data = 'train'} (as \code{x} may not contain test data).

--- a/R/plotFFTrees_function.R
+++ b/R/plotFFTrees_function.R
@@ -419,13 +419,13 @@ plot.FFTrees <- function(x = NULL,
         x <<- x  # to change global x?
         # Problem: Assigns a global object "x", rather than the current FFTrees object.
 
-        message("Success, and assigned x to a global FFTrees object 'x'")
+        message("Success, and assigned x to a global FFTrees object 'x'!")
 
       } else {
 
         x <- fftrees_apply(x, mydata = "test", newdata = data)
 
-        message("Success, but re-assign 'x <- fftrees_apply(x, newdata = data)' to change global x")
+        message("Success, but re-assign 'x <- fftrees_apply(x, newdata = data)' to change x globally!")
 
       }
 

--- a/R/plotFFTrees_function.R
+++ b/R/plotFFTrees_function.R
@@ -20,8 +20,12 @@
 #'
 #' @param x An \code{FFTrees} object created by the \code{\link{FFTrees}} function.
 #'
-#' @param data The data in \code{x} to be plotted (as a string);
-#' must be either \code{'train'} (for fitting performance) or \code{'test'} (for prediction performance).
+#' @param data The data type in \code{x} to be plotted (as a string) or a test dataset (as a data frame).
+#' \itemize{
+#'   \item{A valid data string must be either \code{'train'} (for fitting performance) or \code{'test'} (for prediction performance).}
+#'   \item{For a valid data frame, the specified tree is evaluated and plotted for this data (as 'test' data),
+#'   but the global \code{FFTrees} object \code{x} remains unchanged.}
+#'  }
 #' By default, \code{data = 'train'} (as \code{x} may not contain test data).
 #'
 #' @param what What should be plotted (as a string)? Valid options are:

--- a/R/printFFTrees_function.R
+++ b/R/printFFTrees_function.R
@@ -50,12 +50,47 @@ print.FFTrees <- function(x = NULL,
 
   # data: ----
 
-  data <- tolower(data)  # for robustness
+  # Note: data can be either a string "train"/"test"
+  #       OR an entire data frame (of new test data):
 
-  # testthat::expect_true(data %in% c("train", "test"))
-  if (!data %in% c("test", "train")){
-    stop("The data to print must be 'test' or 'train'.")
+  if (inherits(data, "character")) {
+
+    data <- tolower(data)  # increase robustness
+
+    # testthat::expect_true(data %in% c("train", "test"))
+    if (!data %in% c("test", "train")){
+      stop("The data to print must be 'test' or 'train'.")
+    }
   }
+
+
+  if (inherits(data, "data.frame")) {
+
+    message("Applying FFTrees object x to new test data")
+
+    bang <- FALSE
+
+    if (bang){
+
+      x <- fftrees_apply(x, mydata = "test", newdata = data)
+
+      x <<- x  # to change global x?
+      # Problem: Assigns a global object "x", rather than the current FFTrees object.
+
+      message("Success, and assigned x to a global FFTrees object 'x'!")
+
+    } else {
+
+      x <- fftrees_apply(x, mydata = "test", newdata = data)
+
+      message("Success, but re-assign 'x <- fftrees_apply(x, newdata = data)' to change x globally!")
+
+    }
+
+    data <- "test" # in rest of this function
+
+  }
+
 
   if (data == "test" & is.null(x$trees$stats$test)){ # use "train" data:
 

--- a/R/printFFTrees_function.R
+++ b/R/printFFTrees_function.R
@@ -12,8 +12,12 @@
 #' To print the best training or best test tree with respect to the \code{goal} specified during FFT construction,
 #' use \code{"best.train"} or \code{"best.test"}, respectively.
 #'
-#' @param data The data in \code{x} to be printed (as a string);
-#' must be either \code{'train'} (for fitting performance) or \code{'test'} (for prediction performance).
+#' @param data The data type in \code{x} to be printed (as a string) or a test dataset (as a data frame).
+#' \itemize{
+#'   \item{A valid data string must be either \code{'train'} (for fitting performance) or \code{'test'} (for prediction performance).}
+#'   \item{For a valid data frame, the specified tree is evaluated and printed for this data (as 'test' data),
+#'   but the global \code{FFTrees} object \code{x} remains unchanged.}
+#'  }
 #' By default, \code{data = 'train'} (as \code{x} may not contain test data).
 #'
 #' @param ... additional arguments passed to \code{print}.

--- a/R/printFFTrees_function.R
+++ b/R/printFFTrees_function.R
@@ -59,7 +59,7 @@ print.FFTrees <- function(x = NULL,
 
   if (data == "test" & is.null(x$trees$stats$test)){ # use "train" data:
 
-    warning("You asked to print 'test' data, but there were no test data. I'll print the best training tree instead...")
+    warning("You asked to print 'test' data, but there were no test data. Printed 'train' data instead...")
 
     data <- "train"
   }
@@ -72,7 +72,7 @@ print.FFTrees <- function(x = NULL,
   }
 
   if (tree == "best.test" & is.null(x$tree$stats$test)) {
-    warning("You asked to print the best test tree, but there were no test data. I'll print the best training tree instead...")
+    warning("You asked to print the 'best.test' tree, but there were no test data. Printed the best tree for 'train' data instead...")
 
     tree <- "best.train"
   }
@@ -83,7 +83,7 @@ print.FFTrees <- function(x = NULL,
   if (tree == "best.train") {
 
     if (data == "test"){
-      warning("You asked to print the best training tree, but data was set to 'test'. I'll use 'train' data instead...")
+      warning("You asked to print the 'best.train' tree, but data was set to 'test'. Printed the best tree for 'train' data instead...")
       data <- "train"
       main <- "Data (Training)"
     }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.7.0.9004 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.7.0.9005 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Status badges: -->
 
@@ -45,17 +45,13 @@ and easy to interpret, use, and communicate.
 To install the latest release of **FFTrees** [from
 CRAN](https://CRAN.R-project.org/package=FFTrees) evaluate:
 
-``` r
-install.packages("FFTrees")
-```
+    install.packages("FFTrees")
 
 The current development version of **FFTrees** can be installed [from
 GitHub](https://github.com/ndphillips/FFTrees) with:
 
-``` r
-# install.packages("devtools")
-devtools::install_github("ndphillips/FFTrees", build_vignettes = TRUE)
-```
+    # install.packages("devtools")
+    devtools::install_github("ndphillips/FFTrees", build_vignettes = TRUE)
 
 ## Getting started
 
@@ -63,9 +59,7 @@ As an example, let’s create a FFT predicting heart disease status
 (*Healthy* vs. *Diseased*) based on the `heartdisease` dataset included
 in **FFTrees**:
 
-``` r
-library(FFTrees)  # load package
-```
+    library(FFTrees)  # load package
 
 ### Using data
 
@@ -78,48 +72,46 @@ first rows and columns of both subsets of the `heartdisease` data:
 -   `heart.train` (the training / fitting dataset) contains the data
     from 150 patients:
 
-``` r
-heart.train
-#> # A tibble: 150 × 14
-#>    diagnosis   age   sex cp    trest…¹  chol   fbs restecg thalach exang oldpeak
-#>    <lgl>     <dbl> <dbl> <chr>   <dbl> <dbl> <dbl> <chr>     <dbl> <dbl>   <dbl>
-#>  1 FALSE        44     0 np        108   141     0 normal      175     0     0.6
-#>  2 FALSE        51     0 np        140   308     0 hypert…     142     0     1.5
-#>  3 FALSE        52     1 np        138   223     0 normal      169     0     0  
-#>  4 TRUE         48     1 aa        110   229     0 normal      168     0     1  
-#>  5 FALSE        59     1 aa        140   221     0 normal      164     1     0  
-#>  6 FALSE        58     1 np        105   240     0 hypert…     154     1     0.6
-#>  7 FALSE        41     0 aa        126   306     0 normal      163     0     0  
-#>  8 TRUE         39     1 a         118   219     0 normal      140     0     1.2
-#>  9 TRUE         77     1 a         125   304     0 hypert…     162     1     0  
-#> 10 FALSE        41     0 aa        105   198     0 normal      168     0     0  
-#> # … with 140 more rows, 3 more variables: slope <chr>, ca <dbl>, thal <chr>,
-#> #   and abbreviated variable name ¹​trestbps
-#> # ℹ Use `print(n = ...)` to see more rows, and `colnames()` to see all variable names
-```
+<!-- -->
+
+    heart.train
+    #> # A tibble: 150 × 14
+    #>    diagnosis   age   sex cp    trestbps  chol   fbs restecg     thalach exang
+    #>    <lgl>     <dbl> <dbl> <chr>    <dbl> <dbl> <dbl> <chr>         <dbl> <dbl>
+    #>  1 FALSE        44     0 np         108   141     0 normal          175     0
+    #>  2 FALSE        51     0 np         140   308     0 hypertrophy     142     0
+    #>  3 FALSE        52     1 np         138   223     0 normal          169     0
+    #>  4 TRUE         48     1 aa         110   229     0 normal          168     0
+    #>  5 FALSE        59     1 aa         140   221     0 normal          164     1
+    #>  6 FALSE        58     1 np         105   240     0 hypertrophy     154     1
+    #>  7 FALSE        41     0 aa         126   306     0 normal          163     0
+    #>  8 TRUE         39     1 a          118   219     0 normal          140     0
+    #>  9 TRUE         77     1 a          125   304     0 hypertrophy     162     1
+    #> 10 FALSE        41     0 aa         105   198     0 normal          168     0
+    #> # … with 140 more rows, and 4 more variables: oldpeak <dbl>, slope <chr>,
+    #> #   ca <dbl>, thal <chr>
 
 -   `heart.test` (the testing / prediction dataset) contains data from a
     new set of 153 patients:
 
-``` r
-heart.test
-#> # A tibble: 153 × 14
-#>    diagnosis   age   sex cp    trest…¹  chol   fbs restecg thalach exang oldpeak
-#>    <lgl>     <dbl> <dbl> <chr>   <dbl> <dbl> <dbl> <chr>     <dbl> <dbl>   <dbl>
-#>  1 FALSE        51     0 np        120   295     0 hypert…     157     0     0.6
-#>  2 TRUE         45     1 ta        110   264     0 normal      132     0     1.2
-#>  3 TRUE         53     1 a         123   282     0 normal       95     1     2  
-#>  4 TRUE         45     1 a         142   309     0 hypert…     147     1     0  
-#>  5 FALSE        66     1 a         120   302     0 hypert…     151     0     0.4
-#>  6 TRUE         48     1 a         130   256     1 hypert…     150     1     0  
-#>  7 TRUE         55     1 a         140   217     0 normal      111     1     5.6
-#>  8 FALSE        56     1 aa        130   221     0 hypert…     163     0     0  
-#>  9 TRUE         42     1 a         136   315     0 normal      125     1     1.8
-#> 10 FALSE        45     1 a         115   260     0 hypert…     185     0     0  
-#> # … with 143 more rows, 3 more variables: slope <chr>, ca <dbl>, thal <chr>,
-#> #   and abbreviated variable name ¹​trestbps
-#> # ℹ Use `print(n = ...)` to see more rows, and `colnames()` to see all variable names
-```
+<!-- -->
+
+    heart.test
+    #> # A tibble: 153 × 14
+    #>    diagnosis   age   sex cp    trestbps  chol   fbs restecg     thalach exang
+    #>    <lgl>     <dbl> <dbl> <chr>    <dbl> <dbl> <dbl> <chr>         <dbl> <dbl>
+    #>  1 FALSE        51     0 np         120   295     0 hypertrophy     157     0
+    #>  2 TRUE         45     1 ta         110   264     0 normal          132     0
+    #>  3 TRUE         53     1 a          123   282     0 normal           95     1
+    #>  4 TRUE         45     1 a          142   309     0 hypertrophy     147     1
+    #>  5 FALSE        66     1 a          120   302     0 hypertrophy     151     0
+    #>  6 TRUE         48     1 a          130   256     1 hypertrophy     150     1
+    #>  7 TRUE         55     1 a          140   217     0 normal          111     1
+    #>  8 FALSE        56     1 aa         130   221     0 hypertrophy     163     0
+    #>  9 TRUE         42     1 a          136   315     0 normal          125     1
+    #> 10 FALSE        45     1 a          115   260     0 hypertrophy     185     0
+    #> # … with 143 more rows, and 4 more variables: oldpeak <dbl>, slope <chr>,
+    #> #   ca <dbl>, thal <chr>
 
 Most of the variables in our data are potential predictors. The
 criterion variable is `diagnosis` — a logical column indicating the true
@@ -133,62 +125,62 @@ evaluate their predictive performance on the `heart.test` data:
 
 -   Create an `FFTrees` object from the `heartdisease` data:
 
-``` r
-# Create an FFTrees object from the heartdisease data: 
-heart.fft <- FFTrees(formula = diagnosis ~., 
-                     data = heart.train,
-                     data.test = heart.test, 
-                     decision.labels = c("Healthy", "Disease"))
-#> Setting 'goal = bacc'
-#> Setting 'goal.chase = bacc'
-#> Setting 'goal.threshold = bacc'
-#> Setting cost.outcomes = list(hi = 0, mi = 1, fa = 1, cr = 0)
-#> Growing FFTs with ifan:
-#> Fitting other algorithms for comparison (disable with do.comp = FALSE) ...
-```
+<!-- -->
+
+    # Create an FFTrees object from the heartdisease data: 
+    heart.fft <- FFTrees(formula = diagnosis ~., 
+                         data = heart.train,
+                         data.test = heart.test, 
+                         decision.labels = c("Healthy", "Disease"))
+    #> Setting 'goal = bacc'
+    #> Setting 'goal.chase = bacc'
+    #> Setting 'goal.threshold = bacc'
+    #> Setting cost.outcomes = list(hi = 0, mi = 1, fa = 1, cr = 0)
+    #> Growing FFTs with ifan:
+    #> Fitting other algorithms for comparison (disable with do.comp = FALSE) ...
 
 -   Printing an `FFTrees` object shows basic information and summary
     statistics (on the best training tree, FFT \#1):
 
-``` r
-# Print:
-heart.fft
-#> FFTrees 
-#> - Trees: 7 fast-and-frugal trees predicting diagnosis
-#> - Outcome costs: [hi = 0, mi = 1, fa = 1, cr = 0]
-#> 
-#> FFT #1: Definition
-#> [1] If thal = {rd,fd}, decide Disease.
-#> [2] If cp != {a}, decide Healthy.
-#> [3] If ca > 0, decide Disease, otherwise, decide Healthy.
-#> 
-#> FFT #1: Training Accuracy
-#> Training data: N = 150, Pos (+) = 66 (44%) 
-#> 
-#> |          | True + | True - | Totals:
-#> |----------|--------|--------|
-#> | Decide + | hi  54 | fa  18 |      72
-#> | Decide - | mi  12 | cr  66 |      78
-#> |----------|--------|--------|
-#>   Totals:        66       84   N = 150
-#> 
-#> acc  = 80.0%   ppv  = 75.0%   npv  = 84.6%
-#> bacc = 80.2%   sens = 81.8%   spec = 78.6%
-#> 
-#> FFT #1: Training Speed, Frugality, and Cost
-#> mcu = 1.74,  pci = 0.87,  E(cost) = 0.200
-```
+<!-- -->
+
+    # Print:
+    heart.fft
+    #> FFTrees 
+    #> - Trees: 7 fast-and-frugal trees predicting diagnosis
+    #> - Outcome costs: [hi = 0, mi = 1, fa = 1, cr = 0]
+    #> 
+    #> FFT #1: Definition
+    #> [1] If thal = {rd,fd}, decide Disease.
+    #> [2] If cp != {a}, decide Healthy.
+    #> [3] If ca > 0, decide Disease, otherwise, decide Healthy.
+    #> 
+    #> FFT #1: Training Accuracy
+    #> Training data: N = 150, Pos (+) = 66 (44%) 
+    #> 
+    #> |          | True + | True - | Totals:
+    #> |----------|--------|--------|
+    #> | Decide + | hi  54 | fa  18 |      72
+    #> | Decide - | mi  12 | cr  66 |      78
+    #> |----------|--------|--------|
+    #>   Totals:        66       84   N = 150
+    #> 
+    #> acc  = 80.0%   ppv  = 75.0%   npv  = 84.6%
+    #> bacc = 80.2%   sens = 81.8%   spec = 78.6%
+    #> 
+    #> FFT #1: Training Speed, Frugality, and Cost
+    #> mcu = 1.74,  pci = 0.87,  E(cost) = 0.200
 
 -   To evaluate the predictive performance of an FFT, we plot an
     `FFTrees` object to visualize a tree and its performance (on the
     `test` data):
 
-``` r
-# Plot the best tree applied to the test data: 
-plot(heart.fft,
-     data = "test",
-     main = "Heart Disease")
-```
+<!-- -->
+
+    # Plot the best tree applied to the test data: 
+    plot(heart.fft,
+         data = "test",
+         main = "Heart Disease")
 
 ![An FFT predicting heart disease for `test`
 data.](man/figures/README-example-heart-plot-1.png)
@@ -199,21 +191,20 @@ data.](man/figures/README-example-heart-plot-1.png)
 -   Additionally, we can compare the predictive performance between
     different machine learning algorithms on a range of metrics:
 
-``` r
-# Compare predictive performance across algorithms: 
-heart.fft$competition$test
-#> # A tibble: 5 × 17
-#>   algorithm     n    hi    fa    mi    cr  sens  spec    far   ppv   npv   acc
-#>   <chr>     <int> <int> <int> <int> <int> <dbl> <dbl>  <dbl> <dbl> <dbl> <dbl>
-#> 1 fftrees     153    64    19     9    61 0.877 0.762 0.238  0.771 0.871 0.817
-#> 2 lr          153    55    13    18    67 0.753 0.838 0.162  0.809 0.788 0.797
-#> 3 cart        153    50    19    23    61 0.685 0.762 0.238  0.725 0.726 0.725
-#> 4 rf          153    59     8    14    72 0.808 0.9   0.1    0.881 0.837 0.856
-#> 5 svm         153    55     7    18    73 0.753 0.912 0.0875 0.887 0.802 0.837
-#> # … with 5 more variables: bacc <dbl>, wacc <dbl>, cost <dbl>,
-#> #   cost_decisions <dbl>, cost_cues <dbl>
-#> # ℹ Use `colnames()` to see all variable names
-```
+<!-- -->
+
+    # Compare predictive performance across algorithms: 
+    heart.fft$competition$test
+    #> # A tibble: 5 × 17
+    #>   algorithm     n    hi    fa    mi    cr  sens  spec    far   ppv   npv   acc
+    #>   <chr>     <int> <int> <int> <int> <int> <dbl> <dbl>  <dbl> <dbl> <dbl> <dbl>
+    #> 1 fftrees     153    64    19     9    61 0.877 0.762 0.238  0.771 0.871 0.817
+    #> 2 lr          153    55    13    18    67 0.753 0.838 0.162  0.809 0.788 0.797
+    #> 3 cart        153    50    19    23    61 0.685 0.762 0.238  0.725 0.726 0.725
+    #> 4 rf          153    59     8    14    72 0.808 0.9   0.1    0.881 0.837 0.856
+    #> 5 svm         153    55     7    18    73 0.753 0.912 0.0875 0.887 0.802 0.837
+    #> # … with 5 more variables: bacc <dbl>, wacc <dbl>, cost <dbl>,
+    #> #   cost_decisions <dbl>, cost_cues <dbl>
 
 <!-- FFTs by verbal description: -->
 
@@ -233,24 +224,22 @@ evaluate its performance on the `heart.test` data:
 These conditions can directly be supplied to the `my.tree` argument of
 `FFTrees()`:
 
-``` r
-# Create custom FFT 'in words' and apply it to test data:
+    # Create custom FFT 'in words' and apply it to test data:
 
-# 1. Create my own FFT (from verbal description):
-my.fft <- FFTrees(formula = diagnosis ~., 
-                  data = heart.train,
-                  data.test = heart.test, 
-                  decision.labels = c("Healthy", "Disease"),
-                  my.tree = "If sex = 1, predict Disease.
-                             If age < 45, predict Healthy.
-                             If thal = {fd, normal}, predict Healthy,  
-                             Otherwise, predict Disease.")
+    # 1. Create my own FFT (from verbal description):
+    my.fft <- FFTrees(formula = diagnosis ~., 
+                      data = heart.train,
+                      data.test = heart.test, 
+                      decision.labels = c("Healthy", "Disease"),
+                      my.tree = "If sex = 1, predict Disease.
+                                 If age < 45, predict Healthy.
+                                 If thal = {fd, normal}, predict Healthy,  
+                                 Otherwise, predict Disease.")
 
-# 2. Plot and evaluate my custom FFT (for test data):
-plot(my.fft,
-     data = "test",
-     main = "My custom FFT")
-```
+    # 2. Plot and evaluate my custom FFT (for test data):
+    plot(my.fft,
+         data = "test",
+         main = "My custom FFT")
 
 ![An FFT created from a verbal
 description.](man/figures/README-example-heart-verbal-1.png)
@@ -282,7 +271,7 @@ decision trees* (available in
     FFTrees: A toolbox to create, visualize, and evaluate
     fast-and-frugal decision trees. *Judgment and Decision Making*, *12*
     (4), 344–368. Retrieved from
-    <https://journal.sjdm.org/17/17217/jdm17217.pdf>
+    <a href="https://journal.sjdm.org/17/17217/jdm17217.pdf" class="uri">https://journal.sjdm.org/17/17217/jdm17217.pdf</a>
 
 We encourage you to read the article to learn more about the history of
 FFTs and how the **FFTrees** package creates, visualizes, and evaluates
@@ -333,6 +322,6 @@ for the full list):
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2022-09-09.\]
+\[File `README.Rmd` last updated on 2022-09-10.\]
 
 <!-- eof. -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.7.0.9005 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.7.0.9006 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Status badges: -->
 
@@ -322,6 +322,6 @@ for the full list):
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2022-09-10.\]
+\[File `README.Rmd` last updated on 2022-09-11.\]
 
 <!-- eof. -->

--- a/man/plot.FFTrees.Rd
+++ b/man/plot.FFTrees.Rd
@@ -37,8 +37,12 @@
 \arguments{
 \item{x}{An \code{FFTrees} object created by the \code{\link{FFTrees}} function.}
 
-\item{data}{The data in \code{x} to be plotted (as a string);
-must be either \code{'train'} (for fitting performance) or \code{'test'} (for prediction performance).
+\item{data}{The data type in \code{x} to be plotted (as a string) or a test dataset (as a data frame).
+\itemize{
+  \item{A valid data string must be either \code{'train'} (for fitting performance) or \code{'test'} (for prediction performance).}
+  \item{For a valid data frame, the specified tree is evaluated and plotted for this data (as 'test' data),
+  but the global \code{FFTrees} object \code{x} remains unchanged.}
+ }
 By default, \code{data = 'train'} (as \code{x} may not contain test data).}
 
 \item{what}{What should be plotted (as a string)? Valid options are:

--- a/man/print.FFTrees.Rd
+++ b/man/print.FFTrees.Rd
@@ -14,8 +14,12 @@ Default: \code{tree = 1}.
 To print the best training or best test tree with respect to the \code{goal} specified during FFT construction,
 use \code{"best.train"} or \code{"best.test"}, respectively.}
 
-\item{data}{The data in \code{x} to be printed (as a string);
-must be either \code{'train'} (for fitting performance) or \code{'test'} (for prediction performance).
+\item{data}{The data type in \code{x} to be printed (as a string) or a test dataset (as a data frame).
+\itemize{
+  \item{A valid data string must be either \code{'train'} (for fitting performance) or \code{'test'} (for prediction performance).}
+  \item{For a valid data frame, the specified tree is evaluated and printed for this data (as 'test' data),
+  but the global \code{FFTrees} object \code{x} remains unchanged.}
+ }
 By default, \code{data = 'train'} (as \code{x} may not contain test data).}
 
 \item{...}{additional arguments passed to \code{print}.}


### PR DESCRIPTION
This PR addresses the bug of Issue #91 — i.e., re-enables plotting and printing trees when providing a data frame as `data` for both `print()` and `plot()` — but does not (yet) use a `newdata` argument. 