### PR TITLE
Manually defining FFTs and user feedback

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
 Version: 1.7.5.9010
-Date: 2022-12-14
+Date: 2022-12-15
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.7.5.9009
+Version: 1.7.5.9010
 Date: 2022-12-14
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.7
 
-## 1.7.5.9009
+## 1.7.5.9010
 
 <!-- Development version: --> 
 
@@ -15,8 +15,8 @@ Changes since last release:
 
 ### Major changes
 
+- Enabled manually defining FFTs with `tree.definitions` or using FFTs of `object` in `FFTrees()`. 
 - Enabled setting `goal = 'dprime'` to select FFTs in `FFTrees()`. 
-- Trimmed white space from elements in tree definitions (in `fftrees_apply.R`).
 
 <!-- Blank line. --> 
 
@@ -28,6 +28,7 @@ Changes since last release:
     - Bug fix: Removed clipping of titles and labels.
     - Tweaked spacing parameters.
 
+- Trimmed white space from elements in tree definitions (in `fftrees_apply.R`). 
 - Added user feedback when `quiet = FALSE`. 
 
 <!-- Blank line. --> 
@@ -348,6 +349,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2022-12-14.]
+[File `NEWS.md` last updated on 2022-12-15.]
 
 <!-- eof. -->

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -39,7 +39,7 @@ fftrees_apply <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    message(paste0("Aiming to apply FFTs to ", mydata, " data"))
+    message(paste0("Aiming to apply FFTs to ", mydata, " data:"))
   }
 
 
@@ -332,7 +332,7 @@ fftrees_apply <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    message(paste0("Successfully applied FFTs to ", mydata, " data"))
+    message(paste0("Successfully applied FFTs to ", mydata, " data."))
   }
 
 

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -39,7 +39,7 @@ fftrees_apply <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    message(paste0("Aiming to apply FFTs to ", mydata, " data."))
+    message(paste0("Aiming to apply FFTs to ", mydata, " data"))
   }
 
 
@@ -332,7 +332,7 @@ fftrees_apply <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    message(paste0("Successfully applied FFTs to ", mydata, " data."))
+    message(paste0("Successfully applied FFTs to ", mydata, " data"))
   }
 
 

