### PR TITLE
Return invisible `FFTrees` object `x` when plotting or printing `x`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.7.0.9006
+Version: 1.7.0.9007
 Date: 2022-09-11
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.7 
 
-## 1.7.0.9006
+## 1.7.0.9007
 
 <!-- Development version: --> 
 
@@ -14,6 +14,7 @@ Changes since last release:
 
 ### Major changes
 
+- Return an invisible `FFTrees` object `x` when plotting or printing FFTs (to allow re-assigning to global `x` when using new test data).
 - Enabled applying a tree to new data when providing a data frame to `plot.FFTrees()` and `print.FFTrees()`. 
 - Added new plotting options to `plot.FFTrees()` (e.g., `what = 'all'` vs. `what = 'tree'` and `what = 'icontree'`). 
 

--- a/R/plotFFTrees_function.R
+++ b/R/plotFFTrees_function.R
@@ -24,7 +24,7 @@
 #' \itemize{
 #'   \item{A valid data string must be either \code{'train'} (for fitting performance) or \code{'test'} (for prediction performance).}
 #'   \item{For a valid data frame, the specified tree is evaluated and plotted for this data (as 'test' data),
-#'   but the global \code{FFTrees} object \code{x} remains unchanged.}
+#'   but the global \code{FFTrees} object \code{x} remains unchanged unless it is re-assigned.}
 #'  }
 #' By default, \code{data = 'train'} (as \code{x} may not contain test data).
 #'
@@ -88,7 +88,9 @@
 #' to \code{\link{showcues}} when \code{what = 'cues'} or
 #' to \code{\link{title}} when \code{what = 'roc'}).
 #'
-#' @return A plot visualizing and describing an FFT.
+#' @return An (invisible) \code{FFTrees} object \code{x}
+#' and a plot visualizing and describing an FFT (as side effect).
+#'
 #'
 #' @examples
 #' # Create FFTs (for heartdisease data):
@@ -411,28 +413,14 @@ plot.FFTrees <- function(x = NULL,
       }
     }
 
+
     if (inherits(data, "data.frame")) {
 
-      message("Applying FFTrees object x to new test data")
+      message("Applying FFTrees object x to new test data...")
 
-      bang <- FALSE
+      x <- fftrees_apply(x, mydata = "test", newdata = data)
 
-      if (bang){
-
-        x <- fftrees_apply(x, mydata = "test", newdata = data)
-
-        x <<- x  # to change global x?
-        # Problem: Assigns a global object "x", rather than the current FFTrees object.
-
-        message("Success, and assigned x to a global FFTrees object 'x'!")
-
-      } else {
-
-        x <- fftrees_apply(x, mydata = "test", newdata = data)
-
-        message("Success, but re-assign 'x <- fftrees_apply(x, newdata = data)' to change x globally!")
-
-      }
+      message("Success, but re-assign output to x or use fftrees_apply() to globally change x")
 
       data <- "test" # in rest of this function
 
@@ -2479,6 +2467,12 @@ plot.FFTrees <- function(x = NULL,
 
 
   } # if (what != "cues").
+
+
+  # Output: ------
+
+  # Output x may differ from input x when applying new 'test' data (as df):
+  return(invisible(x))
 
 } # plot.FFTrees().
 

--- a/R/plotFFTrees_function.R
+++ b/R/plotFFTrees_function.R
@@ -56,7 +56,6 @@
 #' @param comp Should the performance of competitive algorithms (e.g.; logistic regression, random forests, etc.)
 #' be shown in the ROC plot (if available, as logical)?
 #'
-#'
 #' @param show.header Show header with basic data properties (in top panel, as logical)?
 #'
 #' @param show.iconguide Show icon guide (in middle panel, as logical)?
@@ -88,7 +87,7 @@
 #' to \code{\link{showcues}} when \code{what = 'cues'} or
 #' to \code{\link{title}} when \code{what = 'roc'}).
 #'
-#' @return An (invisible) \code{FFTrees} object \code{x}
+#' @return An invisible \code{FFTrees} object \code{x}
 #' and a plot visualizing and describing an FFT (as side effect).
 #'
 #'

--- a/R/printFFTrees_function.R
+++ b/R/printFFTrees_function.R
@@ -16,13 +16,14 @@
 #' \itemize{
 #'   \item{A valid data string must be either \code{'train'} (for fitting performance) or \code{'test'} (for prediction performance).}
 #'   \item{For a valid data frame, the specified tree is evaluated and printed for this data (as 'test' data),
