### PR TITLE
Trim spaces in tree definitions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.7.5.9006
-Date: 2022-11-18
+Version: 1.7.5.9007
+Date: 2022-12-10
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.7
 
-## 1.7.5.9004
+## 1.7.5.9007
 
 <!-- Development version: --> 
 
@@ -16,7 +16,7 @@ Changes since last release:
 ### Major changes
 
 - Enabled setting `goal = 'dprime'` to select FFTs in `FFTrees()`. 
-
+- Trimmed white space from elements in tree definitions (in `fftrees_apply.R`).
 
 <!-- Blank line. --> 
 
@@ -345,6 +345,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2022-10-01.]
+[File `NEWS.md` last updated on 2022-12-10.]
 
 <!-- eof. -->

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -26,7 +26,7 @@
 #' @export
 
 fftrees_apply <- function(x,
-                          mydata = NULL,
+                          mydata = NULL,   # either "train" or "test"
                           newdata = NULL,
                           allNA.pred = FALSE) {
 
@@ -48,7 +48,10 @@ fftrees_apply <- function(x,
 
     } else {
 
-      x$data$test <- newdata  # replaces existing test data in x by newdata!
+      # Replace existing test data in x by newdata:
+
+      x$data$test <- newdata
+
     }
 
     valid_train_test_data(train_data = x$data$train, test_data = x$data$test)  # verify (without consequences)
@@ -94,12 +97,13 @@ fftrees_apply <- function(x,
 
   for (tree_i in 1:x$trees$n) {
 
-    # Extract defintions for current tree
-    cue_v <- unlist(strsplit(x$trees$definitions$cues[tree_i], ";"))
-    class_v <- unlist(strsplit(x$trees$definitions$classes[tree_i], ";"))
-    exit_v <- unlist(strsplit(x$trees$definitions$exits[tree_i], ";"))
-    threshold_v <- unlist(strsplit(x$trees$definitions$thresholds[tree_i], ";"))
-    direction_v <- unlist(strsplit(x$trees$definitions$directions[tree_i], ";"))
+    # Extract definitions for current tree:
+    cue_v   <- trimws(unlist(strsplit(x$trees$definitions$cues[tree_i], ";")))  # +++ here now +++: Added trimws()
+    class_v <- trimws(unlist(strsplit(x$trees$definitions$classes[tree_i], ";")))
+    exit_v  <- trimws(unlist(strsplit(x$trees$definitions$exits[tree_i], ";")))
+    threshold_v <- trimws(unlist(strsplit(x$trees$definitions$thresholds[tree_i], ";")))
+    direction_v <- trimws(unlist(strsplit(x$trees$definitions$directions[tree_i], ";")))
+
     level_n <- x$trees$definitions$nodes[tree_i]
 
     decisions_df <- decisions_ls[[tree_i]]

--- a/README.Rmd
+++ b/README.Rmd
@@ -35,7 +35,7 @@ url_JDM_pdf   <- "https://journal.sjdm.org/17/17217/jdm17217.pdf"
 [![Build Status](https://travis-ci.org/ndphillips/FFTrees.svg?branch=master)](https://travis-ci.org/ndphillips/FFTrees)
 [![Downloads](https://cranlogs.r-pkg.org/badges/FFTrees?color=brightgreen)](https://www.r-pkg.org/pkg/FFTrees)
 
-<!-- Goal of R package: -->
+<!-- Goal: -->
 
 The R package **FFTrees** creates, visualizes and evaluates _fast-and-frugal decision trees_ (FFTs) for solving binary classification tasks following the methods described in Phillips, Neth, Woike & Gaissmaier (2017, as\ [html](`r url_JDM_html`) | [PDF](`r url_JDM_pdf`)). 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.7.5.9006 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.7.5.9007 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Status badges: -->
 
@@ -11,7 +11,7 @@
 Status](https://travis-ci.org/ndphillips/FFTrees.svg?branch=master)](https://travis-ci.org/ndphillips/FFTrees)
 [![Downloads](https://cranlogs.r-pkg.org/badges/FFTrees?color=brightgreen)](https://www.r-pkg.org/pkg/FFTrees)
 
-<!-- Goal of R package: -->
+<!-- Goal: -->
 
 The R package **FFTrees** creates, visualizes and evaluates
 *fast-and-frugal decision trees* (FFTs) for solving binary
@@ -321,6 +321,6 @@ for the full list):
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2022-11-18.\]
+\[File `README.Rmd` last updated on 2022-12-10.\]
 
 <!-- eof. -->


### PR DESCRIPTION
Trimming both leading and trailing spaces when interpreting tree definitions (in `fftrees_apply()`, to address Issue #111).
 