--- a/R/fftrees_define.R
+++ b/R/fftrees_define.R
@@ -61,7 +61,7 @@ fftrees_define <- function(x,
     x$trees$n <- as.integer(nrow(tree.definitions))
 
     if (!x$params$quiet) {
-      message("Set FFTs in 'x' to 'tree.definitions'")
+      message("Using FFTs of 'tree.definitions' as current trees")
     }
 
 
@@ -75,7 +75,7 @@ fftrees_define <- function(x,
     x$trees$n <- as.integer(nrow(object$trees$definitions))
 
     if (!x$params$quiet) {
-      message("Set FFTs in 'x' to trees of 'object'")
+      message("Using FFTs of 'object' as current trees")
     }
 
 

--- a/R/fftrees_define.R
+++ b/R/fftrees_define.R
@@ -52,20 +52,20 @@ fftrees_define <- function(x,
   testthat::expect_s3_class(x, class = "FFTrees")
 
 
-  # Main: Distinguish 4 use cases ------
+  # Main: Distinguish between 4 use cases ------
 
-  if (!is.null(tree.definitions)) { # 1. Use tree.definitions in x: ----
+  if (!is.null(tree.definitions)) { # 1. Use FFTs from tree.definitions: ----
 
     # Change x by using the tree.definitions:
     x$trees$definitions <- tree.definitions
     x$trees$n <- as.integer(nrow(tree.definitions))
 
     if (!x$params$quiet) {
-      message("Using FFTs of 'tree.definitions' as current trees")
+      message(paste0("Using ", x$trees$n, " FFTs from 'tree.definitions' as current trees."))
     }
 
 
-  } else if (!is.null(object)) { # 2. Use FFTs provided in object: ----
+  } else if (!is.null(object)) { # 2. Use FFTs from object: ----
 
     # Verify object$trees$definitions:
     testthat::expect_true(!is.null(object$trees$definitions))
@@ -75,7 +75,7 @@ fftrees_define <- function(x,
     x$trees$n <- as.integer(nrow(object$trees$definitions))
 
     if (!x$params$quiet) {
-      message("Using FFTs of 'object' as current trees")
+      message(paste0("Using ", x$trees$n, " FFTs from 'object' as current trees."))
     }
 
 

--- a/R/fftrees_fitcomp.R
+++ b/R/fftrees_fitcomp.R
@@ -56,9 +56,12 @@ fftrees_fitcomp <- function(x) {
 
   # B. Competition: ------
 
+
+  # Provide user feedback: ----
+
   if (do.lr | do.cart | do.rf | do.svm) {
     if (!x$params$quiet) {
-      message("Fitting other algorithms for comparison (disable with do.comp = FALSE) ...")
+      message("Aiming to fit other algorithms for comparison (disable with do.comp = FALSE)")
     }
   }
 
@@ -196,6 +199,15 @@ fftrees_fitcomp <- function(x) {
                            dplyr::mutate(algorithm = "svm") %>%
                            dplyr::mutate(cost_cues = NA) %>%
                            dplyr::select(tidyselect::all_of(my_cols)))
+    }
+  }
+
+
+  # Provide user feedback: ----
+
+  if (do.lr | do.cart | do.rf | do.svm) {
+    if (!x$params$quiet) {
+      message("Successfully fitted other algorithms for comparison")
     }
   }
 

--- a/R/fftrees_fitcomp.R
+++ b/R/fftrees_fitcomp.R
@@ -61,7 +61,7 @@ fftrees_fitcomp <- function(x) {
 
   if (do.lr | do.cart | do.rf | do.svm) {
     if (!x$params$quiet) {
-      message("Aiming to fit other algorithms for comparison (disable with do.comp = FALSE)")
+      message("Aiming to fit other algorithms for comparison (disable with do.comp = FALSE):")
     }
   }
 
@@ -207,7 +207,7 @@ fftrees_fitcomp <- function(x) {
 
   if (do.lr | do.cart | do.rf | do.svm) {
     if (!x$params$quiet) {
-      message("Successfully fitted other algorithms for comparison")
+      message("Successfully fitted other algorithms for comparison.")
     }
   }
 

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -533,7 +533,7 @@ fftrees_grow_fan <- function(x,
 
   # Provide user feedback:
   if (!x$params$quiet) {
-    message(paste0("Successfully created FFTs with ", x$params$algorithm, "."))
+    message(paste0("Successfully created ", x$trees$n, " FFTs with ", x$params$algorithm, "."))
   }
 
 

--- a/R/fftrees_wordstofftrees.R
+++ b/R/fftrees_wordstofftrees.R
@@ -34,7 +34,7 @@ fftrees_wordstofftrees <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    message("Aiming to create an FFT from 'my.tree' description")
+    message("Aiming to create an FFT from 'my.tree' description:")
   }
 
   # Parameters / options: ------
@@ -284,7 +284,7 @@ fftrees_wordstofftrees <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    message("Successfully created an FFT from 'my.tree' description")
+    message("Successfully created an FFT from 'my.tree' description.")
   }
 
   # Output: ------

--- a/R/fftrees_wordstofftrees.R
+++ b/R/fftrees_wordstofftrees.R
@@ -34,7 +34,7 @@ fftrees_wordstofftrees <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    message("Aiming to create an FFT from 'my.tree'")
+    message("Aiming to create an FFT from 'my.tree' description")
   }
 
   # Parameters / options: ------
@@ -284,7 +284,7 @@ fftrees_wordstofftrees <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    message("Successfully created FFT from 'my.tree'")
+    message("Successfully created an FFT from 'my.tree' description")
   }
 
   # Output: ------

--- a/R/helper.R
+++ b/R/helper.R
@@ -11,14 +11,16 @@
 #
 # Currently, it is only verified that both DFs have some cases and
 # contain the SAME names (but the content or order of variables is not checked or altered).
-# Future versions may want to verify that 'test' data is valid, given current 'train' data
-# (e.g., "test" contains all required variables of "train" to create the current FFTs).
+# Future versions may want to verify that 'test' data is valid, given current FFTs:
+# data fits to FFTs in FFTrees object (i.e., object$trees$definitions) or tree.definitions
+# (e.g., data contains all required variables to create the current FFTs).
 #
 # Output: Boolean.
 
 valid_train_test_data <- function(train_data, test_data){
 
-  # Initialize:
+  # Initialize: ----
+
   valid <- FALSE
 
   train_names <- names(train_data)
@@ -27,7 +29,9 @@ valid_train_test_data <- function(train_data, test_data){
   train_names_not_in_test <- setdiff(train_names, test_names)
   test_names_not_in_train <- setdiff(test_names,  train_names)
 
-  # Conditions:
+
+  # Conditions: ----
+
   if (nrow(train_data) < 1){
 
     msg <- paste("The 'train' data contains no cases (rows).")
@@ -58,7 +62,9 @@ valid_train_test_data <- function(train_data, test_data){
 
   }
 
-  # Output:
+
+  # Output: ----
+
   return(valid)
 
 } # valid_train_test_data().

--- a/README.Rmd
+++ b/README.Rmd
@@ -29,7 +29,6 @@ url_JDM_pdf   <- "https://journal.sjdm.org/17/17217/jdm17217.pdf"
 
 # FFTrees `r packageVersion("FFTrees")` <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
-
 <!-- Status badges: --> 
 
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees)

--- a/README.Rmd
+++ b/README.Rmd
@@ -29,6 +29,7 @@ url_JDM_pdf   <- "https://journal.sjdm.org/17/17217/jdm17217.pdf"
 
 # FFTrees `r packageVersion("FFTrees")` <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
+
 <!-- Status badges: --> 
 
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees)
@@ -38,6 +39,7 @@ url_JDM_pdf   <- "https://journal.sjdm.org/17/17217/jdm17217.pdf"
 <!-- Goal: -->
 
 The R package **FFTrees** creates, visualizes and evaluates _fast-and-frugal decision trees_ (FFTs) for solving binary classification tasks following the methods described in Phillips, Neth, Woike & Gaissmaier (2017, as\ [html](`r url_JDM_html`) | [PDF](`r url_JDM_pdf`)). 
+
 
 ## What are fast-and-frugal trees (FFTs)?
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.7.5.9009 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.7.5.9010 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Status badges: -->
 
-[![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees)
+[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees)
 [![Build
 Status](https://travis-ci.org/ndphillips/FFTrees.svg?branch=master)](https://travis-ci.org/ndphillips/FFTrees)
 [![Downloads](https://cranlogs.r-pkg.org/badges/FFTrees?color=brightgreen)](https://www.r-pkg.org/pkg/FFTrees)
@@ -45,13 +45,17 @@ and easy to interpret, use, and communicate.
 To install the latest release of **FFTrees** [from
 CRAN](https://CRAN.R-project.org/package=FFTrees) evaluate:
 
-    install.packages("FFTrees")
+``` r
+install.packages("FFTrees")
+```
 
 The current development version of **FFTrees** can be installed [from
 GitHub](https://github.com/ndphillips/FFTrees) with:
 
-    # install.packages("devtools")
-    devtools::install_github("ndphillips/FFTrees", build_vignettes = TRUE)
+``` r
+# install.packages("devtools")
+devtools::install_github("ndphillips/FFTrees", build_vignettes = TRUE)
+```
 
 ## Getting started
 
@@ -59,7 +63,9 @@ As an example, let’s create a FFT predicting heart disease status
 (*Healthy* vs. *Diseased*) based on the `heartdisease` dataset included
 in **FFTrees**:
 
-    library(FFTrees)  # load package
+``` r
+library(FFTrees)  # load package
+```
 
 ### Using data
 
@@ -69,39 +75,39 @@ subsets: A `heart.train` dataset for fitting decision trees, and
 `heart.test` dataset for a testing the resulting trees. Here are the
 first rows and columns of both subsets of the `heartdisease` data:
 
--   `heart.train` (the training / fitting dataset) contains the data
-    from 150 patients:
+- `heart.train` (the training / fitting dataset) contains the data from
+  150 patients:
 
-<!-- -->
+``` r
+head(heart.train)
+#> # A tibble: 6 × 14
+#>   diagnosis   age   sex cp    trestbps  chol   fbs restecg thalach exang oldpeak
+#>   <lgl>     <dbl> <dbl> <chr>    <dbl> <dbl> <dbl> <chr>     <dbl> <dbl>   <dbl>
+#> 1 FALSE        44     0 np         108   141     0 normal      175     0     0.6
+#> 2 FALSE        51     0 np         140   308     0 hypert…     142     0     1.5
+#> 3 FALSE        52     1 np         138   223     0 normal      169     0     0  
+#> 4 TRUE         48     1 aa         110   229     0 normal      168     0     1  
+#> 5 FALSE        59     1 aa         140   221     0 normal      164     1     0  
+#> 6 FALSE        58     1 np         105   240     0 hypert…     154     1     0.6
+#> # … with 3 more variables: slope <chr>, ca <dbl>, thal <chr>
+```
 
-    head(heart.train)
-    #> # A tibble: 6 × 14
-    #>   diagnosis   age   sex cp    trestbps  chol   fbs restecg thalach exang oldpeak
-    #>   <lgl>     <dbl> <dbl> <chr>    <dbl> <dbl> <dbl> <chr>     <dbl> <dbl>   <dbl>
-    #> 1 FALSE        44     0 np         108   141     0 normal      175     0     0.6
-    #> 2 FALSE        51     0 np         140   308     0 hypert…     142     0     1.5
-    #> 3 FALSE        52     1 np         138   223     0 normal      169     0     0  
-    #> 4 TRUE         48     1 aa         110   229     0 normal      168     0     1  
-    #> 5 FALSE        59     1 aa         140   221     0 normal      164     1     0  
-    #> 6 FALSE        58     1 np         105   240     0 hypert…     154     1     0.6
-    #> # … with 3 more variables: slope <chr>, ca <dbl>, thal <chr>
+- `heart.test` (the testing / prediction dataset) contains data from a
+  new set of 153 patients:
 
--   `heart.test` (the testing / prediction dataset) contains data from a
-    new set of 153 patients:
-
-<!-- -->
-
-    head(heart.test)
-    #> # A tibble: 6 × 14
-    #>   diagnosis   age   sex cp    trestbps  chol   fbs restecg thalach exang oldpeak
-    #>   <lgl>     <dbl> <dbl> <chr>    <dbl> <dbl> <dbl> <chr>     <dbl> <dbl>   <dbl>
-    #> 1 FALSE        51     0 np         120   295     0 hypert…     157     0     0.6
-    #> 2 TRUE         45     1 ta         110   264     0 normal      132     0     1.2
-    #> 3 TRUE         53     1 a          123   282     0 normal       95     1     2  
-    #> 4 TRUE         45     1 a          142   309     0 hypert…     147     1     0  
-    #> 5 FALSE        66     1 a          120   302     0 hypert…     151     0     0.4
-    #> 6 TRUE         48     1 a          130   256     1 hypert…     150     1     0  
-    #> # … with 3 more variables: slope <chr>, ca <dbl>, thal <chr>
+``` r
+head(heart.test)
+#> # A tibble: 6 × 14
+#>   diagnosis   age   sex cp    trestbps  chol   fbs restecg thalach exang oldpeak
+#>   <lgl>     <dbl> <dbl> <chr>    <dbl> <dbl> <dbl> <chr>     <dbl> <dbl>   <dbl>
+#> 1 FALSE        51     0 np         120   295     0 hypert…     157     0     0.6
+#> 2 TRUE         45     1 ta         110   264     0 normal      132     0     1.2
+#> 3 TRUE         53     1 a          123   282     0 normal       95     1     2  
+#> 4 TRUE         45     1 a          142   309     0 hypert…     147     1     0  
+#> 5 FALSE        66     1 a          120   302     0 hypert…     151     0     0.4
+#> 6 TRUE         48     1 a          130   256     1 hypert…     150     1     0  
+#> # … with 3 more variables: slope <chr>, ca <dbl>, thal <chr>
+```
 
 Most of the variables in our data are potential predictors. The
 criterion variable is `diagnosis` — a logical column indicating the true
@@ -113,64 +119,69 @@ patient suffers from heart disease).
 Now let’s use `FFTrees()` to create FFTs for the `heart.train` data and
 evaluate their predictive performance on the `heart.test` data:
 
--   Create an `FFTrees` object from the `heartdisease` data:
+- Create an `FFTrees` object from the `heartdisease` data:
 
-<!-- -->
+``` r
+# Create an FFTrees object from the heartdisease data: 
+heart_fft <- FFTrees(formula = diagnosis ~., 
+                     data = heart.train,
+                     data.test = heart.test, 
+                     decision.labels = c("Healthy", "Disease"))
+#> Setting 'goal = bacc'
+#> Setting 'goal.chase = bacc'
+#> Setting 'goal.threshold = bacc'
+#> Setting cost.outcomes = list(hi = 0, mi = 1, fa = 1, cr = 0)
+#> Aiming to grow FFTs with ifan:
+#> Successfully created FFTs with ifan.
+#> Aiming to apply FFTs to train data
+#> Successfully applied FFTs to train data
+#> Aiming to apply FFTs to test data
+#> Successfully applied FFTs to test data
+#> Aiming to fit other algorithms for comparison (disable with do.comp = FALSE)
+#> Successfully fitted other algorithms for comparison
+```
 
-    # Create an FFTrees object from the heartdisease data: 
-    heart_fft <- FFTrees(formula = diagnosis ~., 
-                         data = heart.train,
-                         data.test = heart.test, 
-                         decision.labels = c("Healthy", "Disease"))
-    #> Setting 'goal = bacc'
-    #> Setting 'goal.chase = bacc'
-    #> Setting 'goal.threshold = bacc'
-    #> Setting cost.outcomes = list(hi = 0, mi = 1, fa = 1, cr = 0)
-    #> Growing FFTs with ifan:
-    #> Fitting other algorithms for comparison (disable with do.comp = FALSE) ...
+- Printing an `FFTrees` object shows basic information and summary
+  statistics (on the best training tree, FFT #1):
 
--   Printing an `FFTrees` object shows basic information and summary
-    statistics (on the best training tree, FFT \#1):
+``` r
+# Print:
+heart_fft
+#> FFTrees 
+#> - Trees: 7 fast-and-frugal trees predicting diagnosis
+#> - Outcome costs: [hi = 0, mi = 1, fa = 1, cr = 0]
+#> 
+#> FFT #1: Definition
+#> [1] If thal = {rd,fd}, decide Disease.
+#> [2] If cp != {a}, decide Healthy.
+#> [3] If ca > 0, decide Disease, otherwise, decide Healthy.
+#> 
+#> FFT #1: Training Accuracy
+#> Training data: N = 150, Pos (+) = 66 (44%) 
+#> 
+#> |          | True + | True - | Totals:
+#> |----------|--------|--------|
+#> | Decide + | hi  54 | fa  18 |      72
+#> | Decide - | mi  12 | cr  66 |      78
+#> |----------|--------|--------|
+#>   Totals:        66       84   N = 150
+#> 
+#> acc  = 80.0%   ppv  = 75.0%   npv  = 84.6%
+#> bacc = 80.2%   sens = 81.8%   spec = 78.6%
+#> 
+#> FFT #1: Training Speed, Frugality, and Cost
+#> mcu = 1.74,  pci = 0.87,  E(cost) = 0.200
+```
 
-<!-- -->
+- To evaluate the predictive performance of an FFT, we plot an `FFTrees`
+  object to visualize a tree and its performance (on the `test` data):
 
-    # Print:
-    heart_fft
-    #> FFTrees 
-    #> - Trees: 7 fast-and-frugal trees predicting diagnosis
-    #> - Outcome costs: [hi = 0, mi = 1, fa = 1, cr = 0]
-    #> 
-    #> FFT #1: Definition
-    #> [1] If thal = {rd,fd}, decide Disease.
-    #> [2] If cp != {a}, decide Healthy.
-    #> [3] If ca > 0, decide Disease, otherwise, decide Healthy.
-    #> 
-    #> FFT #1: Training Accuracy
-    #> Training data: N = 150, Pos (+) = 66 (44%) 
-    #> 
-    #> |          | True + | True - | Totals:
-    #> |----------|--------|--------|
-    #> | Decide + | hi  54 | fa  18 |      72
-    #> | Decide - | mi  12 | cr  66 |      78
-    #> |----------|--------|--------|
-    #>   Totals:        66       84   N = 150
-    #> 
-    #> acc  = 80.0%   ppv  = 75.0%   npv  = 84.6%
-    #> bacc = 80.2%   sens = 81.8%   spec = 78.6%
-    #> 
-    #> FFT #1: Training Speed, Frugality, and Cost
-    #> mcu = 1.74,  pci = 0.87,  E(cost) = 0.200
-
--   To evaluate the predictive performance of an FFT, we plot an
-    `FFTrees` object to visualize a tree and its performance (on the
-    `test` data):
-
-<!-- -->
-
-    # Plot the best tree applied to the test data: 
-    plot(heart_fft,
-         data = "test",
-         main = "Heart Disease")
+``` r
+# Plot the best tree applied to the test data: 
+plot(heart_fft,
+     data = "test",
+     main = "Heart Disease")
+```
 
 ![An FFT predicting heart disease for `test`
 data.](man/figures/README-example-heart-plot-1.png)
@@ -178,23 +189,23 @@ data.](man/figures/README-example-heart-plot-1.png)
 **Figure 1**: A fast-and-frugal tree (FFT) predicting heart disease for
 `test` data and its performance characteristics.
 
--   Additionally, we can compare the predictive performance between
-    different machine learning algorithms on a range of metrics:
+- Additionally, we can compare the predictive performance between
+  different machine learning algorithms on a range of metrics:
 
-<!-- -->
-
-    # Compare predictive performance across algorithms: 
-    heart_fft$competition$test
-    #> # A tibble: 5 × 17
-    #>   algorithm     n    hi    fa    mi    cr  sens  spec    far   ppv   npv   acc
-    #>   <chr>     <int> <int> <int> <int> <int> <dbl> <dbl>  <dbl> <dbl> <dbl> <dbl>
-    #> 1 fftrees     153    64    19     9    61 0.877 0.762 0.238  0.771 0.871 0.817
-    #> 2 lr          153    55    13    18    67 0.753 0.838 0.162  0.809 0.788 0.797
-    #> 3 cart        153    50    19    23    61 0.685 0.762 0.238  0.725 0.726 0.725
-    #> 4 rf          153    59     8    14    72 0.808 0.9   0.1    0.881 0.837 0.856
-    #> 5 svm         153    55     7    18    73 0.753 0.912 0.0875 0.887 0.802 0.837
-    #> # … with 5 more variables: bacc <dbl>, wacc <dbl>, cost <dbl>,
-    #> #   cost_decisions <dbl>, cost_cues <dbl>
+``` r
+# Compare predictive performance across algorithms: 
+heart_fft$competition$test
+#> # A tibble: 5 × 17
+#>   algorithm     n    hi    fa    mi    cr  sens  spec    far   ppv   npv   acc
+#>   <chr>     <int> <int> <int> <int> <int> <dbl> <dbl>  <dbl> <dbl> <dbl> <dbl>
+#> 1 fftrees     153    64    19     9    61 0.877 0.762 0.238  0.771 0.871 0.817
+#> 2 lr          153    55    13    18    67 0.753 0.838 0.162  0.809 0.788 0.797
+#> 3 cart        153    50    19    23    61 0.685 0.762 0.238  0.725 0.726 0.725
+#> 4 rf          153    59     8    14    72 0.808 0.9   0.1    0.881 0.837 0.856
+#> 5 svm         153    55     7    18    73 0.753 0.912 0.0875 0.887 0.802 0.837
+#> # … with 5 more variables: bacc <dbl>, wacc <dbl>, cost <dbl>,
+#> #   cost_decisions <dbl>, cost_cues <dbl>
+```
 
 <!-- FFTs by verbal description: -->
 
@@ -214,22 +225,24 @@ evaluate its performance on the `heart.test` data:
 These conditions can directly be supplied to the `my.tree` argument of
 `FFTrees()`:
 
-    # Create custom FFT 'in words' and apply it to test data:
+``` r
+# Create custom FFT 'in words' and apply it to test data:
 
-    # 1. Create my own FFT (from verbal description):
-    my_fft <- FFTrees(formula = diagnosis ~., 
-                      data = heart.train,
-                      data.test = heart.test, 
-                      decision.labels = c("Healthy", "Disease"),
-                      my.tree = "If sex = 1, predict Disease.
-                                 If age < 45, predict Healthy.
-                                 If thal = {fd, normal}, predict Healthy,  
-                                 Otherwise, predict Disease.")
+# 1. Create my own FFT (from verbal description):
+my_fft <- FFTrees(formula = diagnosis ~., 
+                  data = heart.train,
+                  data.test = heart.test, 
+                  decision.labels = c("Healthy", "Disease"),
+                  my.tree = "If sex = 1, predict Disease.
+                             If age < 45, predict Healthy.
+                             If thal = {fd, normal}, predict Healthy,  
+                             Otherwise, predict Disease.")
 
-    # 2. Plot and evaluate my custom FFT (for test data):
-    plot(my_fft,
-         data = "test",
-         main = "My custom FFT")
+# 2. Plot and evaluate my custom FFT (for test data):
+plot(my_fft,
+     data = "test",
+     main = "My custom FFT")
+```
 
 ![An FFT created from a verbal
 description.](man/figures/README-example-heart-verbal-1.png)
@@ -266,11 +279,10 @@ decision trees* (available in
 
 **Citation** (in APA format):
 
--   Phillips, N. D., Neth, H., Woike, J. K. & Gaissmaier, W. (2017).
-    FFTrees: A toolbox to create, visualize, and evaluate
-    fast-and-frugal decision trees. *Judgment and Decision Making*, *12*
-    (4), 344–368. Retrieved from
-    <a href="https://journal.sjdm.org/17/17217/jdm17217.pdf" class="uri">https://journal.sjdm.org/17/17217/jdm17217.pdf</a>
+- Phillips, N. D., Neth, H., Woike, J. K. & Gaissmaier, W. (2017).
+  FFTrees: A toolbox to create, visualize, and evaluate fast-and-frugal
+  decision trees. *Judgment and Decision Making*, *12* (4), 344–368.
+  Retrieved from <https://journal.sjdm.org/17/17217/jdm17217.pdf>
 
 We encourage you to read the article to learn more about the history of
 FFTs and how the **FFTrees** package creates, visualizes, and evaluates
@@ -286,41 +298,40 @@ Here are some scientific publications that have used **FFTrees** (see
 Scholar](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=205528310591558601)
 for the full list):
 
--   [Lötsch, J., Haehner, A., & Hummel, T. (2020).
-    Machine-learning-derived rules set excludes risk of Parkinson’s
-    disease in patients with olfactory or gustatory symptoms with high
-    accuracy. *Journal of Neurology*, *267*(2),
-    469-478.](https://link.springer.com/article/10.1007/s00415-019-09604-6)
+- [Lötsch, J., Haehner, A., & Hummel, T. (2020).
+  Machine-learning-derived rules set excludes risk of Parkinson’s
+  disease in patients with olfactory or gustatory symptoms with high
+  accuracy. *Journal of Neurology*, *267*(2),
+  469-478.](https://link.springer.com/article/10.1007/s00415-019-09604-6)
 
--   [Kagan, R., Parlee, L., Beckett, B., Hayden, J. B., Gundle, K. R., &
-    Doung, Y. C. (2020). Radiographic parameter-driven decision tree
-    reliably predicts aseptic mechanical failure of compressive
-    osseointegration fixation. *Acta Orthopaedica*, *91*(2),
-    171-176.](https://www.tandfonline.com/doi/full/10.1080/17453674.2020.1716295)
+- [Kagan, R., Parlee, L., Beckett, B., Hayden, J. B., Gundle, K. R., &
+  Doung, Y. C. (2020). Radiographic parameter-driven decision tree
+  reliably predicts aseptic mechanical failure of compressive
+  osseointegration fixation. *Acta Orthopaedica*, *91*(2),
+  171-176.](https://www.tandfonline.com/doi/full/10.1080/17453674.2020.1716295)
 
--   [Klement, R. J., Sonke, J. J., Allgäuer, M., Andratschke, N.,
-    Appold, S., Belderbos, J., … & Mantel, F. (2020). Correlating dose
-    variables with local tumor control in stereotactic body radiotherapy
-    for early stage non-small cell lung cancer: A modeling study on 1500
-    individual treatments. *International Journal of Radiation
-    Oncology \* Biology \*
-    Physics*.](https://www.sciencedirect.com/science/article/pii/S036030162030897X)
+- [Klement, R. J., Sonke, J. J., Allgäuer, M., Andratschke, N., Appold,
+  S., Belderbos, J., … & Mantel, F. (2020). Correlating dose variables
+  with local tumor control in stereotactic body radiotherapy for early
+  stage non-small cell lung cancer: A modeling study on 1500 individual
+  treatments. *International Journal of Radiation Oncology \* Biology \*
+  Physics*.](https://www.sciencedirect.com/science/article/pii/S036030162030897X)
 
--   [Nobre, G. G., Hunink, J. E., Baruth, B., Aerts, J. C., & Ward, P.
-    J. (2019). Translating large-scale climate variability into crop
-    production forecast in Europe. *Scientific Reports*, *9*(1),
-    1-13.](https://www.nature.com/articles/s41598-018-38091-4)
+- [Nobre, G. G., Hunink, J. E., Baruth, B., Aerts, J. C., & Ward, P. J.
+  (2019). Translating large-scale climate variability into crop
+  production forecast in Europe. *Scientific Reports*, *9*(1),
+  1-13.](https://www.nature.com/articles/s41598-018-38091-4)
 
--   [Buchinsky, F. J., Valentino, W. L., Ruszkay, N., Powell, E.,
-    Derkay, C. S., Seedat, R. Y., … & Mortelliti, A. J. (2019). Age at
-    diagnosis, but not HPV type, is strongly associated with clinical
-    course in recurrent respiratory papillomatosis. *PloS One*,
-    *14*(6).](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6563955/)
+- [Buchinsky, F. J., Valentino, W. L., Ruszkay, N., Powell, E.,
+  Derkay, C. S., Seedat, R. Y., … & Mortelliti, A. J. (2019). Age at
+  diagnosis, but not HPV type, is strongly associated with clinical
+  course in recurrent respiratory papillomatosis. *PloS One*,
+  *14*(6).](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6563955/)
 
 <!-- footer: -->
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2022-12-13.\]
+\[File `README.Rmd` last updated on 2022-12-14.\]
 
 <!-- eof. -->

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <!-- Status badges: -->
 
-[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees)
+[![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees)
 [![Build
 Status](https://travis-ci.org/ndphillips/FFTrees.svg?branch=master)](https://travis-ci.org/ndphillips/FFTrees)
 [![Downloads](https://cranlogs.r-pkg.org/badges/FFTrees?color=brightgreen)](https://www.r-pkg.org/pkg/FFTrees)
@@ -45,17 +45,13 @@ and easy to interpret, use, and communicate.
 To install the latest release of **FFTrees** [from
 CRAN](https://CRAN.R-project.org/package=FFTrees) evaluate:
 
-``` r
-install.packages("FFTrees")
-```
+    install.packages("FFTrees")
 
 The current development version of **FFTrees** can be installed [from
 GitHub](https://github.com/ndphillips/FFTrees) with:
 
-``` r
-# install.packages("devtools")
-devtools::install_github("ndphillips/FFTrees", build_vignettes = TRUE)
-```
+    # install.packages("devtools")
+    devtools::install_github("ndphillips/FFTrees", build_vignettes = TRUE)
 
 ## Getting started
 
@@ -63,9 +59,7 @@ As an example, let’s create a FFT predicting heart disease status
 (*Healthy* vs. *Diseased*) based on the `heartdisease` dataset included
 in **FFTrees**:
 
-``` r
-library(FFTrees)  # load package
-```
+    library(FFTrees)  # load package
 
 ### Using data
 
@@ -75,39 +69,39 @@ subsets: A `heart.train` dataset for fitting decision trees, and
 `heart.test` dataset for a testing the resulting trees. Here are the
 first rows and columns of both subsets of the `heartdisease` data:
 
-- `heart.train` (the training / fitting dataset) contains the data from
-  150 patients:
+-   `heart.train` (the training / fitting dataset) contains the data
+    from 150 patients:
 
-``` r
-head(heart.train)
-#> # A tibble: 6 × 14
-#>   diagnosis   age   sex cp    trestbps  chol   fbs restecg thalach exang oldpeak
-#>   <lgl>     <dbl> <dbl> <chr>    <dbl> <dbl> <dbl> <chr>     <dbl> <dbl>   <dbl>
-#> 1 FALSE        44     0 np         108   141     0 normal      175     0     0.6
-#> 2 FALSE        51     0 np         140   308     0 hypert…     142     0     1.5
-#> 3 FALSE        52     1 np         138   223     0 normal      169     0     0  
-#> 4 TRUE         48     1 aa         110   229     0 normal      168     0     1  
-#> 5 FALSE        59     1 aa         140   221     0 normal      164     1     0  
-#> 6 FALSE        58     1 np         105   240     0 hypert…     154     1     0.6
-#> # … with 3 more variables: slope <chr>, ca <dbl>, thal <chr>
-```
+<!-- -->
 
-- `heart.test` (the testing / prediction dataset) contains data from a
-  new set of 153 patients:
+    head(heart.train)
+    #> # A tibble: 6 × 14
+    #>   diagnosis   age   sex cp    trestbps  chol   fbs restecg thalach exang oldpeak
+    #>   <lgl>     <dbl> <dbl> <chr>    <dbl> <dbl> <dbl> <chr>     <dbl> <dbl>   <dbl>
+    #> 1 FALSE        44     0 np         108   141     0 normal      175     0     0.6
+    #> 2 FALSE        51     0 np         140   308     0 hypert…     142     0     1.5
+    #> 3 FALSE        52     1 np         138   223     0 normal      169     0     0  
+    #> 4 TRUE         48     1 aa         110   229     0 normal      168     0     1  
+    #> 5 FALSE        59     1 aa         140   221     0 normal      164     1     0  
+    #> 6 FALSE        58     1 np         105   240     0 hypert…     154     1     0.6
+    #> # … with 3 more variables: slope <chr>, ca <dbl>, thal <chr>
 
-``` r
-head(heart.test)
-#> # A tibble: 6 × 14
-#>   diagnosis   age   sex cp    trestbps  chol   fbs restecg thalach exang oldpeak
-#>   <lgl>     <dbl> <dbl> <chr>    <dbl> <dbl> <dbl> <chr>     <dbl> <dbl>   <dbl>
-#> 1 FALSE        51     0 np         120   295     0 hypert…     157     0     0.6
-#> 2 TRUE         45     1 ta         110   264     0 normal      132     0     1.2
-#> 3 TRUE         53     1 a          123   282     0 normal       95     1     2  
-#> 4 TRUE         45     1 a          142   309     0 hypert…     147     1     0  
-#> 5 FALSE        66     1 a          120   302     0 hypert…     151     0     0.4
-#> 6 TRUE         48     1 a          130   256     1 hypert…     150     1     0  
-#> # … with 3 more variables: slope <chr>, ca <dbl>, thal <chr>
-```
+-   `heart.test` (the testing / prediction dataset) contains data from a
+    new set of 153 patients:
+
+<!-- -->
+
+    head(heart.test)
+    #> # A tibble: 6 × 14
+    #>   diagnosis   age   sex cp    trestbps  chol   fbs restecg thalach exang oldpeak
+    #>   <lgl>     <dbl> <dbl> <chr>    <dbl> <dbl> <dbl> <chr>     <dbl> <dbl>   <dbl>
+    #> 1 FALSE        51     0 np         120   295     0 hypert…     157     0     0.6
+    #> 2 TRUE         45     1 ta         110   264     0 normal      132     0     1.2
+    #> 3 TRUE         53     1 a          123   282     0 normal       95     1     2  
+    #> 4 TRUE         45     1 a          142   309     0 hypert…     147     1     0  
+    #> 5 FALSE        66     1 a          120   302     0 hypert…     151     0     0.4
+    #> 6 TRUE         48     1 a          130   256     1 hypert…     150     1     0  
+    #> # … with 3 more variables: slope <chr>, ca <dbl>, thal <chr>
 
 Most of the variables in our data are potential predictors. The
 criterion variable is `diagnosis` — a logical column indicating the true
@@ -119,69 +113,70 @@ patient suffers from heart disease).
 Now let’s use `FFTrees()` to create FFTs for the `heart.train` data and
 evaluate their predictive performance on the `heart.test` data:
 
-- Create an `FFTrees` object from the `heartdisease` data:
+-   Create an `FFTrees` object from the `heartdisease` data:
 
-``` r
-# Create an FFTrees object from the heartdisease data: 
-heart_fft <- FFTrees(formula = diagnosis ~., 
-                     data = heart.train,
-                     data.test = heart.test, 
-                     decision.labels = c("Healthy", "Disease"))
-#> Setting 'goal = bacc'
-#> Setting 'goal.chase = bacc'
-#> Setting 'goal.threshold = bacc'
-#> Setting cost.outcomes = list(hi = 0, mi = 1, fa = 1, cr = 0)
-#> Aiming to grow FFTs with ifan:
-#> Successfully created FFTs with ifan.
-#> Aiming to apply FFTs to train data
-#> Successfully applied FFTs to train data
-#> Aiming to apply FFTs to test data
-#> Successfully applied FFTs to test data
-#> Aiming to fit other algorithms for comparison (disable with do.comp = FALSE)
-#> Successfully fitted other algorithms for comparison
-```
+<!-- -->
 
-- Printing an `FFTrees` object shows basic information and summary
-  statistics (on the best training tree, FFT #1):
+    # Create an FFTrees object from the heartdisease data: 
+    heart_fft <- FFTrees(formula = diagnosis ~., 
+                         data = heart.train,
+                         data.test = heart.test, 
+                         decision.labels = c("Healthy", "Disease"))
+    #> Setting 'goal = bacc'
+    #> Setting 'goal.chase = bacc'
+    #> Setting 'goal.threshold = bacc'
+    #> Setting cost.outcomes = list(hi = 0, mi = 1, fa = 1, cr = 0)
+    #> Aiming to grow FFTs with ifan:
+    #> Successfully created 7 FFTs with ifan.
+    #> Aiming to apply FFTs to train data:
+    #> Successfully applied FFTs to train data.
+    #> Aiming to apply FFTs to test data:
+    #> Successfully applied FFTs to test data.
+    #> Aiming to fit other algorithms for comparison (disable with do.comp = FALSE):
+    #> Successfully fitted other algorithms for comparison.
 
-``` r
-# Print:
-heart_fft
-#> FFTrees 
-#> - Trees: 7 fast-and-frugal trees predicting diagnosis
-#> - Outcome costs: [hi = 0, mi = 1, fa = 1, cr = 0]
-#> 
-#> FFT #1: Definition
-#> [1] If thal = {rd,fd}, decide Disease.
-#> [2] If cp != {a}, decide Healthy.
-#> [3] If ca > 0, decide Disease, otherwise, decide Healthy.
-#> 
-#> FFT #1: Training Accuracy
-#> Training data: N = 150, Pos (+) = 66 (44%) 
-#> 
-#> |          | True + | True - | Totals:
-#> |----------|--------|--------|
-#> | Decide + | hi  54 | fa  18 |      72
-#> | Decide - | mi  12 | cr  66 |      78
-#> |----------|--------|--------|
-#>   Totals:        66       84   N = 150
-#> 
-#> acc  = 80.0%   ppv  = 75.0%   npv  = 84.6%
-#> bacc = 80.2%   sens = 81.8%   spec = 78.6%
-#> 
-#> FFT #1: Training Speed, Frugality, and Cost
-#> mcu = 1.74,  pci = 0.87,  E(cost) = 0.200
-```
+-   Printing an `FFTrees` object shows basic information and summary
+    statistics (on the best training tree, FFT \#1):
 
-- To evaluate the predictive performance of an FFT, we plot an `FFTrees`
-  object to visualize a tree and its performance (on the `test` data):
+<!-- -->
 
-``` r
-# Plot the best tree applied to the test data: 
-plot(heart_fft,
-     data = "test",
-     main = "Heart Disease")
-```
+    # Print:
+    heart_fft
+    #> FFTrees 
+    #> - Trees: 7 fast-and-frugal trees predicting diagnosis
+    #> - Outcome costs: [hi = 0, mi = 1, fa = 1, cr = 0]
+    #> 
+    #> FFT #1: Definition
+    #> [1] If thal = {rd,fd}, decide Disease.
+    #> [2] If cp != {a}, decide Healthy.
+    #> [3] If ca > 0, decide Disease, otherwise, decide Healthy.
+    #> 
+    #> FFT #1: Training Accuracy
+    #> Training data: N = 150, Pos (+) = 66 (44%) 
+    #> 
+    #> |          | True + | True - | Totals:
+    #> |----------|--------|--------|
+    #> | Decide + | hi  54 | fa  18 |      72
+    #> | Decide - | mi  12 | cr  66 |      78
+    #> |----------|--------|--------|
+    #>   Totals:        66       84   N = 150
+    #> 
+    #> acc  = 80.0%   ppv  = 75.0%   npv  = 84.6%
+    #> bacc = 80.2%   sens = 81.8%   spec = 78.6%
+    #> 
+    #> FFT #1: Training Speed, Frugality, and Cost
+    #> mcu = 1.74,  pci = 0.87,  E(cost) = 0.200
+
+-   To evaluate the predictive performance of an FFT, we plot an
+    `FFTrees` object to visualize a tree and its performance (on the
+    `test` data):
+
+<!-- -->
+
+    # Plot the best tree applied to the test data: 
+    plot(heart_fft,
+         data = "test",
+         main = "Heart Disease")
 
 ![An FFT predicting heart disease for `test`
 data.](man/figures/README-example-heart-plot-1.png)
@@ -189,23 +184,23 @@ data.](man/figures/README-example-heart-plot-1.png)
 **Figure 1**: A fast-and-frugal tree (FFT) predicting heart disease for
 `test` data and its performance characteristics.
 
-- Additionally, we can compare the predictive performance between
-  different machine learning algorithms on a range of metrics:
+-   Additionally, we can compare the predictive performance between
+    different machine learning algorithms on a range of metrics:
 
-``` r
-# Compare predictive performance across algorithms: 
-heart_fft$competition$test
-#> # A tibble: 5 × 17
-#>   algorithm     n    hi    fa    mi    cr  sens  spec    far   ppv   npv   acc
-#>   <chr>     <int> <int> <int> <int> <int> <dbl> <dbl>  <dbl> <dbl> <dbl> <dbl>
-#> 1 fftrees     153    64    19     9    61 0.877 0.762 0.238  0.771 0.871 0.817
-#> 2 lr          153    55    13    18    67 0.753 0.838 0.162  0.809 0.788 0.797
-#> 3 cart        153    50    19    23    61 0.685 0.762 0.238  0.725 0.726 0.725
-#> 4 rf          153    59     8    14    72 0.808 0.9   0.1    0.881 0.837 0.856
-#> 5 svm         153    55     7    18    73 0.753 0.912 0.0875 0.887 0.802 0.837
-#> # … with 5 more variables: bacc <dbl>, wacc <dbl>, cost <dbl>,
-#> #   cost_decisions <dbl>, cost_cues <dbl>
-```
+<!-- -->
+
+    # Compare predictive performance across algorithms: 
+    heart_fft$competition$test
+    #> # A tibble: 5 × 17
+    #>   algorithm     n    hi    fa    mi    cr  sens  spec    far   ppv   npv   acc
+    #>   <chr>     <int> <int> <int> <int> <int> <dbl> <dbl>  <dbl> <dbl> <dbl> <dbl>
+    #> 1 fftrees     153    64    19     9    61 0.877 0.762 0.238  0.771 0.871 0.817
+    #> 2 lr          153    55    13    18    67 0.753 0.838 0.162  0.809 0.788 0.797
+    #> 3 cart        153    50    19    23    61 0.685 0.762 0.238  0.725 0.726 0.725
+    #> 4 rf          153    59     8    14    72 0.808 0.9   0.1    0.881 0.837 0.856
+    #> 5 svm         153    55     7    18    73 0.753 0.912 0.0875 0.887 0.802 0.837
+    #> # … with 5 more variables: bacc <dbl>, wacc <dbl>, cost <dbl>,
+    #> #   cost_decisions <dbl>, cost_cues <dbl>
 
 <!-- FFTs by verbal description: -->
 
@@ -225,24 +220,22 @@ evaluate its performance on the `heart.test` data:
 These conditions can directly be supplied to the `my.tree` argument of
 `FFTrees()`:
 
-``` r
-# Create custom FFT 'in words' and apply it to test data:
+    # Create custom FFT 'in words' and apply it to test data:
 
-# 1. Create my own FFT (from verbal description):
-my_fft <- FFTrees(formula = diagnosis ~., 
-                  data = heart.train,
-                  data.test = heart.test, 
-                  decision.labels = c("Healthy", "Disease"),
-                  my.tree = "If sex = 1, predict Disease.
-                             If age < 45, predict Healthy.
-                             If thal = {fd, normal}, predict Healthy,  
-                             Otherwise, predict Disease.")
+    # 1. Create my own FFT (from verbal description):
+    my_fft <- FFTrees(formula = diagnosis ~., 
+                      data = heart.train,
+                      data.test = heart.test, 
+                      decision.labels = c("Healthy", "Disease"),
+                      my.tree = "If sex = 1, predict Disease.
+                                 If age < 45, predict Healthy.
+                                 If thal = {fd, normal}, predict Healthy,  
+                                 Otherwise, predict Disease.")
 
-# 2. Plot and evaluate my custom FFT (for test data):
-plot(my_fft,
-     data = "test",
-     main = "My custom FFT")
-```
+    # 2. Plot and evaluate my custom FFT (for test data):
+    plot(my_fft,
+         data = "test",
+         main = "My custom FFT")
 
 ![An FFT created from a verbal
 description.](man/figures/README-example-heart-verbal-1.png)
@@ -279,10 +272,11 @@ decision trees* (available in
 
 **Citation** (in APA format):
 
-- Phillips, N. D., Neth, H., Woike, J. K. & Gaissmaier, W. (2017).
-  FFTrees: A toolbox to create, visualize, and evaluate fast-and-frugal
-  decision trees. *Judgment and Decision Making*, *12* (4), 344–368.
-  Retrieved from <https://journal.sjdm.org/17/17217/jdm17217.pdf>
+-   Phillips, N. D., Neth, H., Woike, J. K. & Gaissmaier, W. (2017).
+    FFTrees: A toolbox to create, visualize, and evaluate
+    fast-and-frugal decision trees. *Judgment and Decision Making*, *12*
+    (4), 344–368. Retrieved from
+    <a href="https://journal.sjdm.org/17/17217/jdm17217.pdf" class="uri">https://journal.sjdm.org/17/17217/jdm17217.pdf</a>
 
 We encourage you to read the article to learn more about the history of
 FFTs and how the **FFTrees** package creates, visualizes, and evaluates
@@ -298,40 +292,41 @@ Here are some scientific publications that have used **FFTrees** (see
 Scholar](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=205528310591558601)
 for the full list):
 
-- [Lötsch, J., Haehner, A., & Hummel, T. (2020).
-  Machine-learning-derived rules set excludes risk of Parkinson’s
-  disease in patients with olfactory or gustatory symptoms with high
-  accuracy. *Journal of Neurology*, *267*(2),
-  469-478.](https://link.springer.com/article/10.1007/s00415-019-09604-6)
+-   [Lötsch, J., Haehner, A., & Hummel, T. (2020).
+    Machine-learning-derived rules set excludes risk of Parkinson’s
+    disease in patients with olfactory or gustatory symptoms with high
+    accuracy. *Journal of Neurology*, *267*(2),
+    469-478.](https://link.springer.com/article/10.1007/s00415-019-09604-6)
 
-- [Kagan, R., Parlee, L., Beckett, B., Hayden, J. B., Gundle, K. R., &
-  Doung, Y. C. (2020). Radiographic parameter-driven decision tree
-  reliably predicts aseptic mechanical failure of compressive
-  osseointegration fixation. *Acta Orthopaedica*, *91*(2),
-  171-176.](https://www.tandfonline.com/doi/full/10.1080/17453674.2020.1716295)
+-   [Kagan, R., Parlee, L., Beckett, B., Hayden, J. B., Gundle, K. R., &
+    Doung, Y. C. (2020). Radiographic parameter-driven decision tree
+    reliably predicts aseptic mechanical failure of compressive
+    osseointegration fixation. *Acta Orthopaedica*, *91*(2),
+    171-176.](https://www.tandfonline.com/doi/full/10.1080/17453674.2020.1716295)
 
-- [Klement, R. J., Sonke, J. J., Allgäuer, M., Andratschke, N., Appold,
-  S., Belderbos, J., … & Mantel, F. (2020). Correlating dose variables
-  with local tumor control in stereotactic body radiotherapy for early
-  stage non-small cell lung cancer: A modeling study on 1500 individual
-  treatments. *International Journal of Radiation Oncology \* Biology \*
-  Physics*.](https://www.sciencedirect.com/science/article/pii/S036030162030897X)
+-   [Klement, R. J., Sonke, J. J., Allgäuer, M., Andratschke, N.,
+    Appold, S., Belderbos, J., … & Mantel, F. (2020). Correlating dose
+    variables with local tumor control in stereotactic body radiotherapy
+    for early stage non-small cell lung cancer: A modeling study on 1500
+    individual treatments. *International Journal of Radiation
+    Oncology \* Biology \*
+    Physics*.](https://www.sciencedirect.com/science/article/pii/S036030162030897X)
 
-- [Nobre, G. G., Hunink, J. E., Baruth, B., Aerts, J. C., & Ward, P. J.
-  (2019). Translating large-scale climate variability into crop
-  production forecast in Europe. *Scientific Reports*, *9*(1),
-  1-13.](https://www.nature.com/articles/s41598-018-38091-4)
+-   [Nobre, G. G., Hunink, J. E., Baruth, B., Aerts, J. C., & Ward, P.
+    J. (2019). Translating large-scale climate variability into crop
+    production forecast in Europe. *Scientific Reports*, *9*(1),
+    1-13.](https://www.nature.com/articles/s41598-018-38091-4)
 
-- [Buchinsky, F. J., Valentino, W. L., Ruszkay, N., Powell, E.,
-  Derkay, C. S., Seedat, R. Y., … & Mortelliti, A. J. (2019). Age at
-  diagnosis, but not HPV type, is strongly associated with clinical
-  course in recurrent respiratory papillomatosis. *PloS One*,
-  *14*(6).](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6563955/)
+-   [Buchinsky, F. J., Valentino, W. L., Ruszkay, N., Powell, E.,
+    Derkay, C. S., Seedat, R. Y., … & Mortelliti, A. J. (2019). Age at
+    diagnosis, but not HPV type, is strongly associated with clinical
+    course in recurrent respiratory papillomatosis. *PloS One*,
+    *14*(6).](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6563955/)
 
 <!-- footer: -->
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2022-12-14.\]
+\[File `README.Rmd` last updated on 2022-12-15.\]
 
 <!-- eof. -->

--- a/man/FFTrees.Rd
+++ b/man/FFTrees.Rd
@@ -34,9 +34,9 @@ FFTrees(
   do.lr = TRUE,
   do.rf = TRUE,
   do.svm = TRUE,
-  force = FALSE,
   quiet = FALSE,
   comp = NULL,
+  force = NULL,
   rank.method = NULL,
   store.data = NULL,
   verbose = NULL
@@ -95,10 +95,10 @@ Default: \code{goal.threshold = "bacc"}.}
 \item{my.tree}{string. A string representing a verbal description of an FFT, i.e., an FFT in words.
 For example, \code{my.tree = "If age > 20, predict TRUE. If sex = {m}, predict FALSE. Otherwise, predict TRUE."}}
 
-\item{object}{An optional existing \code{FFTrees} object. When specified, no new trees are fitted, but existing trees are applied to \code{data} and \code{data.test}.}
+\item{object}{An optional existing \code{FFTrees} object. When specified, no new FFTs are fitted, but existing trees are applied to \code{data} and \code{data.test}.}
 
-\item{tree.definitions}{dataframe. An optional hard-coded definition of FFTs (in the same format as in \code{object}).
-If specified, no new trees are created, but the tree definitions in \code{object} are replaced by the tree definitions provided and \code{object} is re-evaluated.}
+\item{tree.definitions}{A \code{data.frame}. An optional hard-coded definition of FFTs (in the same format as in an \code{FFTrees} object).
+If specified, no new FFTs are fitted, but the tree definitions provided are used to re-evaluate the current \code{FFTrees} object.}
 
 \item{do.comp, do.cart, do.lr, do.rf, do.svm}{logical. Should alternative algorithms be created for comparison? All TRUE by default. Options are:
 \code{cart} = regular (non-frugal) trees with \strong{rpart};
@@ -107,11 +107,9 @@ If specified, no new trees are created, but the tree definitions in \code{object
 \code{svm} = support vector machines with \strong{e1071}.
 Specifying \code{comp = FALSE} sets all these arguments to \code{FALSE}.}
 
-\item{force}{logical. Setting \code{force = TRUE} forces some parameters (like goal) to be as specified by the user even when the algorithm thinks those specifications don't make sense. Default is \code{force = FALSE}.}
-
 \item{quiet}{logical. Should progress reports be suppressed? Setting \code{quiet = FALSE} is helpful for diagnosing errors. Default: \code{quiet = FALSE} (i.e., show progress).}
 
-\item{comp, rank.method, store.data, verbose}{Deprecated arguments (unused or replaced, to be retired in future releases).}
+\item{comp, force, rank.method, store.data, verbose}{Deprecated arguments (unused or replaced, to be retired in future releases).}
 }
 \value{
 An \code{FFTrees} object with the following elements:
@@ -121,8 +119,8 @@ An \code{FFTrees} object with the following elements:
   \item{formula}{The \code{\link{formula}} specified when creating the FFTs.}
   \item{trees}{A list of FFTs created, with further details contained in \code{n}, \code{best}, \code{definitions}, \code{inwords}, \code{stats}, \code{level_stats}, and \code{decisions}.}
   \item{data}{The original training and test data (if available).}
-  \item{params}{A list of defined control parameters (e.g.; \code{algorithm}, \code{goal}).}
-  \item{competition}{Models and classification statistics for competitive classification algorithms: Regularized logistic regression, CART, and random forest.}
+  \item{params}{A list of defined control parameters (e.g.; \code{algorithm}, \code{goal}, \code{sens.w}, as well as various thresholds, stopping rule, and cost parameters).}
+  \item{competition}{Models and classification statistics for competitive classification algorithms: Logistic regression, CART, random forests RF, and SVM.}
   \item{cues}{A list of cue information, with further details contained in \code{thresholds} and \code{stats}.}
 }
 }
@@ -136,6 +134,20 @@ that can then be printed, plotted, and examined further.
 
 The criterion and predictor variables are specified in \code{\link{formula}} notation.
 Based on the settings of \code{data} and \code{data.test}, FFTs are trained on a (required) training dataset and tested on an (optional) test dataset.
+
+If an existing \code{FFTrees} object \code{object} or \code{tree.definitions} are provided as inputs,
+no new FFTs are created.
+When both arguments are provided, \code{tree.definitions} take priority over the FFTs in an existing \code{object}.
+Specifically,
+
+\itemize{
+
+  \item{If \code{tree.definitions} are provided, these are assigned to the FFTs of \code{x}.}
+
+  \item{If no \code{tree.definitions} are provided, but an existing \code{FFTrees} object \code{object} is provided,
+  the trees from \code{object} are assigned to the FFTs of \code{x}.}
+
+}
 
 Create and evaluate fast-and-frugal trees (FFTs).
 }

--- a/man/fftrees_define.Rd
+++ b/man/fftrees_define.Rd
@@ -4,27 +4,42 @@
 \alias{fftrees_define}
 \title{Create FFT definitions}
 \usage{
-fftrees_define(x, object = NULL)
+fftrees_define(x, object = NULL, tree.definitions = NULL)
 }
 \arguments{
 \item{x}{The current \code{FFTrees} object (to be changed and returned).}
 
 \item{object}{An existing \code{FFTrees} object (with tree definitions).}
+
+\item{tree.definitions}{A \code{data.frame}. An optional hard-coded definition of FFTs (in the same format as in an \code{FFTrees} object).
+If specified, no new FFTs are created, but the tree definitions in \code{object} or \code{x} are replaced by the tree definitions provided
+and the current object is re-evaluated.}
 }
 \value{
 An \code{FFTrees} object with tree definitions.
 }
 \description{
-\code{fftrees_define} creates fast-and-frugal trees
-(FFTs) from provided definitions or by applying algorithms (when no definitions are provided),
-and returns an \code{FFTrees} object.
+\code{fftrees_define} defines fast-and-frugal trees (FFTs)
+either from the definitions provided or by applying algorithms (when no definitions are provided),
+and returns a modified \code{FFTrees} object that contains those definitions.
 
-\code{fftrees_define} usually passes passes \code{x} either
+In most use cases, \code{fftrees_define} passes a new \code{FFTrees} object \code{x} either
 to \code{\link{fftrees_grow_fan}} (to create new FFTs by applying algorithms to data) or
 to \code{\link{fftrees_wordstofftrees}} (if \code{my.tree} is specified).
 
-If an existing \code{FFTrees} object \code{object} is provided,
-\code{fftrees_define} uses the trees from this \code{FFTrees} object.
+If an existing \code{FFTrees} object \code{object} or \code{tree.definitions} are provided as inputs,
+no new FFTs are created.
+When both arguments are provided, \code{tree.definitions} take priority over the FFTs in an existing \code{object}.
+Specifically,
+
+\itemize{
+
+  \item{If \code{tree.definitions} are provided, these are assigned to the FFTs of \code{x}.}
+
+  \item{If no \code{tree.definitions} are provided, but an existing \code{FFTrees} object \code{object} is provided,
+  the trees from \code{object} are assigned to the FFTs of \code{x}.}
+
+}
 }
 \seealso{
 \code{\link{fftrees_create}} for creating \code{FFTrees} objects;

--- a/vignettes/FFTrees_function.Rmd
+++ b/vignettes/FFTrees_function.Rmd
@@ -165,7 +165,7 @@ Here is a description of the frequency counts and corresponding statistics provi
 | `acc` | Accuracy    | The percentage of cases that were correctly classified. |
 | `ppv`  | Positive predictive value  | The percentage (or conditional probability) of positive decisions being correct (i.e., True\ + cases). |
 | `npv`  | Negative predictive value  | The percentage (or conditional probability) of negative decisions being correct (i.e., True\ - cases). |
-| `wacc`| Weighted accuracy | The weighted average of sensitivity and specificity, where sensitivity is weighted by `sens.w` (by default, `sens.w = .5`). |
+| `wacc`| Weighted accuracy | The weighted average of sensitivity and specificity, where sensitivity is weighted by `sens.w` (by default, `sens.w = .50`). |
 | `sens`| Sensitivity | The percentage (or conditional probability) of true positive cases being correctly classified. |
 | `spec`| Specificity | The percentage (or conditional probability) of true negative cases being correctly classified. |
 | _Frugality_: |   |   | 
@@ -388,7 +388,7 @@ As we can see, the performance of this particular tree is pretty terrible ---\ b
 
 <!-- Hint: Defining mytree vignette -->
 
-See the [Specifying FFTs directly](FFTrees_mytree.html) vignette for more details on designing FFTs from their descriptions. 
+See the [Specifying FFTs directly](FFTrees_mytree.html) vignette for more details on designing FFTs from verbal or abstract descriptions. 
 
 
 ## Vignettes

--- a/vignettes/FFTrees_mytree.Rmd
+++ b/vignettes/FFTrees_mytree.Rmd
@@ -379,6 +379,98 @@ print(fft_5, data = "test", tree = "best.test")
 ```
 
 
+<!-- Demo: Create all permutations of cues (i.e., orders of a given tree): -->
+
+```{r manual-tree-defs, echo = FALSE, eval = FALSE}
+# Create FFTs by algorithm:
+fft_0 <- FFTrees(formula = diagnosis ~ .,           # Criterion and (all) predictors
+                 data = heart.train,                # Training data
+                 data.test = heart.test,            # Testing data
+                 main = "Heart Disease (auto)",      # General label
+                 decision.labels = c("low risk", "high risk"), # Labels for decisions
+                 quiet = FALSE  # enable/suppress user feedback
+                 )
+
+print(fft_0, tree = "best.train", data = "train")
+plot(fft_0, tree = "best.train", data = "train")
+plot(fft_0, tree = "best.test", data = "test")
+
+# Inspect trees:
+fft_0$trees$definitions
+fft_0$trees$best
+
+# FFT #1:
+fft_0$trees$definitions[1, ]
+
+# Re-create FFT #1:
+my_fft_df <- data.frame(tree = c(1),
+                        nodes = c(3),
+                        classes = c("c; c; n"),
+                        cues = c("thal; cp; ca"),
+                        directions = c("=; =; >"),
+                        thresholds = c("rd,fd; a; 0"),
+                        exits = c("1; 0; 0.5"),
+                        stringsAsFactors = FALSE
+)
+
+
+
+# Re-evaluate FFT on same data:
+fft_1 <- FFTrees(formula = diagnosis ~ .,           # Criterion and (all) predictors
+                 data = heart.train,                # Training data
+                 data.test = heart.test,            # Testing data
+                 tree.definitions = my_fft_df,      # provide definition (as df)
+                 main = "Heart Disease (manual)"   # new label
+                 )
+
+fft_1
+
+print(fft_1, tree = "best.train", data = "train")
+plot(fft_1, tree = "best.train", data = "train")
+plot(fft_1, tree = "best.test", data = "test")
+
+# Inspect trees:
+fft_1$trees$definitions
+fft_1$trees$best
+
+
+# Re-create FFT #1 and permutations of cue orders:
+my_fft_df_2 <- data.frame(tree = c(1, 2, 3),
+                          nodes = c(3, 3, 3), 
+                          classes = c("c; c; n", "c; n; c", "n; c; c"),
+                          cues = c("thal; cp; ca", "thal; ca; cp", "ca; thal; cp"),
+                          directions = c("=; =; >", "=; >; =", ">; =; ="),
+                          thresholds = c("rd,fd; a; 0", "rd,fd; 0; a", "0; rd,fd; a"),
+                          exits = c("1; 0; 0.5", "1; 1; 0.5", "0; 1; 0.5"),
+                          stringsAsFactors = FALSE
+)
+my_fft_df_2
+
+# Re-evaluate FFTs on same data:
+fft_2 <- FFTrees(formula = diagnosis ~ .,           # Criterion and (all) predictors
+                 data = heart.train,                # Training data
+                 data.test = heart.test,            # Testing data
+                 tree.definitions = my_fft_df_2,    # provide definitions (as df)
+                 main = "Heart Disease (manual)"   # new label
+                 )
+
+fft_2
+
+# Inspect trees:
+fft_2$trees$definitions  # Note: FFTs #2 and #3 swapped positions!
+fft_2$trees$best
+
+fft_2$trees$stats
+
+plot(fft_2, tree = 2, data = "train")
+plot(fft_2, tree = 2, data = "test")
+
+plot(fft_2, tree = 3, data = "train")
+plot(fft_2, tree = 3, data = "test")
+```
+
+
+
 For details on understanding and changing tree definitions, see the section on **Tree definitions** in the [Creating FFTs with FFTrees()](FFTrees_function.html) vignette. 
 
 

--- a/vignettes/FFTrees_mytree.Rmd
+++ b/vignettes/FFTrees_mytree.Rmd
@@ -223,7 +223,9 @@ plot(fft_4)
 
 <!-- ToDo: 2nd way to specify an FFT:  -->
 
-<!--       2. as a data frame using the `tree.definitions` argument  -->
+<!-- 2. as a data frame using the `tree.definitions` argument  -->
+
+<!-- A. tree.definitions and object: -->
 
 ```{r design-fft-df, echo = FALSE, eval = FALSE}
 # Modify and use an existing FFT:
@@ -254,7 +256,7 @@ my_fft
 # Make some changes: 
 # Swap nodes 1 and 2 of Tree 1 (and add leading/trailing spaces):
 my_fft$cues <- " cp ; thal ; ca "
-my_fft$thresholds <- " a; rd,fd ; 0 "  # swap according to cues
+my_fft$thresholds <- " a ; rd,fd ; 0 "  # swap according to cues
 my_fft$exits <- "0 ; 1 ; 0.5 "         # swap according to cues
 
 my_fft$tree <- 8  # signal new tree (with new number)
@@ -265,14 +267,14 @@ my_fft$tree <- 8  # signal new tree (with new number)
 # fft_1$trees$definitions[8, ] <- my_fft
 
 # # OR (combine tree definitions as rows of data frames):
-old_new_fft_df <- rbind(fft_1$trees$definitions, my_fft)
-old_new_fft_df
+my_fft_df <- rbind(fft_1$trees$definitions, my_fft)
+my_fft_df
 
 # (2) Manual replacement: ---- 
 
 # Replace definitions in FFTrees object fft_1:
-fft_1$trees$definitions <- old_new_fft_df
-fft_1$trees$n <- as.integer(nrow(old_new_fft_df))
+fft_1$trees$definitions <- my_fft_df
+fft_1$trees$n <- as.integer(nrow(my_fft_df))
 
 # HAS fft_1 been changed?
 fft_1$trees$n
@@ -296,36 +298,86 @@ plot(fft_2, data = "test", tree = 8)
 
 # +++ here now +++
 
-# Create original FFTs:
-fft_3 <- FFTrees(formula = diagnosis ~ .,           # as before
-                 object = fft_0,                    # original FFTrees object
-                 tree.definitions = old_new_fft_df, # new tree definitions (as df)
-                 data = heart.train,                # training data
-                 data.test = heart.test,            # testing data
-                 main = "Heart Disease (mod)",      # changed label
+# Cover 3 cases: 
+
+# C. Provide both an existing FFTrees object and tree.definitions: 
+fft_3 <- FFTrees(formula = diagnosis ~ .,            # as before
+                 object = fft_1,                     # some valid FFTrees object 
+                 tree.definitions = my_fft_df,       # new tree definitions (as df)
+                 data = heart.train,                 # training data
+                 data.test = heart.test,             # testing data
+                 main = "Heart Disease (manual 1)",  # changed label
                  decision.labels = c("low risk", "high risk")  # changed labels for decisions
 )
 
+# => tree.definitions are being used, object is ignored!
 
 plot(fft_3)
 
 fft_3$trees$definitions  # 8 trees: New FFT is now #4
 
-fft_3$trees$best
+fft_3$trees$best  # FFT #4 is best test tree!
 
 plot(fft_3, data = "train", tree = "best.train")  # FFT #1
 plot(fft_3, data = "test", tree = "best.test")    # FFT #4
 
 print(fft_3, data = "test", tree = "best.test")
 
-# Use changed or new FFT object to predict same / new data:
-predict(fft_1, newdata = heartdisease, tree = 8)  # yields an ERROR in applying new/8-th tree...
-predict(fft_2, newdata = heartdisease, tree = 8)  # yields an ERROR in applying new/8-th tree...
-
-# But:
+# Use new FFT object to predict same / new data:
 predict(fft_3, newdata = heartdisease, tree = 4)  # WORKS, qed. 
+```
+
+<!-- A. Provide tree.definitions but no object: -->
+
+```{r design-fft-df-2, echo = FALSE, eval = FALSE}
+# Provide tree.definitions but no object:
+fft_4 <- FFTrees(formula = diagnosis ~ .,            # as before
+                 object = NULL,                      # NO FFTrees object
+                 tree.definitions = my_fft_df,       # new tree definitions (as df)
+                 data = heart.train,                 # training data
+                 data.test = heart.test,             # testing data
+                 main = "Heart Disease (manual 2)",  # changed label
+                 decision.labels = c("low R", "high R")  # changed labels for decisions
+)
+
+fft_4
+
+fft_4$trees$definitions  # 8 trees: New FFT is #4
+
+fft_4$trees$best  # FFT #4 is best test tree!
+
+plot(fft_4, data = "train", tree = "best.train")  # FFT #1
+plot(fft_4, data = "test", tree = "best.test")    # FFT #4
+
+print(fft_4, data = "test", tree = "best.test")
 
 ```
+
+<!-- B. Provide an object but no tree.definitions: -->
+
+```{r design-fft-df-3, echo = FALSE, eval = FALSE}
+# Provide tree.definitions but no object:
+fft_5 <- FFTrees(formula = diagnosis ~ .,            # as before
+                 object = fft_3,                     # an existing FFTrees object
+                 tree.definitions = NULL,            # NO tree definitions (as df)
+                 data = heart.train,                 # training data
+                 data.test = heart.test,             # testing data
+                 main = "Heart Disease (manual 2)",  # changed label
+                 decision.labels = c("low R", "high R")  # changed labels for decisions
+)
+
+fft_5
+
+fft_5$trees$definitions  # 8 trees: New FFT is #4
+
+fft_5$trees$best  # FFT #4 is best test tree!
+
+plot(fft_5, data = "train", tree = "best.train")  # FFT #1
+plot(fft_5, data = "test", tree = "best.test")    # FFT #4
+
+print(fft_5, data = "test", tree = "best.test")
+```
+
 
 For details on understanding and changing tree definitions, see the section on **Tree definitions** in the [Creating FFTs with FFTrees()](FFTrees_function.html) vignette. 
 


### PR DESCRIPTION
This PR still addresses Issue #111 and serves 2 functions:

1. **Manually defining FFTs**:  In `FFTrees()`, both providing `tree.definitions` (as a `data.frame`) and an `object` (as an `FFTrees` object) allow providing existing FFT definitions.  To manage their interaction, both arguments are now passed on to `fftrees_define()`.  If either argument is present, its FFTs are used as the tree definitions of `x$trees$definitions`. If _both_ are present, `tree.definitions` take priority over `object`.

2. Provide more consistent and explicit **user feedback** on current steps and progress:  Most key steps now provide 2 messages: An initial "aiming to ..." and a final "successfully done" message. This allows pin-pointing errors more precisely (and can be suppressed by `quiet = TRUE`). 