-#'   but the global \code{FFTrees} object \code{x} remains unchanged.}
+#'   but the global \code{FFTrees} object \code{x} remains unchanged unless it is re-assigned.}
 #'  }
 #' By default, \code{data = 'train'} (as \code{x} may not contain test data).
 #'
 #' @param ... additional arguments passed to \code{print}.
 #'
-#' @return Prints summary information about an FFT to the console.
+#' @return An (invisible) \code{FFTrees} object \code{x}
+#' and summary information on an FFT printed to the console (as side effect).
 #'
 #' @seealso
 #' \code{\link{plot.FFTrees}} for plotting FFTs;
@@ -70,26 +71,11 @@ print.FFTrees <- function(x = NULL,
 
   if (inherits(data, "data.frame")) {
 
-    message("Applying FFTrees object x to new test data")
+    message("Applying FFTrees object x to new test data...")
 
-    bang <- FALSE
+    x <- fftrees_apply(x, mydata = "test", newdata = data)
 
-    if (bang){
-
-      x <- fftrees_apply(x, mydata = "test", newdata = data)
-
-      x <<- x  # to change global x?
-      # Problem: Assigns a global object "x", rather than the current FFTrees object.
-
-      message("Success, and assigned x to a global FFTrees object 'x'!")
-
-    } else {
-
-      x <- fftrees_apply(x, mydata = "test", newdata = data)
-
-      message("Success, but re-assign 'x <- fftrees_apply(x, newdata = data)' to change x globally!")
-
-    }
+    message("Success, but re-assign output to x or use fftrees_apply() to globally change x")
 
     data <- "test" # in rest of this function
 
@@ -310,7 +296,10 @@ print.FFTrees <- function(x = NULL,
   cat("\n\n")
 
 
-  # Output: none. ------
+  # Output: ------
+
+  # Output x may differ from input x when applying new 'test' data (as df):
+  return(invisible(x))
 
 } # print.FFTrees().
 

--- a/R/printFFTrees_function.R
+++ b/R/printFFTrees_function.R
@@ -22,7 +22,7 @@
 #'
 #' @param ... additional arguments passed to \code{print}.
 #'
-#' @return An (invisible) \code{FFTrees} object \code{x}
+#' @return An invisible \code{FFTrees} object \code{x}
 #' and summary information on an FFT printed to the console (as side effect).
 #'
 #' @seealso

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.7.0.9006 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.7.0.9007 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Status badges: -->
 

--- a/man/plot.FFTrees.Rd
+++ b/man/plot.FFTrees.Rd
@@ -41,7 +41,7 @@
 \itemize{
   \item{A valid data string must be either \code{'train'} (for fitting performance) or \code{'test'} (for prediction performance).}
   \item{For a valid data frame, the specified tree is evaluated and plotted for this data (as 'test' data),
-  but the global \code{FFTrees} object \code{x} remains unchanged.}
+  but the global \code{FFTrees} object \code{x} remains unchanged unless it is re-assigned.}
  }
 By default, \code{data = 'train'} (as \code{x} may not contain test data).}
 
@@ -115,7 +115,8 @@ to \code{\link{showcues}} when \code{what = 'cues'} or
 to \code{\link{title}} when \code{what = 'roc'}).}
 }
 \value{
-A plot visualizing and describing an FFT.
+An invisible \code{FFTrees} object \code{x}
+and a plot visualizing and describing an FFT (as side effect).
 }
 \description{
 \code{plot.FFTrees} visualizes an \code{FFTrees} object created by the \code{\link{FFTrees}} function.

--- a/man/print.FFTrees.Rd
+++ b/man/print.FFTrees.Rd
@@ -18,14 +18,15 @@ use \code{"best.train"} or \code{"best.test"}, respectively.}
 \itemize{
   \item{A valid data string must be either \code{'train'} (for fitting performance) or \code{'test'} (for prediction performance).}
   \item{For a valid data frame, the specified tree is evaluated and printed for this data (as 'test' data),
-  but the global \code{FFTrees} object \code{x} remains unchanged.}
+  but the global \code{FFTrees} object \code{x} remains unchanged unless it is re-assigned.}
  }
 By default, \code{data = 'train'} (as \code{x} may not contain test data).}
 
 \item{...}{additional arguments passed to \code{print}.}
 }
 \value{
-Prints summary information about an FFT to the console.
+An invisible \code{FFTrees} object \code{x}
+and summary information on an FFT printed to the console (as side effect).
 }
 \description{
 \code{print.FFTrees} prints basic information on FFTs for an \code{FFTrees} object \code{x}.


### PR DESCRIPTION
Returning a possibly modified `FFTrees` object `x` allows to re-assign it to a global `x` when it has been changed within either function by applying `x` to new test data (provided as df to the `data` argument).