### PR TITLE
Replace **crayon** by **cli** functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.7.5.9014
-Date: 2022-12-24
+Version: 1.7.5.9015
+Date: 2022-12-25
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),
@@ -19,7 +19,7 @@ Imports:
     rpart,
     randomForest,
     e1071,
-    crayon,
+    cli,
     graphics,
     progress,
     scales,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.7
 
-## 1.7.5.9013
+## 1.7.5.9015
 
 <!-- Development version: --> 
 
@@ -42,6 +42,7 @@ Changes since last release:
 
 ### Details 
 
+- Replaced **crayon** package by **cli** package. 
 - Removed `anova` from **stats** imports.  
 - Replaced `expect_is()` by more precise **testthat** inheritance functions. 
 - Revised documentation and vignettes. 

--- a/R/helper.R
+++ b/R/helper.R
@@ -1345,29 +1345,6 @@ if (getRversion() >= "2.15.1") utils::globalVariables(c(".", "tree", "tree_new",
 
 
 
-
-# (3) User feedback: ------
-
-# Define RGB colors: ----
-
-g_25 <- round( 63/255, 0)  # dark grey
-g_50 <- round(127/255, 0)  # mid grey
-g_75 <- round(191/255, 0)  # light grey
-
-grey_25 <- rgb(g_25, g_25, g_25)
-grey_50 <- rgb(g_50, g_50, g_50)
-grey_75 <- rgb(g_75, g_75, g_75)
-
-
-# Create crayon styles: ----
-
-u_f_ini <- crayon::make_style("black", colors = 256)      # "darkgrey"
-u_f_fin <- crayon::make_style("darkgreen", colors = 256)  # "black"
-
-u_f_msg <- crayon::make_style("darkgrey", colors = 256)   # normal message
-u_f_hig <- crayon::make_style("darkblue", colors = 256)   # highlighted msg
-
-
 # ToDo: ------
 
 # - Bring back dprime as goal and goal.chase (and verify its computation).

--- a/R/helper_col.R
+++ b/R/helper_col.R
@@ -1,0 +1,48 @@
+# helper_col.R:
+# Color-related auxiliary/utility functions.
+# ------------------------------------------
+
+# (1) User feedback: ------
+
+# Define RGB colors: ----
+
+# g_25 <- round( 63/255, 0)  # dark grey
+# g_50 <- round(127/255, 0)  # mid grey
+# g_75 <- round(191/255, 0)  # light grey
+#
+# grey_25 <- rgb(g_25, g_25, g_25)
+# grey_50 <- rgb(g_50, g_50, g_50)
+# grey_75 <- rgb(g_75, g_75, g_75)
+
+
+
+# Define crayon styles: ----
+
+# u_f_ini <- crayon::make_style("black", colors = 256)      # "darkgrey"
+# u_f_fin <- crayon::make_style("darkgreen", colors = 256)  # "black"
+#
+# u_f_msg <- crayon::make_style("darkgrey", colors = 256)   # normal message
+# u_f_hig <- crayon::make_style("darkblue", colors = 256)   # highlighted msg
+
+
+
+# Define cli styles: ----
+
+in_grey <- cli::make_ansi_style("grey45", grey = TRUE, colors = 256)
+
+in_red   <- cli::make_ansi_style("red4", colors = 256)
+in_green <- cli::make_ansi_style("green4", colors = 256)
+in_blue  <- cli::make_ansi_style("steelblue4", colors = 256)
+
+u_f_ini <- cli::make_ansi_style("black", colors = 256)      # "darkgrey"
+u_f_fin <- cli::make_ansi_style("darkgreen", colors = 256)  # "black"
+
+u_f_msg <- cli::make_ansi_style("darkgrey", colors = 256)   # normal message
+u_f_hig <- cli::make_ansi_style("darkblue", colors = 256)   # highlighted msg
+
+
+# ToDo: ------
+
+# - Replace crayon by cli package.
+
+# eof.

--- a/R/helper_col.R
+++ b/R/helper_col.R
@@ -15,7 +15,6 @@
 # grey_75 <- rgb(g_75, g_75, g_75)
 
 
-
 # Define crayon styles: ----
 
 # u_f_ini <- crayon::make_style("black", colors = 256)      # "darkgrey"
@@ -28,11 +27,16 @@
 
 # Define cli styles: ----
 
+# ANSI color styles:
+
 in_grey <- cli::make_ansi_style("grey45", grey = TRUE, colors = 256)
 
-in_red   <- cli::make_ansi_style("red4", colors = 256)
-in_green <- cli::make_ansi_style("green4", colors = 256)
-in_blue  <- cli::make_ansi_style("steelblue4", colors = 256)
+in_red   <- cli::make_ansi_style("darkred", colors = 256)     # "red4" "firebrick4"
+in_green <- cli::make_ansi_style("darkgreen", colors = 256)   # "green4"
+in_blue  <- cli::make_ansi_style("steelblue4", colors = 256)  # "steelblue4" "darkblue"
+
+
+# User feedback messages:
 
 u_f_ini <- cli::make_ansi_style("black", colors = 256)      # "darkgrey"
 u_f_fin <- cli::make_ansi_style("darkgreen", colors = 256)  # "black"
@@ -43,6 +47,6 @@ u_f_hig <- cli::make_ansi_style("darkblue", colors = 256)   # highlighted msg
 
 # ToDo: ------
 
-# - Replace crayon by cli package.
+# - etc.
 
 # eof.

--- a/R/helper_plot.R
+++ b/R/helper_plot.R
@@ -73,14 +73,14 @@ console_confusionmatrix <- function(hi, mi, fa, cr,  sens.w,  cost) {
 
   cat("| Decide +",
       " | ",
-      crayon::silver("hi"),
+      in_grey("hi"),
       rep(" ", max(1, col_width - 4 - num_space(hi))),
-      crayon::green(scales::comma(hi)),
+      in_green(scales::comma(hi)),
       # rep(" ", max(0, col_width - num_space(hi) - 4)),
       " | ",
-      crayon::silver("fa"),
+      in_grey("fa"),
       rep(" ", max(1, col_width - 4 - num_space(fa))),
-      crayon::red(scales::comma(fa)),
+      in_red(scales::comma(fa)),
       # rep(" ", max(0, col_width - num_space(fa) - 4)),
       " | ",
       sep = ""
@@ -96,14 +96,14 @@ console_confusionmatrix <- function(hi, mi, fa, cr,  sens.w,  cost) {
 
   cat("| Decide -",
       " | ",
-      crayon::silver("mi"),
+      in_grey("mi"),
       rep(" ", max(1, col_width - 4 - num_space(mi))),
-      crayon::red(scales::comma(mi)),
+      in_red(scales::comma(mi)),
       # rep(" ", max(0, col_width - num_space(mi) - 4)),
       " | ",
-      crayon::silver("cr"),
+      in_grey("cr"),
       rep(" ", max(1, col_width - 4 - num_space(cr))),
-      crayon::green(scales::comma(cr)),
+      in_green(scales::comma(cr)),
       # rep(" ", max(0, col_width - num_space(cr) - 4)),
       " | ",
       sep = ""
@@ -136,7 +136,7 @@ console_confusionmatrix <- function(hi, mi, fa, cr,  sens.w,  cost) {
   # cat(" | ")  # with |
 
   cat("N = ")
-  cat(crayon::underline(scales::comma(N), sep = ""), sep = "")
+  cat(cli::style_underline(scales::comma(N), sep = ""), sep = "")
 
   cat("\n\n")
 

--- a/R/printFFTrees_function.R
+++ b/R/printFFTrees_function.R
@@ -157,13 +157,13 @@ print.FFTrees <- function(x = NULL,
 
   # FFTrees: ----
 
-  cat(crayon::blue("FFTrees ")) # , rep("-", times = 50 - nchar("FFTrees")), "\n", sep = "")
+  cat(in_blue("FFTrees ")) # , rep("-", times = 50 - nchar("FFTrees")), "\n", sep = "")
   cat("\n")
 
   # Trees: ----
 
   cat("- Trees: ", x$trees$n, " fast-and-frugal ", tree_s, " predicting ",
-      crayon::underline(x$criterion_name), "\n",
+      cli::style_underline(x$criterion_name), "\n",
       sep = ""
   )
 
@@ -185,8 +185,8 @@ print.FFTrees <- function(x = NULL,
   #
   # if(tree == x$trees$best$train) {
   #
-  #   cat(paste("- FFT ", crayon::underline("#", x$trees$best$train, sep = ""), " optimises ", crayon::underline(x$params$goal), " using ", train.cues.n, " cues: {",
-  #             crayon::underline(paste(unlist(strsplit(train.cues, ",")), collapse = ", ")), "}", sep = ""))
+  #   cat(paste("- FFT ", cli::style_underline("#", x$trees$best$train, sep = ""), " optimises ", cli::style_underline(x$params$goal), " using ", train.cues.n, " cues: {",
+  #             cli::style_underline(paste(unlist(strsplit(train.cues, ",")), collapse = ", ")), "}", sep = ""))
   #
   #   cat("\n")
   #
@@ -198,7 +198,7 @@ print.FFTrees <- function(x = NULL,
 
   # FFT description: ------
 
-  cat(crayon::blue("FFT #", tree, ": Definition", sep = ""), sep = "")
+  cat(in_blue("FFT #", tree, ": Definition", sep = ""), sep = "")
   cat("\n")
 
   # FFT in words:
@@ -249,7 +249,7 @@ print.FFTrees <- function(x = NULL,
 
   # Accuracy information: ------
 
-  cat(crayon::blue("FFT #", tree, ": ", crayon::underline(task), " Accuracy\n", sep = ""), sep = "")
+  cat(in_blue("FFT #", tree, ": ", cli::style_underline(task), " Accuracy\n", sep = ""), sep = "")
 
   # - Data info: ----
 
@@ -290,7 +290,7 @@ print.FFTrees <- function(x = NULL,
 
   # Speed, frugality, and cost: ------
 
-  cat(crayon::blue("FFT #", tree, ": ", crayon::underline(task), " Speed, Frugality, and Cost\n", sep = ""), sep = "")
+  cat(in_blue("FFT #", tree, ": ", cli::style_underline(task), " Speed, Frugality, and Cost\n", sep = ""), sep = "")
 
   cat("mcu = ", round(x$trees$stats[[mydata]]$mcu[tree], 2), sep = "")
   cat(",  pci = ", round(x$trees$stats[[mydata]]$pci[tree], 2), sep = "")

--- a/R/summaryFFTrees_function.R
+++ b/R/summaryFFTrees_function.R
@@ -150,6 +150,7 @@ summary.FFTrees <- function(object,
       }
 
     } # if (tree > n_trees).
+
   } # if tree not NULL.
 
 

--- a/R/summaryFFTrees_function.R
+++ b/R/summaryFFTrees_function.R
@@ -78,10 +78,10 @@ summary.FFTrees <- function(object,
     cat(o_main, "\n\n", sep = "")  # main object title
   }
 
-  cat(crayon::blue("FFTrees ")) # , rep("-", times = 50 - nchar("FFTrees")), "\n", sep = "")
+  cat(in_blue("FFTrees ")) # , rep("-", times = 50 - nchar("FFTrees")), "\n", sep = "")
   cat("\n")
 
-  cat("- Trees: ", n_trees, " fast-and-frugal ", tree_s, " predicting ", crayon::underline(o_crit), "\n", sep = "")
+  cat("- Trees: ", n_trees, " fast-and-frugal ", tree_s, " predicting ", cli::style_underline(o_crit), "\n", sep = "")
 
 
   # Parameter summary: ------
@@ -102,7 +102,7 @@ summary.FFTrees <- function(object,
   if ((is.null(tree) == FALSE) && (length(tree) == 1) && (tree %in% tree_options)){  # only 1 tree:
 
     cat("\n")
-    cat(crayon::blue("FFT #", tree, ": Definition", "\n", sep = ""), sep = "")
+    cat(in_blue("FFT #", tree, ": Definition", "\n", sep = ""), sep = "")
 
     # FFT in words:
 
@@ -155,14 +155,14 @@ summary.FFTrees <- function(object,
 
   # Print tables (on console): ----
 
-  cap_def <- crayon::blue(paste("Tree", crayon::underline("definitions")))
+  cap_def <- in_blue(paste("Tree", cli::style_underline("definitions")))
   print(knitr::kable(out$definitions, caption = cap_def))
 
-  cap_train <- crayon::blue(paste("Tree statistics on", crayon::underline("training"), "data"))
+  cap_train <- in_blue(paste("Tree statistics on", cli::style_underline("training"), "data"))
   print(knitr::kable(out$stats$train, caption = cap_train, digits = digits))
 
   if (is.null(out$stats$test) == FALSE){
-    cap_test <- crayon::blue(paste("Tree statistics on", crayon::underline("test"), "data"))
+    cap_test <- in_blue(paste("Tree statistics on", cli::style_underline("test"), "data"))
     print(knitr::kable(out$stats$test, caption = cap_test, digits = digits))
   }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,8 +13,8 @@
   packageStartupMessage("    / \\     ")
   packageStartupMessage("   F   Trees ")
   packageStartupMessage("             ")
-  packageStartupMessage(crayon::silver("Welcome to ", crayon::blue(paste("FFTrees ", version_nr, sep = "")), "!", sep = ""))
-  packageStartupMessage(crayon::silver("FFTrees.guide() opens the main guide."))
+  packageStartupMessage(in_grey("Welcome to ", in_blue(paste("FFTrees ", version_nr, sep = "")), "!", sep = ""))
+  packageStartupMessage(in_grey("FFTrees.guide() opens the main guide."))
 
 } # .onAttach().
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -29,13 +29,11 @@ url_JDM_pdf   <- "https://journal.sjdm.org/17/17217/jdm17217.pdf"
 
 # FFTrees `r packageVersion("FFTrees")` <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
-
 <!-- Status badges: --> 
 
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees)
 [![Build Status](https://travis-ci.org/ndphillips/FFTrees.svg?branch=master)](https://travis-ci.org/ndphillips/FFTrees)
 [![Downloads](https://cranlogs.r-pkg.org/badges/FFTrees?color=brightgreen)](https://www.r-pkg.org/pkg/FFTrees)
-
 
 <!-- Goal: -->
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.7.5.9014 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.7.5.9015 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Status badges: -->
 
@@ -334,6 +334,6 @@ for the full list):
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2022-12-24.\]
+\[File `README.Rmd` last updated on 2022-12-25.\]
 
 <!-- eof. -->


### PR DESCRIPTION
As the **crayon** package is being superseded by the **cli** package, this PR replaces corresponding function calls:

Colored terminal output (e.g., in summaries and user feedback messages) is now handled by ANSI styles (defined in `helper_col.R`).  