### PR TITLE
Maintenance: Stats computed when growing FFTs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.7.5.9002
-Date: 2022-09-22
+Version: 1.7.5.9003
+Date: 2022-09-23
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -1,7 +1,8 @@
 #' Calculate thresholds that optimize some statistic (goal) for cues in data
 #'
 #' \code{fftrees_cuerank} takes an \code{FFTrees} object \code{x} and
-#' optimizes its \code{goal.threshold} (from \code{x$params}) for all cues in \code{data}.
+#' optimizes its \code{goal.threshold} (from \code{x$params}) for all cues in
+#' a dataset \code{newdata} (of some \code{data} type).
 #'
 #' \code{fftrees_cuerank} creates a data frame \code{cuerank_df}
 #' that is added to \code{x$cues$stats}.
@@ -10,11 +11,13 @@
 #' to grow fast-and-frugal trees (FFTs).
 #'
 #' @param x An \code{FFTrees} object.
-#' @param newdata dataframe.
-#' @param data dataframe.
-#' @param rounding integer.
+#' @param newdata The dataset to with cues to be ranked (as data frame).
+#' @param data The type of data with cues to be ranked (as character: \code{'train'}, \code{'test'}, or \code{'dynamic'}).
+#' Default: \code{data = 'train'}.
+#' @param rounding Number of digits used to round (as integer).
+#' Default: \code{rounding = NULL}.
 #'
