### PR TITLE
Manually defining FFTs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.7.5.9013
-Date: 2022-12-23
+Version: 1.7.5.9014
+Date: 2022-12-24
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -197,6 +197,14 @@ fftrees_apply <- function(x,
       # Current cue values from data (as df):
       cue_values <- data[[cue_i]]
 
+      cur_class <- substr(class(cue_values), 1, 1)
+
+      # print(paste0("class_i = ", class_i, "; cur_class = ", cur_class)) # 4debugging
+
+      if (cur_class != class_i){
+        warning(paste0("Mismatch: class_i = ", class_i, "; cur_class = ", cur_class))
+      }
+
       decisions_df$current_cue_values <- cue_values
 
 

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -93,9 +93,11 @@ fftrees_cuerank <- function(x = NULL,
       {
 
         # A. Numeric and integer cues: ----
+
         if (substr(cue_i_class, 1, 1) %in% c("n", "i")) {
 
           # 1. "optimize" method: ----
+
           if (x$params$numthresh.method == "o") {
 
             # Get all possible (sorted) cue values:
@@ -106,29 +108,38 @@ fftrees_cuerank <- function(x = NULL,
               indicies <- round(seq(1, length(cue_i_levels), length.out = x$params$numthresh.n), 0)
               cue_i_levels <- cue_i_levels[indicies]
             }
+
           }
 
           # 2. "median" method: ----
+
           if (x$params$numthresh.method == "m") {
+
             if (isTRUE(all.equal(length(unique(unlist(cue_i_v))), 2))) {
               cue_i_levels <- unique(unlist(cue_i_v))
             } else {
               cue_i_levels <- median(unlist(cue_i_v))
             }
+
           }
 
           # Round cue levels:
           if (!is.null(rounding)) {
+
             cue_i_levels <- round(cue_i_levels,
                                   digits = rounding
             )
+
           }
 
           # Remove potential duplicates:
           cue_i_levels <- cue_i_levels[duplicated(cue_i_levels) == FALSE]
+
         }
 
-        # B. Non-numeric and integer cues: ----
+
+        # B. Factors, character, and logical cues ----
+
         if (substr(cue_i_class, 1, 1) %in% c("f", "c", "l")) {
 
           # Use all unique cue values:
@@ -187,9 +198,10 @@ fftrees_cuerank <- function(x = NULL,
             cost.outcomes = cost.outcomes,
             goal.threshold = goal.threshold
           )
+
         } # a. numeric/integer cues.
 
-        # b. factor, character, and logical cues: ----
+        # b. Factors, character, and logical cues: ----
         if (substr(cue_i_class, 1, 1) %in% c("f", "c", "l")) {
 
           cue_i_stats <- fftrees_threshold_factor_grid(
@@ -202,6 +214,7 @@ fftrees_cuerank <- function(x = NULL,
             cost.outcomes = cost.outcomes,
             goal.threshold = goal.threshold
           )
+
         } # b. factor/character/logical cues.
 
 
@@ -232,6 +245,7 @@ fftrees_cuerank <- function(x = NULL,
 
       # Step 3: Set best cue direction and threshold to NULL [cue_i_best]: ----
       {
+
         cue_i_best <- fftrees_threshold_factor_grid(
           thresholds = NULL,
           cue_v = NULL,
@@ -240,6 +254,7 @@ fftrees_cuerank <- function(x = NULL,
           cost.outcomes = cost.outcomes,
           goal.threshold = goal.threshold
         )
+
       } # Step 3.
 
     } # if (all(is.na(cue_i_v)).

--- a/README.Rmd
+++ b/README.Rmd
@@ -29,11 +29,13 @@ url_JDM_pdf   <- "https://journal.sjdm.org/17/17217/jdm17217.pdf"
 
 # FFTrees `r packageVersion("FFTrees")` <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
+
 <!-- Status badges: --> 
 
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees)
 [![Build Status](https://travis-ci.org/ndphillips/FFTrees.svg?branch=master)](https://travis-ci.org/ndphillips/FFTrees)
 [![Downloads](https://cranlogs.r-pkg.org/badges/FFTrees?color=brightgreen)](https://www.r-pkg.org/pkg/FFTrees)
+
 
 <!-- Goal: -->
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.7.5.9013 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.7.5.9014 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Status badges: -->
 
@@ -334,6 +334,6 @@ for the full list):
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2022-12-23.\]
+\[File `README.Rmd` last updated on 2022-12-24.\]
 
 <!-- eof. -->

--- a/vignettes/FFTrees_heart.Rmd
+++ b/vignettes/FFTrees_heart.Rmd
@@ -80,22 +80,24 @@ heart.fft <- FFTrees(formula = diagnosis ~ .,           # Criterion and (all) pr
                      )
 ```
 
-The resulting trees, decisions, and accuracy statistics are now stored in an `FFTrees` object called `heart.fft`.
+Evaluating this expression runs code that examines the data, optimizes thresholds based on our current goals for each cue, and creates and evaluates `r heart.fft$trees$n`\ FFTs. 
+The resulting trees, their decisions and their accuracy statistics, are now stored in an `FFTrees` object called `heart.fft`.
 
 #### Other arguments
 
 - `algorithm`: There are two different algorithms available to build FFTs `"ifan"` [@phillips2017FFTrees] and `"dfan"` [@phillips2017FFTrees]. (`"max"` [@martignon2008categorization], and `"zigzag"` [@martignon2008categorization] are no longer supported). 
 
-- `max.levels`: Changes the maximum number of levels allowed in the tree.
+- `max.levels`: Changes the maximum number of levels that are allowed in the tree.
 
-The following arguments apply to the "ifan" and "dfan" algorithms only:
+The following arguments apply when using the "ifan" or "dfan" algorithms for creating new FFTs:
 
 - `goal.chase`: The `goal.chase` argument changes which statistic is maximized during tree construction (for the `"ifan"` and `"dfan"` algorithms). Possible arguments include `"acc"`, `"bacc"`, `"wacc"`, `"dprime"`, and `"cost"`. The default is `"wacc"` with a sensitivity weight of\ 0.50 (which renders it identical to `"bacc"`). 
 
 - `goal`: The `goal` argument changes which statistic is maximized when _selecting_ trees after construction (for the `"ifan"` and `"dfan"` algorithms). Possible arguments include `"acc"`, `"bacc"`, `"wacc"`, `"dprime"`, and `"cost"`.
 
-- `my.tree`: We can define a tree verbally as a sentence using the `my.tree` argument. 
-See the [Defining an FFT verbally](FFTrees_mytree.html) vignette for details. 
+- `my.tree` or `tree.definitions`: We can define a new tree from a verbal description (as a set of sentences), 
+or manually specify sets of FFTs as a data frame (in appropriate format). 
+See the [Manually specifying FFTs](FFTrees_mytree.html) vignette for details. 
 
 
 ### Step\ 3: Inspect and summarize FFTs

--- a/vignettes/FFTrees_mytree.Rmd
+++ b/vignettes/FFTrees_mytree.Rmd
@@ -234,6 +234,50 @@ plot(fft_4)
 <!-- ToDo: 2nd way to specify an FFT:  -->
 <!-- 2. as a data frame using the `tree.definitions` argument  -->
 
+
+### Using `tree.definitions`
+
+More experienced users may want to define and evaluate more than one FFTs at a time. 
+To achieve this, the `FFTrees()` function allows providing sets of `tree.definitions` (as a data frame). 
+However, as questions regarding specific trees usually arise late in an exploration of FFTs, the `tree.definitions` argument is mostly used in combination with an existing `FFTrees` object\ `x`. 
+In this case, the parameters (e.g., regarding the `formula`, `data` and goals to be used) from\ `x` are being used, but its tree definitions (stored in `x$trees$definitions`) are replaced by those in `tree.definitions` and the object is re-evaluated for those FFTs.
+
+<!-- Example: -->
+
+We illustrate a typical workflow by redefining some FFTs that were built in the [Tutorial: FFTs for heart disease](FFTrees_heart.html) and evaluating them on the (full) `heartdisease` data. 
+
+First, we use our default algorithms to create an `FFTrees` object `heart.fft`:
+
+```{r fft-treedef-01, message = FALSE}
+# Create an FFTrees object x:
+x <- FFTrees(formula = diagnosis ~ .,           # Criterion and (all) predictors
+             data = heart.train,                # Training data
+             data.test = heart.test,            # Testing data
+             main = "Heart Disease",            # General label
+             decision.labels = c("Low-Risk", "High-Risk")  # Decision labels (False/True)
+)
+```
+
+As we have seen in the [Tutorial](FFTrees_heart.html), evaluating this expression yields a set of `r x$trees$n`\ FFTs. 
+Rather than evaluating them individually (by issuing `print(x)` or `plot(x)` commands to inspect specific trees), we can obtain both their definitions and their performance characteristics on a variety of measures either by running `summary(x)` or by inspecting corresponding parts of the `FFTrees` object. 
+For instance, the following alternatives would both show the current definitions of the generated FFTs: 
+
+```{r fft-treedef-02, message = FALSE}
+# Tree definitions of x:
+summary(x)["definitions"]  # from summary()
+# x$trees$definitions      # from FFTrees object x
+```
+
+Each line in these tree definitions defines an FFT in the context of our current `FFTrees` object\ `x` (see the [Creating FFTs with FFTrees()](FFTrees_function.html) vignette how to interpret such tree definitions). 
+
++++ here now +++ 
+
+
+
+creating and evaluating FFTs from `tree.definitions` requires the 
+
+
+
 <!-- +++ here now +++  -->
 
 <!-- For experienced users: Method for manually or computationally defining sets of FFTs. -->

--- a/vignettes/FFTrees_mytree.Rmd
+++ b/vignettes/FFTrees_mytree.Rmd
@@ -41,7 +41,7 @@ There are two ways to define fast-and-frugal trees manually when using the `FFTr
 Both of these methods will bypass the tree construction algorithms built into the **FFTrees** package.
 
 
-### Using `my.tree`
+### 1. Using `my.tree`
 
 The first method is to use the `my.tree` argument, where `my.tree` is a sentence describing a (single) FFT. 
 When this argument is specified in `FFTrees()`, the function (specifically, an auxiliary `fftrees_wordstofftrees()` function) will try to convert the verbal description into the definition of a FFT (of an `FFTrees` object). 
@@ -69,7 +69,7 @@ in_words <- "If sex = 1, predict True.
 As we will see shortly, the `FFTrees()` function accepts such descriptions (assigned here to a character string `in_words`) as its `my.tree` argument, create a corresponding FFT, and evaluate it on a corresponding dataset. 
 
 
-#### How to define FFTs 
+#### Verbally defining FFTs 
 
 Here are some **instructions** for manually specifying trees: 
 
@@ -235,14 +235,15 @@ plot(fft_4)
 <!-- 2. as a data frame using the `tree.definitions` argument  -->
 
 
-### Using `tree.definitions`
+### 2. Using `tree.definitions`
 
 More experienced users may want to define and evaluate more than one FFTs at a time. 
 To achieve this, the `FFTrees()` function allows providing sets of `tree.definitions` (as a data frame). 
 However, as questions regarding specific trees usually arise late in an exploration of FFTs, the `tree.definitions` argument is mostly used in combination with an existing `FFTrees` object\ `x`. 
 In this case, the parameters (e.g., regarding the `formula`, `data` and goals to be used) from\ `x` are being used, but its tree definitions (stored in `x$trees$definitions`) are replaced by those in `tree.definitions` and the object is re-evaluated for those FFTs.
 
-<!-- Example: -->
+
+#### Example
 
 We illustrate a typical workflow by redefining some FFTs that were built in the [Tutorial: FFTs for heart disease](FFTrees_heart.html) and evaluating them on the (full) `heartdisease` data. 
 
@@ -264,60 +265,82 @@ For instance, the following alternatives would both show the current definitions
 
 ```{r fft-treedef-02, message = FALSE}
 # Tree definitions of x:
-summary(x)$definitions   # from summary()
-# x$trees$definitions    # from FFTrees object x
+# summary(x)$definitions   # from summary()
+x$trees$definitions        # from FFTrees object x
 ```
 
 Each line in these tree definitions defines an FFT in the context of our current `FFTrees` object\ `x` (see the vignette on [Creating FFTs with FFTrees()](FFTrees_function.html) for help on interpreting tree definitions). 
 As the "ifan" algorithm responsible for creating these trees yields a family of highly similar FFTs (as the FFTs vary only by their exits, and some truncate the last cue), we may want to examine alternative versions for these trees. 
 
+#### Modifying tree definitions 
+
+To demonstrate how to create and evaluate manual FFT definitions, we copy the existing tree definitions (as a data frame), select three FFTs (rows), and then create a 4th definition (with a different exit structure):
 
 ```{r fft-treedef-03, message = FALSE}
-tree_df <- summary(x)$definitions  # get FFT definitions (as df)
-tree_df <- tree_df[c(1, 3, 5), ]   # filter 3 particular FFTs
+# 0. Copy and choose some existing FFT definitions:
+tree_df <- x$trees$definitions    # get FFT definitions (as df)
+tree_df <- tree_df[c(1, 3, 5), ]  # filter 3 particular FFTs
 
-# Add a tree with 1;1;0.5 exit structure (a "rake" tree with Signal bias):
+# 1. Add a tree with 1;1;0.5 exit structure (a "rake" tree with Signal bias):
 tree_df[4, ] <- tree_df[1, ]        # initialize new FFT #4 (as copy of FFT #1)
-tree_df$exits[4] <- c("1;1;0.5")  # modify exits of FFT #4
-
-# Change cue orders:
-tree_df[5:8, ] <- tree_df[1:4, ]  # initialize 4 new FFTs (as copys of existing ones)
-tree_df$cues[5:8] <- "cp;thal;ca"  # modify cue order
-tree_df$thresholds[5:8] <- "a;rd,fd;0"  # modify cue order
-
+tree_df$exits[4] <- c("1; 1; 0.5")  # modify exits of FFT #4
 
 tree_df$tree <- 1:nrow(tree_df)   # adjust tree numbers
-
-tree_df
+# tree_df
 ```
 
-Evaluate `FFTrees` object `x` with new `tree.definitions`:
+Moreover, let's define four additional FFTs that reverse the order of the 1st and 2nd cues. 
+As both cues are categorical (i.e., of class\ `c`) and have the same direction (i.e., `=`), we only need to reverse the `thresholds` (so that they correspond to the new cue order):
 
-```{r fft-treedef-04, message = TRUE}
+```{r fft-treedef-04, message = FALSE}
+# 2. Change cue orders:
+tree_df[5:8, ] <- tree_df[1:4, ]     # 4 new FFTs (as copiess of existing ones)
+tree_df$cues[5:8] <- "cp; thal; ca"       # modify order of cues
+tree_df$thresholds[5:8] <- "a; rd,fd; 0"  # modify order of thresholds accordingly
+
+tree_df$tree <- 1:nrow(tree_df)           # adjust tree numbers
+# tree_df
+```
+
+The resulting data frame `tree_df` contains the definitions of eight FFTs. 
+The first three are copies of trees in\ `x`, but the other five are new. 
+
+#### Evaluating `tree.definitions` 
+
+We can evaluate this set by running the `FFTrees()` function with 
+the previous `FFTrees` object\ `x` (i.e., with its `formula` and `data` settings) and 
+specifying `tree_df` in the `tree.definitions` argument:
+
+```{r fft-treedef-05, message = TRUE}
 # Create a modified FFTrees object y:
 y <- FFTrees(object = x,                  # use previous FFTrees object x
              tree.definitions = tree_df,  # but with new tree definitions
              main = "Heart Disease 2"     # revised label
 )
-
-y$trees$definitions
-
-plot(y, tree = 2)
 ```
 
+The resulting `FFTrees` object\ `y` contains the trees and summary statistics of all eight FFTs. 
+Although it is unlikely that one of the newly created trees beats the automatically created FFTs, we find that reversing the order of the first cues has only minimal effects on training accuracy (as measured by `bacc`):
 
+```{r fft-treedef-06, message = TRUE}
+y$trees$definitions  # tree definitions
+y$trees$stats$train  # training statistics
+```
 
+Note that the trees in\ `y` were sorted by their performance on the current `goal` (here `bacc`). 
+For instance, the new rake tree with cue order `cp; thal; ca` and exits `1; 1; 0.5` is now FFT\ #6. 
+When examining its performance on `"test"` data (i.e., for prediction):
 
+```{r fft-treedef-07, eval = FALSE}
+# Print and plot FFT #6:
+print(y, tree = 6, data = "test")
+plot(y,  tree = 6, data = "test")
+```
 
+we see that it has a balanced accuracy\ `bacc` of\ 70%. 
+More precisely, its bias for predicting `disease` (i.e., signal or True) yields near-perfect sensitivity (96%), but very poor specificity (44%). 
 
-
-+++ here now +++ 
-
-
-
-creating and evaluating FFTs from `tree.definitions` requires the 
-
-
+If we wanted to change more aspects of\ `x` (e.g., use different `data` or `goal` settings), we could have created a new `FFTrees` object without supplying the previous object\ `x`, as long as the FFTs defined in `tree.definitions` fit to the settings of `formula` and `data`. 
 
 <!-- +++ here now +++  -->
 
@@ -440,7 +463,6 @@ fft_4 <- FFTrees(formula = diagnosis ~ .,            # as before
                  main = "Heart Disease (manual 2)",  # changed label
                  decision.labels = c("low R", "high R")  # changed labels for decisions
 )
-
 fft_4
 
 fft_4$trees$definitions  # 8 trees: New FFT is #4
@@ -523,7 +545,6 @@ fft_1 <- FFTrees(formula = diagnosis ~ .,           # Criterion and (all) predic
                  tree.definitions = my_fft_df,      # provide definition (as df)
                  main = "Heart Disease (manual)"   # new label
                  )
-
 fft_1
 
 print(fft_1, tree = "best.train", data = "train")
@@ -554,7 +575,6 @@ fft_2 <- FFTrees(formula = diagnosis ~ .,           # Criterion and (all) predic
                  tree.definitions = my_fft_df_2,    # provide definitions (as df)
                  main = "Heart Disease (manual)"   # new label
                  )
-
 fft_2
 
 # Inspect trees:
@@ -570,8 +590,6 @@ plot(fft_2, tree = 3, data = "train")
 plot(fft_2, tree = 3, data = "test")
 ```
 
-
-For details on understanding and changing tree definitions, see the section on **Tree definitions** in the [Creating FFTs with FFTrees()](FFTrees_function.html) vignette. 
 
 
 ## Vignettes

--- a/vignettes/FFTrees_mytree.Rmd
+++ b/vignettes/FFTrees_mytree.Rmd
@@ -250,11 +250,11 @@ First, we use our default algorithms to create an `FFTrees` object `heart.fft`:
 
 ```{r fft-treedef-01, message = FALSE}
 # Create an FFTrees object x:
-x <- FFTrees(formula = diagnosis ~ .,           # Criterion and (all) predictors
-             data = heart.train,                # Training data
-             data.test = heart.test,            # Testing data
-             main = "Heart Disease",            # General label
-             decision.labels = c("Low-Risk", "High-Risk")  # Decision labels (False/True)
+x <- FFTrees(formula = diagnosis ~ .,           # criterion and (all) predictors
+             data = heart.train,                # training data
+             data.test = heart.test,            # testing data
+             main = "Heart Disease 1",          # initial label
+             decision.labels = c("low risk", "high risk")  # decision labels (False/True)
 )
 ```
 
@@ -264,11 +264,52 @@ For instance, the following alternatives would both show the current definitions
 
 ```{r fft-treedef-02, message = FALSE}
 # Tree definitions of x:
-summary(x)["definitions"]  # from summary()
-# x$trees$definitions      # from FFTrees object x
+summary(x)$definitions   # from summary()
+# x$trees$definitions    # from FFTrees object x
 ```
 
-Each line in these tree definitions defines an FFT in the context of our current `FFTrees` object\ `x` (see the [Creating FFTs with FFTrees()](FFTrees_function.html) vignette how to interpret such tree definitions). 
+Each line in these tree definitions defines an FFT in the context of our current `FFTrees` object\ `x` (see the vignette on [Creating FFTs with FFTrees()](FFTrees_function.html) for help on interpreting tree definitions). 
+As the "ifan" algorithm responsible for creating these trees yields a family of highly similar FFTs (as the FFTs vary only by their exits, and some truncate the last cue), we may want to examine alternative versions for these trees. 
+
+
+```{r fft-treedef-03, message = FALSE}
+tree_df <- summary(x)$definitions  # get FFT definitions (as df)
+tree_df <- tree_df[c(1, 3, 5), ]   # filter 3 particular FFTs
+
+# Add a tree with 1;1;0.5 exit structure (a "rake" tree with Signal bias):
+tree_df[4, ] <- tree_df[1, ]        # initialize new FFT #4 (as copy of FFT #1)
+tree_df$exits[4] <- c("1;1;0.5")  # modify exits of FFT #4
+
+# Change cue orders:
+tree_df[5:8, ] <- tree_df[1:4, ]  # initialize 4 new FFTs (as copys of existing ones)
+tree_df$cues[5:8] <- "cp;thal;ca"  # modify cue order
+tree_df$thresholds[5:8] <- "a;rd,fd;0"  # modify cue order
+
+
+tree_df$tree <- 1:nrow(tree_df)   # adjust tree numbers
+
+tree_df
+```
+
+Evaluate `FFTrees` object `x` with new `tree.definitions`:
+
+```{r fft-treedef-04, message = TRUE}
+# Create a modified FFTrees object y:
+y <- FFTrees(object = x,                  # use previous FFTrees object x
+             tree.definitions = tree_df,  # but with new tree definitions
+             main = "Heart Disease 2"     # revised label
+)
+
+y$trees$definitions
+
+plot(y, tree = 2)
+```
+
+
+
+
+
+
 
 +++ here now +++ 
 


### PR DESCRIPTION
Revised the vignette on **Manually defining FFTs** by including an example that modifies and evaluates a set of `tree.definitions` (to explain changes in response to Issue #111).