### PR TITLE
Increase efficiency of `add_level()` helper

### DIFF
--- a/R/helper_plot.R
+++ b/R/helper_plot.R
@@ -6,8 +6,6 @@
 # (1) General plotting helpers: ------
 
 
-
-
 # num_space: ------
 
 # \code{num_space} computes the width of a representation of \code{x}
@@ -256,7 +254,7 @@ transparent <- function(col_orig = "red",
     col_final[i] <- rgb(col_orig[1, i], col_orig[2, i], col_orig[
       3,
       i
-      ], alpha = (1 - trans.val) * 255, maxColorValue = 255)
+    ], alpha = (1 - trans.val) * 255, maxColorValue = 255)
   }
 
   return(col_final)
@@ -286,7 +284,7 @@ add_balls <- function(x.lim = c(-10, 0),
                       upper.text = "",
                       upper.text.cex = 1,
                       upper.text.adj = 0,
-                      rev.order = F,
+                      rev.order = FALSE,
                       box.col = NULL,
                       box.bg = NULL,
                       n.per.icon = NULL) {
@@ -442,7 +440,7 @@ get_label_cex <- function(i, label.box.text.cex = 2) {
 
 # add_level: Add level display to a plot ----
 
-# df_lloc: Data frame with labels, values, and locations.
+# lloc_row: Data frame with labels, values, and locations.
 
 add_level <- function(name,
                       sub = "",
@@ -452,15 +450,15 @@ add_level <- function(name,
                       bottom.text = "",
                       level.type = "line",
                       # needed from plot:
-                      df_lloc    = NULL,
+                      lloc_row   = NULL,  # element == name row (of df)
                       header_y   = NULL,
                       header_cex = NULL) {
 
   # Parameters:
-  rect.center.x <- df_lloc$center.x[df_lloc$element == name]
-  rect.center.y <- df_lloc$center.y[df_lloc$element == name]
-  rect.height <- df_lloc$height[df_lloc$element == name]
-  rect.width <- df_lloc$width[df_lloc$element == name]
+  rect.center.x <- lloc_row$center.x
+  rect.center.y <- lloc_row$center.y
+  rect.height <- lloc_row$height
+  rect.width <- lloc_row$width
 
   rect.bottom.y <- rect.center.y - rect.height / 2
   rect.top.y    <- rect.center.y + rect.height / 2
@@ -468,9 +466,9 @@ add_level <- function(name,
   rect.left.x  <- rect.center.x - rect.width / 2
   rect.right.x <- rect.center.x + rect.width / 2
 
-  long.name <- df_lloc$long.name[df_lloc$element == name]
-  value <- df_lloc$value[df_lloc$element == name]
-  value.name <- df_lloc$value.name[df_lloc$element == name]
+  long.name <- lloc_row$long.name
+  value <- lloc_row$value
+  value.name <- lloc_row$value.name
 
   #
   # level.col.fun <- circlize::colorRamp2(c(min.val, ok.val,  max.val),
@@ -479,7 +477,7 @@ add_level <- function(name,
 
 
   text(x = rect.center.x, y = header_y,
-    labels = long.name, pos = 1, cex = header_cex
+       labels = long.name, pos = 1, cex = header_cex
   )
 
   # text_outline(x = rect.center.x,
@@ -513,14 +511,14 @@ add_level <- function(name,
          value.height,
          # col = level.col.fun(value.s),
          col = value.col,
-         # col = spec.level.fun(df_lloc$value[df_lloc$element == name]),
+         # col = spec.level.fun(lloc_row$value),
          border = "black"
     )
 
     text_outline(
       x = rect.center.x,
       y = value.height,
-      labels = df_lloc$value.name[df_lloc$element == name],
+      labels = lloc_row$value.name,
       cex = 1.5, r = .008, pos = 3
     )
 
@@ -558,7 +556,7 @@ add_level <- function(name,
     text_outline(
       x = rect.center.x,
       y = value.height,
-      labels = df_lloc$value.name[df_lloc$element == name],
+      labels = lloc_row$value.name,
       cex = 1.5, r = 0, pos = 3
     )
 

--- a/R/plotFFTrees_function.R
+++ b/R/plotFFTrees_function.R
@@ -1487,24 +1487,24 @@ plot.FFTrees <- function(x = NULL,
       # Get either bacc OR wacc (based on sens.w):
       sens.w <- x$params$sens.w
       bacc_wacc <- get_bacc_wacc(sens = final.stats$sens, spec = final.stats$spec, sens.w = sens.w)
+      bacc_wacc_name <- names(bacc_wacc)
 
       # Set labels, values, and locations (as df):
       lloc <- data.frame(
-        element = c("classtable", "mcu", "pci", "sens", "spec", "acc", names(bacc_wacc), "roc"),
-        long.name = c("Classification Table", "mcu", "pci", "sens", "spec", "acc", names(bacc_wacc), "ROC"),
+        element = c("classtable", "mcu", "pci", "sens", "spec", "acc", bacc_wacc_name, "roc"),
+        long.name = c("Classification Table", "mcu", "pci", "sens", "spec", "acc", bacc_wacc_name, "ROC"),
         center.x = c(.18, seq(.35, .65, length.out = 6), .85),
         center.y = rep(level.center.y, 8),
         width = c(.2, rep(level.width, 6), .20),
         height = c(.65, rep(level.max.height, 6), .65),
-        value = c(
-          NA,
-          abs(final.stats$mcu - 5) / (abs(1 - 5)),
-          final.stats$pci, final.stats$sens, final.stats$spec, with(final.stats, (cr + hi) / n), bacc_wacc, NA
-        ),
-        value.name = c(
-          NA, round(final.stats$mcu, 1), pretty_dec(final.stats$pci), pretty_dec(final.stats$sens), pretty_dec(final.stats$spec), pretty_dec(final.stats$acc),
-          pretty_dec(bacc_wacc), NA
-        )
+        value = c(NA,
+                  abs(final.stats$mcu - 5) / (abs(1 - 5)), final.stats$pci,
+                  final.stats$sens, final.stats$spec,
+                  with(final.stats, (cr + hi) / n), bacc_wacc, NA),
+        value.name = c(NA,
+                       round(final.stats$mcu, 1), pretty_dec(final.stats$pci),
+                       pretty_dec(final.stats$sens), pretty_dec(final.stats$spec),
+                       pretty_dec(final.stats$acc), pretty_dec(bacc_wacc), NA)
       )
 
 
@@ -1677,14 +1677,14 @@ plot.FFTrees <- function(x = NULL,
           # mcu level: ----
 
           add_level("mcu", ok.val = .75, min.val = 0, max.val = 1,
-                    level.type = level.type, df_lloc = lloc,
+                    level.type = level.type, lloc_row = lloc[lloc$element == "mcu", ],
                     header_y = header.y.loc, header_cex = header.cex) # , sub = paste(c(final.stats$cr, "/", final.stats$cr + final.stats$fa), collapse = ""))
 
 
           # pci level: ----
 
           add_level("pci", ok.val = .75, min.val = 0, max.val = 1,
-                    level.type = level.type, df_lloc = lloc,
+                    level.type = level.type, lloc_row = lloc[lloc$element == "pci", ],
                     header_y = header.y.loc, header_cex = header.cex) # , sub = paste(c(final.stats$cr, "/", final.stats$cr + final.stats$fa), collapse = ""))
 
           # text(lloc$center.x[lloc$element == "pci"],
@@ -1695,14 +1695,14 @@ plot.FFTrees <- function(x = NULL,
           # spec level: ----
 
           add_level("spec", ok.val = .75, min.val = 0, max.val = 1,
-                    level.type = level.type, df_lloc = lloc,
+                    level.type = level.type, lloc_row = lloc[lloc$element == "spec", ],
                     header_y = header.y.loc, header_cex = header.cex) # , sub = paste(c(final.stats$cr, "/", final.stats$cr + final.stats$fa), collapse = ""))
 
 
           # sens level: ----
 
           add_level("sens", ok.val = .75, min.val = 0, max.val = 1,
-                    level.type = level.type, df_lloc = lloc,
+                    level.type = level.type, lloc_row = lloc[lloc$element == "sens", ],
                     header_y = header.y.loc, header_cex = header.cex) # , sub = paste(c(final.stats$hi, "/", final.stats$hi + final.stats$mi), collapse = ""))
 
 
@@ -1711,7 +1711,7 @@ plot.FFTrees <- function(x = NULL,
           min.acc <- max(crit.br, 1 - crit.br)
 
           add_level("acc", ok.val = .50, min.val = 0, max.val = 1,
-                    level.type = level.type, df_lloc = lloc,
+                    level.type = level.type, lloc_row = lloc[lloc$element == "acc", ],
                     header_y = header.y.loc, header_cex = header.cex) # , sub = paste(c(final.stats$hi + final.stats$cr, "/", final.stats$n), collapse = ""))
 
           # Add baseline to acc level:
@@ -1737,15 +1737,15 @@ plot.FFTrees <- function(x = NULL,
           if (names(bacc_wacc) == "bacc"){ # show bacc level:
 
             add_level("bacc", ok.val = .50, min.val = 0, max.val = 1,
-                      level.type = level.type, df_lloc = lloc,
+                      level.type = level.type, lloc_row = lloc[lloc$element == "bacc", ],
                       header_y = header.y.loc, header_cex = header.cex)
 
-          } else { # default: show wacc level (with sens.w value):
+          } else { # show wacc level (and sens.w value):
 
             sens.w_lbl <- paste0("sens.w = .", pretty_dec(sens.w))
 
             add_level("wacc", ok.val = .50, min.val = 0, max.val = 1,
-                      level.type = level.type, df_lloc = lloc,
+                      level.type = level.type, lloc_row = lloc[lloc$element == "wacc", ],
                       header_y = header.y.loc,
                       bottom.text = sens.w_lbl, header_cex = header.cex)
 

--- a/man/plot.FFTrees.Rd
+++ b/man/plot.FFTrees.Rd
@@ -158,21 +158,12 @@ plot(heart.fft, what = "icontree", n.per.icon = 2,
 plot(heart.fft, what = "roc", main = "Performance comparison for heart disease data")
 
 # Visualize predictions of FFT #2 (for new test data) with custom options:
-plot(heart.fft,
-     tree = 2,
-     data = heart.test,
+plot(heart.fft, tree = 2, data = heart.test,
      main = "Predicting heart disease",
      cue.labels = c("1. thal?", "2. cp?", "3. ca?", "4. exang"),
-     decision.labels = c("ok", "sick"),
-     n.per.icon = 2,
-     show.header = TRUE,
-     show.confusion = FALSE,
-     show.levels = FALSE,
-     show.roc = FALSE,
-     hlines = FALSE,
-     font = 3,
-     col = "steelblue"
-     )
+     decision.labels = c("ok", "sick"), n.per.icon = 2,
+     show.header = TRUE, show.confusion = FALSE, show.levels = FALSE, show.roc = FALSE,
+     hlines = FALSE, font = 3, col = "steelblue")
 
 # For more details, see
 vignette("FFTrees_plot", package = "FFTrees")


### PR DESCRIPTION
Improve efficiency:  When calling `add_level()` from `plot.FFTrees()`, pass only the relevant row of data frame `lloc`, rather than the entire df for very level.