-#' @return A modified \code{FFTrees} object (with cue rank information for current \code{data} in \code{x$cues$stats}).
+#' @return A modified \code{FFTrees} object (with cue rank information for current \code{data} type in \code{x$cues$stats}).
 #'
 #' @importFrom stats median var
 #' @importFrom progress progress_bar

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -111,7 +111,7 @@ fftrees_grow_fan <- function(x,
     level_n <- length(exits_i)
 
     ## Set up placeholders:
-    cue_best_df.original <- x$cues$stats$train
+    cue_best_df_original <- x$cues$stats$train  # Note: Must contain current goal.chase parameter!
 
     # Decisions, levelout, and cost vectors:
     decision_v <- rep(NA, cases_n)
@@ -141,10 +141,10 @@ fftrees_grow_fan <- function(x,
     level_stat_names <- setdiff(names(fftrees_threshold_factor_grid()), c("threshold", "direction"))
     level_stats_i[level_stat_names] <- NA
 
-    # asif.stats shows cumulative classification statistics as if all exemplars were
+    # asif_stats shows cumulative classification statistics as if all exemplars were
     #            classified at the current level (i.e., if the tree stopped here).
 
-    asif.stats <- data.frame(
+    asif_stats <- data.frame(
       "level" = 1:level_n,
       "sens" = NA,
       "spec" = NA,
@@ -157,42 +157,42 @@ fftrees_grow_fan <- function(x,
     )
 
     # Starting values:
-    grow.tree <- TRUE
+    grow_tree <- TRUE
     level_current <- 0
 
     # GROW THE TREE: ------
 
-    while (grow.tree == TRUE) {
+    while (grow_tree == TRUE) {
 
       level_current <- level_current + 1
       exit_current  <- exits_i[level_current]
       cases_remaining <- is.na(decision_v)
 
-      # Step 1: Determine the cue for current level: ------
+      # Step 1: Determine a cue for the current level: ------
       {
-        # A. ifan x$params$algorithm"
+        # A. ifan algorithm:
         if (x$params$algorithm == "ifan") {
 
           # Get accuracies of un-used cues:
-          cue_best_df_current <- cue_best_df.original[(cue_best_df.original$cue %in% level_stats_i$cue) == FALSE, ]
+          cue_best_df_current <- cue_best_df_original[(cue_best_df_original$cue %in% level_stats_i$cue) == FALSE, ]
 
         } # if algorithm == "ifan".
 
-        # B. dfan x$params$algorithm:
+        # B. dfan algorithm:
         if (x$params$algorithm == "dfan") {
 
           data_current <- x$data$train[cases_remaining, ]
 
           # If cues may NOT be repeated, then remove old cues as well:
           if (repeat.cues == FALSE) {
-            remaining.cues.index <- (names(cue_df) %in% level_stats_i$cue) == FALSE
-            remaining.cues <- names(cue_df)[remaining.cues.index]
-            data_current <- data_current[, c(criterion_name, remaining.cues)]
+            remaining_cues_ix <- (names(cue_df) %in% level_stats_i$cue) == FALSE
+            remaining_cues <- names(cue_df)[remaining_cues_ix]
+            data_current <- data_current[, c(criterion_name, remaining_cues)]
           }
 
           # If there is no variance in the criterion, then stop growth!
           if (all(duplicated(data_current)[-1L])) {
-            grow.tree <- FALSE
+            grow_tree <- FALSE
             break
           }
 
@@ -203,7 +203,7 @@ fftrees_grow_fan <- function(x,
           )
 
           # Calculate cue accuracies with remaining exemplars:
-          cue_best_df_current <- x$cues$stats$dynamic
+          cue_best_df_current <- x$cues$stats$dynamic  # Note: Must contain current goal.chase parameter!
 
         } # if algorithm == "dfan".
 
@@ -243,7 +243,7 @@ fftrees_grow_fan <- function(x,
       {
 
         # Get decisions for current cue:
-        cue.decisions <- apply_break(
+        cue_decisions <- apply_break(
 
           direction = cue_direction_new,
           threshold.val = cue_threshold_new,
@@ -259,7 +259,7 @@ fftrees_grow_fan <- function(x,
         asif.levelout_v <- levelout_v
         asif.cuecost_v <- cuecost_v
 
-        asif.decision_v[cases_remaining] <- cue.decisions[cases_remaining]
+        asif.decision_v[cases_remaining] <- cue_decisions[cases_remaining]
         asif.levelout_v[cases_remaining] <- level_current
         asif.cuecost_v[cases_remaining] <- cue_cost_new
 
@@ -271,27 +271,28 @@ fftrees_grow_fan <- function(x,
         )
 
 
-        # Add key stats to asif.stats:
+        # Add key stats to asif_stats:
         # Note: Horizontal/by-row measures (ppv, npv) are currently NOT recorded:  +++ here now +++
-        asif.stats[level_current, c("sens", "spec", "dprime", "acc", "bacc", "wacc", "cost")] <- c(#
-          asif_results$sens, asif_results$spec,
-          asif_results$dprime,
-          asif_results$acc, asif_results$bacc, asif_results$wacc,
-          asif_results$cost
-        )
+        asif_stats[level_current,
+                   c("sens", "spec", "dprime", "acc", "bacc", "wacc", "cost")] <- c(#
+                     asif_results$sens, asif_results$spec,
+                     asif_results$dprime,                                     # ADDED on 2022-09-23
+                     asif_results$acc, asif_results$bacc, asif_results$wacc,
+                     asif_results$cost
+                   )
 
 
         # If ASIF classification is perfect, then stop:
         if (x$params$goal.chase != "cost") {
 
-          if (dplyr::near(asif.stats[[x$params$goal.chase]][level_current], 1)) { # perfect 1:
-            grow.tree <- FALSE
+          if (dplyr::near(asif_stats[[x$params$goal.chase]][level_current], 1)) { # perfect 1:
+            grow_tree <- FALSE
           }
 
         } else { # chasing "cost":
 
-          if (dplyr::near(asif.stats[[x$params$goal.chase]][level_current], 0)) { # perfect 0:
-            grow.tree <- FALSE
+          if (dplyr::near(asif_stats[[x$params$goal.chase]][level_current], 0)) { # perfect 0:
+            grow_tree <- FALSE
           }
 
         }
@@ -301,12 +302,12 @@ fftrees_grow_fan <- function(x,
         # Calculate goal change:
         {
           if (level_current == 1) {
-            asif.stats$goal.change[1] <- asif.stats[[x$params$goal]][1]
+            asif_stats$goal.change[1] <- asif_stats[[x$params$goal]][1]
           }
 
           if (level_current > 1) {
-            goal.change <- asif.stats[[x$params$goal.chase]][level_current] - asif.stats[[x$params$goal.chase]][level_current - 1]
-            asif.stats$goal.change[level_current] <- goal.change
+            goal.change <- asif_stats[[x$params$goal.chase]][level_current] - asif_stats[[x$params$goal.chase]][level_current - 1]
+            asif_stats$goal.change[level_current] <- goal.change
           }
         }
 
@@ -317,18 +318,18 @@ fftrees_grow_fan <- function(x,
       {
         if (dplyr::near(exit_current, 1) | dplyr::near(exit_current, .50)) {
 
-          decide.1.index <- cases_remaining & cue.decisions == TRUE
+          decide_1_index <- cases_remaining & cue_decisions == TRUE
 
-          decision_v[decide.1.index] <- TRUE
-          levelout_v[decide.1.index] <- level_current
+          decision_v[decide_1_index] <- TRUE
+          levelout_v[decide_1_index] <- level_current
         }
 
         if (exit_current == 0 | dplyr::near(exit_current, .50)) {
 
-          decide.0.index <- is.na(decision_v) & cue.decisions == FALSE
+          decide_0_index <- is.na(decision_v) & cue_decisions == FALSE
 
-          decision_v[decide.0.index] <- FALSE
-          levelout_v[decide.0.index] <- level_current
+          decision_v[decide_0_index] <- FALSE
+          levelout_v[decide_0_index] <- level_current
         }
 
         # Update cost vectors:
@@ -374,7 +375,7 @@ fftrees_grow_fan <- function(x,
         # Note: Horizontal/by-row measures (ppv, npv) are currently NOT recorded:  +++ here now +++
         level_stats_v <- c("hi", "fa", "mi", "cr",
                            "sens", "spec",
-                           "dprime",  # NEW here!
+                           "dprime",                   # ADDED on 2022-09-23
                            "bacc", "acc", "wacc",
                            "cost_decisions", "cost")
         level_stats_i[level_current, level_stats_v] <- results_cum[, level_stats_v]
@@ -388,11 +389,11 @@ fftrees_grow_fan <- function(x,
 
         if (cases_remaining_n > 0 & level_current != cues_n & exit.method == "fixed") {
           if (level_current < level_n) {
-            grow.tree <- TRUE
+            grow_tree <- TRUE
           }
 
           if (level_current == level_n) {
-            grow.tree <- FALSE
+            grow_tree <- FALSE
             break
           }
         }
@@ -418,22 +419,22 @@ fftrees_grow_fan <- function(x,
 
       } # Step 5.
 
-    } # STOP while(grow.tree) loop.
+    } # STOP while(grow_tree) loop.
 
 
-    # Step 6: No more growth. Make sure that last level is bidirectional: ----
+    # Step 6: No more growth. Make sure that last level is bi-directional: ----
     {
-      last.level <- max(level_stats_i$level)
-      last.cue <- level_stats_i$cue[last.level]
-      cost.cue <- x$params$cost.cues[[last.cue]]
+      last_level_nr <- max(level_stats_i$level)
+      last_cue <- level_stats_i$cue[last_level_nr]
+      # cost.cue <- x$params$cost.cues[[last_cue]]  # never used???
 
-      last.exitdirection <- level_stats_i$exit[level_stats_i$level == last.level]
+      last.exitdirection <- level_stats_i$exit[level_stats_i$level == last_level_nr]
 
       if (last.exitdirection != .5) {
 
-        decision_v[levelout_v == last.level] <- NA
+        decision_v[levelout_v == last_level_nr] <- NA
 
-        last_cue_stats <- cue_best_df_current[cue_best_df_current$cue == last.cue, ]
+        last_cue_stats <- cue_best_df_current[cue_best_df_current$cue == last_cue, ]
 
         decision.index <- is.na(decision_v)
 
@@ -442,18 +443,18 @@ fftrees_grow_fan <- function(x,
         current.decisions <- apply_break(
           direction = last_cue_stats$direction,
           threshold.val = last_cue_stats$threshold,
-          cue.v = x$data$train[[last.cue]],
+          cue.v = x$data$train[[last_cue]],
           cue.class = last_cue_stats$class
         )
 
-        decide.0.index <- decision.index == TRUE & current.decisions == FALSE
-        decide.1.index <- decision.index == TRUE & current.decisions == TRUE
+        decide_0_index <- decision.index == TRUE & current.decisions == FALSE
+        decide_1_index <- decision.index == TRUE & current.decisions == TRUE
 
-        decision_v[decide.0.index] <- FALSE
-        decision_v[decide.1.index] <- TRUE
+        decision_v[decide_0_index] <- FALSE
+        decision_v[decide_1_index] <- TRUE
 
-        levelout_v[decide.0.index] <- level_current
-        levelout_v[decide.1.index] <- level_current
+        levelout_v[decide_0_index] <- level_current
+        levelout_v[decide_1_index] <- level_current
 
         # up
 
@@ -465,12 +466,16 @@ fftrees_grow_fan <- function(x,
           cost.outcomes = x$params$cost.outcomes
         )
 
-        level_stats_i$exit[last.level] <- .50
+        level_stats_i$exit[last_level_nr] <- .50
 
 
         # Note: Why not use same stats as in level_stats_v above? (Here: "dprime" and "cost" missing): +++ here now +++
-        level_stats_i[last.level, c("hi", "fa", "mi", "cr",
-                                    "sens", "spec", "bacc", "acc", "wacc", "cost_decisions")] <- last.classtable[, c("hi", "fa", "mi", "cr", "sens", "spec", "bacc", "acc", "wacc", "cost_decisions")]
+        # level_stats_i[last_level_nr, c("hi", "fa", "mi", "cr",
+        #                                "sens", "spec", "bacc", "acc", "wacc", "cost_decisions")] <- last.classtable[, c("hi", "fa", "mi", "cr", "sens", "spec", "bacc", "acc", "wacc", "cost_decisions")]
+
+        # NEW (using same level_stats_v as above) on 2022-09-23:
+        level_stats_i[last_level_nr, level_stats_v] <- last.classtable[, level_stats_v]
+
       }
 
     } # Step 6.
@@ -491,39 +496,39 @@ fftrees_grow_fan <- function(x,
 
 
   # Summarize tree definitions and statistics: ------
-  # tree.definitions:
+  # (as df of tree_definitions):
 
   {
 
     # Summarise tree definitions:
-    tree.definitions <- as.data.frame(matrix(NA, nrow = tree_n, ncol = 7))
-    names(tree.definitions) <- c("tree", "nodes", "classes", "cues", "directions", "thresholds", "exits")
+    tree_definitions <- as.data.frame(matrix(NA, nrow = tree_n, ncol = 7))
+    names(tree_definitions) <- c("tree", "nodes", "classes", "cues", "directions", "thresholds", "exits")
 
     for (tree_i in 1:tree_n) {
 
       level_stats_i <- level_stats_ls[[tree_i]]
 
-      tree.definitions$tree[tree_i] <- tree_i
-      tree.definitions$cues[tree_i] <- paste(level_stats_i$cue, collapse = ";")
-      tree.definitions$nodes[tree_i] <- length(level_stats_i$cue)
-      tree.definitions$classes[tree_i] <- paste(substr(level_stats_i$class, 1, 1), collapse = ";")
-      tree.definitions$exits[tree_i] <- paste(level_stats_i$exit, collapse = ";")
-      tree.definitions$thresholds[tree_i] <- paste(level_stats_i$threshold, collapse = ";")
-      tree.definitions$directions[tree_i] <- paste(level_stats_i$direction, collapse = ";")
+      tree_definitions$tree[tree_i] <- tree_i
+      tree_definitions$cues[tree_i] <- paste(level_stats_i$cue, collapse = ";")
+      tree_definitions$nodes[tree_i] <- length(level_stats_i$cue)
+      tree_definitions$classes[tree_i] <- paste(substr(level_stats_i$class, 1, 1), collapse = ";")
+      tree_definitions$exits[tree_i] <- paste(level_stats_i$exit, collapse = ";")
+      tree_definitions$thresholds[tree_i] <- paste(level_stats_i$threshold, collapse = ";")
+      tree_definitions$directions[tree_i] <- paste(level_stats_i$direction, collapse = ";")
 
     } # for (tree).
 
-    duplicate.trees <- duplicated(tree.definitions[c("cues", "exits", "thresholds", "directions")])
-    tree.definitions <- tree.definitions[duplicate.trees == FALSE, ]
-    rownames(tree.definitions) <- 1:nrow(tree.definitions)
-    tree.definitions$tree <- 1:nrow(tree.definitions)
-    tree.definitions <- tree.definitions[, c(which(names(tree.definitions) == "tree"), which(names(tree.definitions) != "tree"))]
+    duplicate.trees <- duplicated(tree_definitions[c("cues", "exits", "thresholds", "directions")])
+    tree_definitions <- tree_definitions[duplicate.trees == FALSE, ]
+    rownames(tree_definitions) <- 1:nrow(tree_definitions)
+    tree_definitions$tree <- 1:nrow(tree_definitions)
+    tree_definitions <- tree_definitions[, c(which(names(tree_definitions) == "tree"), which(names(tree_definitions) != "tree"))]
 
   }
 
-  # Add tree.definitions to x:
-  x$trees$definitions <- tree.definitions
-  x$trees$n <- nrow(tree.definitions)
+  # Add tree_definitions to x:
+  x$trees$definitions <- tree_definitions
+  x$trees$n <- nrow(tree_definitions)
 
 
   # Output: ----

--- a/README.Rmd
+++ b/README.Rmd
@@ -151,7 +151,7 @@ heart.fft$competition$test
 
 ### Building FFTs from verbal descriptions 
 
-Because fast-and-frugal trees are so simple, we even can create FFTs 'from words' and apply them to data!
+FFTs are so simple that we even can create them 'from words' and then apply them to data! 
 
 For example, let's create a tree with the following three nodes and evaluate its performance on the `heart.test` data:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.7.5.9002 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.7.5.9003 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Status badges: -->
 
@@ -200,8 +200,8 @@ data.](man/figures/README-example-heart-plot-1.png)
 
 ### Building FFTs from verbal descriptions
 
-Because fast-and-frugal trees are so simple, we even can create FFTs
-‘from words’ and apply them to data!
+FFTs are so simple that we even can create them ‘from words’ and then
+apply them to data!
 
 For example, let’s create a tree with the following three nodes and
 evaluate its performance on the `heart.test` data:
@@ -312,6 +312,6 @@ for the full list):
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2022-09-22.\]
+\[File `README.Rmd` last updated on 2022-09-23.\]
 
 <!-- eof. -->

--- a/man/fftrees_cuerank.Rd
+++ b/man/fftrees_cuerank.Rd
@@ -9,18 +9,21 @@ fftrees_cuerank(x = NULL, newdata = NULL, data = "train", rounding = NULL)
 \arguments{
 \item{x}{An \code{FFTrees} object.}
 
-\item{newdata}{dataframe.}
+\item{newdata}{The dataset to with cues to be ranked (as data frame).}
 
-\item{data}{dataframe.}
+\item{data}{The type of data with cues to be ranked (as character: \code{'train'}, \code{'test'}, or \code{'dynamic'}).
+Default: \code{data = 'train'}.}
 
-\item{rounding}{integer.}
+\item{rounding}{Number of digits used to round (as integer).
+Default: \code{rounding = NULL}.}
 }
 \value{
-A modified \code{FFTrees} object (with cue rank information for current \code{data} in \code{x$cues$stats}).
+A modified \code{FFTrees} object (with cue rank information for current \code{data} type in \code{x$cues$stats}).
 }
 \description{
 \code{fftrees_cuerank} takes an \code{FFTrees} object \code{x} and
-optimizes its \code{goal.threshold} (from \code{x$params}) for all cues in \code{data}.
+optimizes its \code{goal.threshold} (from \code{x$params}) for all cues in
+a dataset \code{newdata} (of some \code{data} type).
 }
 \details{
 \code{fftrees_cuerank} creates a data frame \code{cuerank_df}

--- a/man/fftrees_grow_fan.Rd
+++ b/man/fftrees_grow_fan.Rd
@@ -9,7 +9,8 @@ fftrees_grow_fan(x, repeat.cues = TRUE)
 \arguments{
 \item{x}{An \code{FFTrees} object.}
 
-\item{repeat.cues}{logical.}
+\item{repeat.cues}{Can cues be considered/used repeatedly (as logical)?
+Default: \code{repeat.cues = TRUE}, but only relevant for \code{dfan} algorithm.}
 }
 \description{
 \code{fftrees_grow_fan} is called by \code{\link{fftrees_define}}


### PR DESCRIPTION
Minor maintenance changes:

- Added and unified variables for stats computed in `fftrees_grow_fan()`. 
- Renamed some variables to distinguish internal variables (using `_`) from function arguments (using `.`).
- Updated documentation.

The background of these changes are discussed in Issue #93.  However, actually using new variables (e.g., dprime) in `goal.chase` or `goal.threshold` would additionally require adding them to cue statistics in `x$cues$stats$train`. 