### PR TITLE
Allowing to select FFTs by dprime value (i.e., `goal = 'dprime'`)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.7.5.9001
-Date: 2022-09-19
+Version: 1.7.5.9002
+Date: 2022-09-22
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.7
 
-## 1.7.5.9001
+## 1.7.5.9002
 
 <!-- Development version: --> 
 
@@ -15,7 +15,8 @@ Changes since last release:
 
 ### Major changes
 
-- None yet.  
+- Enabled setting `goal = 'dprime'` to select FFTs in `FFTrees()`. 
+
 
 <!-- Blank line. --> 
 
@@ -342,6 +343,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2022-09-19.] 
+[File `NEWS.md` last updated on 2022-09-22.] 
 
 <!-- eof. -->

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -46,9 +46,9 @@ fftrees_apply <- function(x,
 
       testthat::expect_true(!is.null(x$data$test))
 
-      } else {
+    } else {
 
-        x$data$test <- newdata  # replaces existing test data in x by newdata!
+      x$data$test <- newdata  # replaces existing test data in x by newdata!
     }
 
     valid_train_test_data(train_data = x$data$train, test_data = x$data$test)  # verify (without consequences)
@@ -64,9 +64,10 @@ fftrees_apply <- function(x,
   # Setup outputs: ------
 
   #  1. [decisions_ls]: ----
-  #     A list containing tibbles with one row per case, and one column per tree:
+  #     A list containing tibbles, with 1 row per case, and 1 column per tree:
 
   decisions_ls <- lapply(1:x$trees$n, FUN = function(i) {
+
     tibble::tibble(
       criterion = criterion_v,
       decision = rep(NA, criterion_n),
@@ -76,12 +77,13 @@ fftrees_apply <- function(x,
       cost = rep(NA, criterion_n),
       current_decision = rep(NA, criterion_n)
     )
+
   })
 
   names(decisions_ls) <- paste0("tree_", 1:x$trees$n)
 
   #  2. [level_stats_ls]: ----
-  #    A list with one element per tree, each containing cumulative level statistics:
+  #     A list with 1 element per tree, each containing cumulative level statistics:
 
   level_stats_ls <- vector("list", length = x$trees$n)
 
@@ -102,7 +104,7 @@ fftrees_apply <- function(x,
 
     decisions_df <- decisions_ls[[tree_i]]
 
-    costc_level <- sapply(cue_v, FUN = function(cue_i) {
+    cost_cue_level <- sapply(cue_v, FUN = function(cue_i) {
       if (cue_i %in% names(x$params$cost.cues)) {
         cost_cue_i <- x$params$cost.cues[[cue_i]]
       } else {
@@ -110,11 +112,11 @@ fftrees_apply <- function(x,
       }
     })
 
-    costc_level_cum <- cumsum(costc_level)
+    cost_cue_level_cum <- cumsum(cost_cue_level)
 
     cue_cost_cum_level <- data.frame(
       level = 1:level_n,
-      cue_cost_cum = costc_level_cum
+      cue_cost_cum = cost_cue_level_cum
     )
 
     # level_stats_i contains cumulative level statistics:
@@ -181,20 +183,20 @@ fftrees_apply <- function(x,
       }
 
       if (isTRUE(all.equal(exit_i, 0))) {
-        classify.now <- decisions_df$current_decision == FALSE & is.na(decisions_df$decision)
+        classify_now <- decisions_df$current_decision == FALSE & is.na(decisions_df$decision)
       }
       if (isTRUE(all.equal(exit_i,  1))) {
-        classify.now <- decisions_df$current_decision == TRUE & is.na(decisions_df$decision)
+        classify_now <- decisions_df$current_decision == TRUE & is.na(decisions_df$decision)
       }
       if (isTRUE(all.equal(exit_i, .5))) {
-        classify.now <- is.na(decisions_df$decision)
+        classify_now <- is.na(decisions_df$decision)
       }
 
       # Convert NAs: ----
 
       # If it is not the final node, then don't classify NA cases:
       if (exit_i %in% c(0, 1)) {
-        classify.now[is.na(classify.now)] <- FALSE
+        classify_now[is.na(classify_now)] <- FALSE
       }
 
       # If it is the final node, then classify NA cases according to most common class:
@@ -205,13 +207,13 @@ fftrees_apply <- function(x,
 
       # Define critical values for current decisions: ----
 
-      decisions_df$decision[classify.now] <- decisions_df$current_decision[classify.now]
-      decisions_df$levelout[classify.now] <- level_i
-      decisions_df$cost_cue[classify.now] <- costc_level_cum[level_i]
+      decisions_df$decision[classify_now] <- decisions_df$current_decision[classify_now]
+      decisions_df$levelout[classify_now] <- level_i
+      decisions_df$cost_cue[classify_now] <- cost_cue_level_cum[level_i]
 
-      decisions_df$cost_decision[decisions_df$criterion == TRUE & decisions_df$decision == TRUE] <- x$params$cost.outcomes$hi
-      decisions_df$cost_decision[decisions_df$criterion == TRUE & decisions_df$decision == FALSE] <- x$params$cost.outcomes$mi
-      decisions_df$cost_decision[decisions_df$criterion == FALSE & decisions_df$decision == TRUE] <- x$params$cost.outcomes$fa
+      decisions_df$cost_decision[decisions_df$criterion == TRUE & decisions_df$decision == TRUE]   <- x$params$cost.outcomes$hi
+      decisions_df$cost_decision[decisions_df$criterion == TRUE & decisions_df$decision == FALSE]  <- x$params$cost.outcomes$mi
+      decisions_df$cost_decision[decisions_df$criterion == FALSE & decisions_df$decision == TRUE]  <- x$params$cost.outcomes$fa
       decisions_df$cost_decision[decisions_df$criterion == FALSE & decisions_df$decision == FALSE] <- x$params$cost.outcomes$cr
 
       decisions_df$cost <- decisions_df$cost_cue + decisions_df$cost_decision

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -131,11 +131,18 @@ fftrees_apply <- function(x,
       stringsAsFactors = FALSE
     )
 
-    # Define critical stats:
-    critical_stats_v <- c("n", "hi", "fa", "mi", "cr",
-                          "sens", "spec", "far", "ppv", "npv",
-                          "acc", "bacc", "wacc",
-                          "cost_decisions")
+    # Define critical stats:  +++ here now +++
+    critical_stats_v <- c(
+      # frequencies:
+      "n", "hi", "fa", "mi", "cr",
+      # conditional probabilities:
+      "sens", "spec", "far",  "ppv", "npv",
+      # derived from probabilities:
+      "dprime",  # enable goal = "dprime" by including in tree stats
+      # accuracy:
+      "acc", "bacc", "wacc",
+      # costs:
+      "cost_decisions")
 
     # Add stat names to level_stats_i:
     level_stats_i[critical_stats_v] <- NA

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -102,19 +102,19 @@ fftrees_apply <- function(x,
 
     decisions_df <- decisions_ls[[tree_i]]
 
-    costc.level <- sapply(cue_v, FUN = function(cue_i) {
+    costc_level <- sapply(cue_v, FUN = function(cue_i) {
       if (cue_i %in% names(x$params$cost.cues)) {
-        cost.cue_i <- x$params$cost.cues[[cue_i]]
+        cost_cue_i <- x$params$cost.cues[[cue_i]]
       } else {
-        cost.cue_i <- 0
+        cost_cue_i <- 0
       }
     })
 
-    costc.level.cum <- cumsum(costc.level)
+    costc_level_cum <- cumsum(costc_level)
 
     cue_cost_cum_level <- data.frame(
       level = 1:level_n,
-      cue_cost_cum = costc.level.cum
+      cue_cost_cum = costc_level_cum
     )
 
     # level_stats_i contains cumulative level statistics:
@@ -129,7 +129,11 @@ fftrees_apply <- function(x,
       stringsAsFactors = FALSE
     )
 
-    critical_stats_v <- c("n", "hi", "fa", "mi", "cr", "sens", "spec", "far", "ppv", "npv", "acc", "bacc", "wacc", "cost_decisions")
+    # Define critical stats:
+    critical_stats_v <- c("n", "hi", "fa", "mi", "cr",
+                          "sens", "spec", "far", "ppv", "npv",
+                          "acc", "bacc", "wacc",
+                          "cost_decisions")
 
     # Add stat names to level_stats_i:
     level_stats_i[critical_stats_v] <- NA
@@ -203,7 +207,7 @@ fftrees_apply <- function(x,
 
       decisions_df$decision[classify.now] <- decisions_df$current_decision[classify.now]
       decisions_df$levelout[classify.now] <- level_i
-      decisions_df$cost_cue[classify.now] <- costc.level.cum[level_i]
+      decisions_df$cost_cue[classify.now] <- costc_level_cum[level_i]
 
       decisions_df$cost_decision[decisions_df$criterion == TRUE & decisions_df$decision == TRUE] <- x$params$cost.outcomes$hi
       decisions_df$cost_decision[decisions_df$criterion == TRUE & decisions_df$decision == FALSE] <- x$params$cost.outcomes$mi
@@ -273,7 +277,7 @@ fftrees_apply <- function(x,
   x$trees$level_stats[[mydata]] <- tibble::as_tibble(level_stats)
   x$trees$decisions[[mydata]]   <- decisions_ls
 
-  # Best tree:
+  # Set best tree values:
   if (mydata == "train"){
     x$trees$best$train <- select_best_tree(x, data = mydata, goal = x$params$goal)
   } else if (mydata == "test"){

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -1,4 +1,4 @@
-#' Grow fast-and-frugal trees (FFTs) using the \code{fan} algorithm
+#' Grow fast-and-frugal trees (FFTs) using the \code{fan} algorithms
 #'
 #' @description \code{fftrees_grow_fan} is called by \code{\link{fftrees_define}}
 #' to create new FFTs by applying the \code{fan} algorithms
@@ -86,6 +86,7 @@ fftrees_grow_fan <- function(x,
     tree_table_names <- c("decision", "levelout")
 
     tree_stats_ls <- lapply(1:length(tree_table_names), FUN = function(x) {
+
       output <- as.data.frame(matrix(NA, nrow = cases_n, ncol = tree_n))
 
       names(output) <- paste("tree", 1:tree_n, sep = ".")

--- a/R/helper.R
+++ b/R/helper.R
@@ -100,7 +100,7 @@ valid_train_test_data <- function(train_data, test_data){
 #'
 #' @param x An \code{FFTrees} object.
 #'
-#' @param data character. Must be either "train" or "test".
+#' @param data The type of data to consider (as character: either 'train' or 'test').
 #'
 #' @param goal character. A goal to maximize or minimize when selecting a tree from an existing \code{x}
 #' (for which values exist in \code{x$trees$stats}).
@@ -170,14 +170,14 @@ select_best_tree <- function(x, data, goal){
     cur_ranks <- rank(+cur_goal_vals, ties.method = "first")  # low rank indicate lower/better values
   }
 
-  tree <- cur_stats$tree[cur_ranks == min(cur_ranks)]  # tree with minimum rank
+  tree <- cur_stats$tree[cur_ranks == min(cur_ranks)]  # get tree with minimum rank
 
 
   # Output: -----
 
   testthat::expect_true(is.integer(tree))  # verify output
 
-  return(tree) # as number
+  return(tree) # as integer
 
 } # select_best_tree().
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.7.5.9001 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.7.5.9002 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Status badges: -->
 
@@ -312,6 +312,6 @@ for the full list):
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2022-09-19.\]
+\[File `README.Rmd` last updated on 2022-09-22.\]
 
 <!-- eof. -->

--- a/man/fftrees_grow_fan.Rd
+++ b/man/fftrees_grow_fan.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/fftrees_grow_fan.R
 \name{fftrees_grow_fan}
 \alias{fftrees_grow_fan}
-\title{Grow fast-and-frugal trees (FFTs) using the \code{fan} algorithm}
+\title{Grow fast-and-frugal trees (FFTs) using the \code{fan} algorithms}
 \usage{
 fftrees_grow_fan(x, repeat.cues = TRUE)
 }

--- a/man/select_best_tree.Rd
+++ b/man/select_best_tree.Rd
@@ -9,7 +9,7 @@ select_best_tree(x, data, goal)
 \arguments{
 \item{x}{An \code{FFTrees} object.}
 
-\item{data}{character. Must be either "train" or "test".}
+\item{data}{The type of data to consider (as character: either 'train' or 'test').}
 
 \item{goal}{character. A goal to maximize or minimize when selecting a tree from an existing \code{x}
 (for which values exist in \code{x$trees$stats}).}


### PR DESCRIPTION
As the **dprime** values of trees were not recorded in tree stats, it was not possible to set `goal = "dprime"` in `FFTrees()` (i.e., select FFTs by their dprime value). 

The current PR fixes this — and hopefully works without causing new issues, as it doesn't affect any fundamental moving parts.

However, allowing to use **dprime** as `goal.chase` or `goal.threshold` will require more profound changes, and should probably be supported by _reporting_ both current **goals** and **dprime** values when printing and plotting FFTs. 

