### PR TITLE
Enabling optimizing FFTs for `dprime`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
 Version: 1.8.1
-Date: 2023-01-12
+Date: 2023-01-13
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,8 @@
 
 ## 1.8.1
 
-**FFTrees** version 1.8.1 is to be released [on CRAN](https://CRAN.R-project.org/package=FFTrees) [on 2023-01-12]. 
-This version mostly fixes an error in a package vignette. 
+**FFTrees** version 1.8.1 is to be released [on CRAN](https://CRAN.R-project.org/package=FFTrees) [on 2023-01-??]. 
+This version adds functionality, improves robustness, and fixes some bugs.
 
 <!-- Log of changes: --> 
 
@@ -12,16 +12,17 @@ Changes since last release:
 
 <!-- Blank line. --> 
 
+
 ### Major changes 
 
-- None yet. 
+- Added support optimizing trees for `dprime` values (as `goal`, `goal.chase`, and `goal.threshold`). 
 
 <!-- Blank line. --> 
 
 
 ### Minor changes 
 
-- None yet. 
+- Included `dprime` values in cue level statistics (in `x$cues$thresholds` and `x$cues$stats`). 
 
 <!-- Blank line. --> 
 
@@ -35,7 +36,7 @@ Changes since last release:
 
 <!-- Development version: --> 
 
-The current development version of **FFTrees** is available at  <https://github.com/ndphillips/FFTrees>. 
+The current development version of **FFTrees** is available at <https://github.com/ndphillips/FFTrees>. 
 
 
 <!-- Released versions: --> 
@@ -397,6 +398,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2023-01-12.]
+[File `NEWS.md` last updated on 2023-01-13.]
 
 <!-- eof. -->

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -256,12 +256,6 @@ fftrees_cuerank <- function(x = NULL,
 
         # B. Identify the best threshold (based on goal.threshold): ----
 
-        if (goal.threshold == "dprime"){  # Note error:
-          stop("Using 'dprime' as 'goal.threshold' is currently not supported.")
-          # ToDo: 'dprime' must be included in cue_i_stats:
-          #        Add dprime to fftrees_threshold_numeric_grid() and fftrees_threshold_factor_grid().
-        }
-
         # Get thresholds that maximize current goal.threshold:
         best_result_index <- which(cue_i_stats[goal.threshold] == max(cue_i_stats[goal.threshold], na.rm = TRUE))
         # Note that cost_dec and cost are NEGATIVE in cue_i_stats (so that goal.threshold == "cost" is MINimized)!

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -242,9 +242,13 @@ fftrees_cuerank <- function(x = NULL,
 
         } # if b. factor/character/logical cue.
 
-        # # User feedback (4debugging):
+        # # Get feedback (4debugging):
         # print(paste0(cue_i, ": cue_i_stats of cue_i_name = ", cue_i_name, ":"))
         # print(cue_i_stats)
+
+        # Re-set rownames:
+        # rownames(cue_i_stats) <- 1:nrow(cue_i_stats)
+        # Note: NOT needed and potentially confusing (when comparing results).
 
         # Store results (i.e., ALL cue thresholds for cue_i): ----
         x$cues$thresholds[[data]][[cue_i_name]] <- cue_i_stats

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -202,11 +202,15 @@ fftrees_cuerank <- function(x = NULL,
 
       # Step 3: Determine best direction and threshold for cue [cue_i_best]: ----
       {
+
+        # Parameters:
         cost.outcomes  <- x$param$cost.outcomes
         # goal.threshold <- x$params$goal.threshold  # (assigned above)
         sens.w <- x$params$sens.w
 
-        # a. Numeric, integer cues: ----
+        # A. Compute cue statistics (based on cue type): ----
+
+        # a. Numeric/integer cue: ----
         if (substr(cue_i_class, 1, 1) %in% c("n", "i")) {
 
           cue_i_stats <- fftrees_threshold_numeric_grid(
@@ -220,9 +224,9 @@ fftrees_cuerank <- function(x = NULL,
             goal.threshold = goal.threshold
           )
 
-        } # a. numeric/integer cues.
+        } # if a. numeric/integer cue.
 
-        # b. Factors, character, and logical cues: ----
+        # b. Factor, character, or logical cue: ----
         if (substr(cue_i_class, 1, 1) %in% c("f", "c", "l")) {
 
           cue_i_stats <- fftrees_threshold_factor_grid(
@@ -236,35 +240,39 @@ fftrees_cuerank <- function(x = NULL,
             goal.threshold = goal.threshold
           )
 
-        } # b. factor/character/logical cues.
+        } # if b. factor/character/logical cue.
 
-        # # User feedback (4debugging): +++ here now +++
+        # # User feedback (4debugging):
         # print(paste0(cue_i, ": cue_i_stats of cue_i_name = ", cue_i_name, ":"))
         # print(cue_i_stats)
 
-
-        # Save results: ----
-
+        # Store results (i.e., ALL cue thresholds for cue_i): ----
         x$cues$thresholds[[data]][[cue_i_name]] <- cue_i_stats
+
+
+        # B. Identify the best threshold (based on goal.threshold): ----
+
+        if (goal.threshold == "dprime"){  # Note error:
+          stop("Using 'dprime' as 'goal.threshold' is currently not supported.")
+          # ToDo: 'dprime' must be included in cue_i_stats:
+          #        Add dprime to fftrees_threshold_numeric_grid() and fftrees_threshold_factor_grid().
+        }
 
         # Get thresholds that maximize current goal.threshold:
         best_result_index <- which(cue_i_stats[goal.threshold] == max(cue_i_stats[goal.threshold], na.rm = TRUE))
         # Note that cost_dec and cost are NEGATIVE in cue_i_stats (so that goal.threshold == "cost" is MINimized)!
 
-        # If there are multiple best indices, take the first:
-        if (length(best_result_index) > 1) {
-          best_result_index <- best_result_index[1]  # ToDo: Not sure if this is the best way to do it...
+        # Handle 2 special cases:
+        if (length(best_result_index) > 1) { # 1. multiple best indices:
+          best_result_index <- best_result_index[1]  # take the 1st   ToDo: Is this the best way? Randomize?
         }
 
-        # If there is NO best index, take 1 (and issue a warning):
-        if (is.na(best_result_index)) {
-
-          warning(paste0("For cue ", cue_i_name, ", best_result_index was NA. Used best_result_index = 1..."))
-
-          best_result_index <- 1
+        if (is.na(best_result_index)) { # 2. NO best index:
+          best_result_index <- 1  # use 1st   ToDo: Is this the best way? Randomize?
+          warning(paste0("For cue ", cue_i_name, ", best_result_index was NA. Used 1st threshold..."))
         }
 
-        cue_i_best <- cue_i_stats[best_result_index, ]
+        cue_i_best <- cue_i_stats[best_result_index, ]  # get corresponding row of cue_i_stats
 
       } # Step 3.
 
@@ -309,14 +317,18 @@ fftrees_cuerank <- function(x = NULL,
 
   rownames(cuerank_df) <- 1:nrow(cuerank_df)
 
-  # Add cue costs: ----
+
+  # Add cost.cues (which are a constant for each cue, i.e., do NOT vary by decision outcomes): ----
 
   cuerank_df$cost_cue <- unlist(x$params$cost.cues[match(cuerank_df$cue, names(x$params$cost.cues))])
 
 
-  # Store in x$cues$stats (as df): ----
+  # Re-order columns: ----
 
-  cuerank_df <- cuerank_df[, c("cue", "class", setdiff(names(cuerank_df), c("cue", "class")))]  # re-order
+  cuerank_df <- cuerank_df[, c("cue", "class", setdiff(names(cuerank_df), c("cue", "class")))]
+
+
+  # Store in x$cues$stats (as df): ----
 
   x$cues$stats[[data]] <- cuerank_df
 

--- a/R/fftrees_threshold_factor_grid.R
+++ b/R/fftrees_threshold_factor_grid.R
@@ -141,12 +141,15 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
 
     # Clean up results: ----
 
+
     # Arrange rows by goal.threshold and change column order:
     ord_new <- order(results[, goal.threshold], decreasing = TRUE)
 
     results <- results[ord_new, c("threshold", "direction",
                                   "n", "hi", "fa", "mi", "cr",
-                                  "sens", "spec", "ppv", "npv", "bacc", "acc", "wacc",
+                                  "sens", "spec", "ppv", "npv",
+                                  "bacc", "acc", "wacc",
+                                  "dprime",
                                   "cost_dec", "cost")]
 
     # Re-set rownames:
@@ -171,6 +174,7 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
       "bacc" = NA,
       "acc" = NA,
       "wacc" = NA,
+      "dprime" = NA,
       "cost_dec" = NA,
       "cost" = NA
     )

--- a/R/fftrees_threshold_factor_grid.R
+++ b/R/fftrees_threshold_factor_grid.R
@@ -153,7 +153,7 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
                                   "cost_dec", "cost")]
 
     # Re-set rownames:
-    rownames(results) <- 1:nrow(results)
+    # rownames(results) <- 1:nrow(results)  # NOT needed and potentially confusing (when comparing results).
 
     # Remove invalid directions: ----
     results[results$direction %in% directions, ]

--- a/R/fftrees_threshold_factor_grid.R
+++ b/R/fftrees_threshold_factor_grid.R
@@ -127,7 +127,7 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
 
     results <- results_cum
 
-    # Add accuracy statistics: ----
+    # Compute accuracy statistics: ----
     new_stats <- add_stats(
       data = results,
       sens.w = sens.w,
@@ -135,10 +135,13 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
       cost.each = cost.each
     )
 
-    # Add accuracy statistics:
+    # Add accuracy statistics (to previous results): ----
     results <- cbind(results, new_stats)
 
-    # Order by goal.threshold and change column order: ----
+
+    # Clean up results: ----
+
+    # Arrange rows by goal.threshold and change column order:
     ord_new <- order(results[, goal.threshold], decreasing = TRUE)
 
     results <- results[ord_new, c("threshold", "direction",
@@ -146,8 +149,12 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
                                   "sens", "spec", "ppv", "npv", "bacc", "acc", "wacc",
                                   "cost_dec", "cost")]
 
+    # Re-set rownames:
+    rownames(results) <- 1:nrow(results)
+
     # Remove invalid directions: ----
     results[results$direction %in% directions, ]
+
 
   } else { # no thresholds exist: ----
 

--- a/R/fftrees_threshold_numeric_grid.R
+++ b/R/fftrees_threshold_numeric_grid.R
@@ -85,22 +85,29 @@ fftrees_threshold_numeric_grid <- function(thresholds,
     results <- rbind(results_gt, results_lt)
   }
 
+
   new_stats <- add_stats(results,
                          sens.w = sens.w,
                          cost.outcomes = cost.outcomes,
                          cost.each = cost.each
   )
 
-  # Add accuracy statistics: ----
+  # Add accuracy statistics (to previous results): ----
   results <- cbind(results, new_stats)
 
-  # Order by goal.threshold and change column order:
+
+  # Clean up results: ----
+
+  # Arrange rows by goal.threshold and change column order:
   ord_new <- order(results[, goal.threshold], decreasing = TRUE)
 
   results <- results[ord_new, c("threshold", "direction",
                                 "n", "hi", "fa", "mi", "cr",
                                 "sens", "spec", "ppv", "npv", "bacc", "acc", "wacc",
                                 "cost_dec", "cost")]
+
+  # Re-set rownames:
+  rownames(results) <- 1:nrow(results)
 
   # Remove invalid directions:
   results[results$direction %in% directions, ]

--- a/R/fftrees_threshold_numeric_grid.R
+++ b/R/fftrees_threshold_numeric_grid.R
@@ -110,7 +110,7 @@ fftrees_threshold_numeric_grid <- function(thresholds,
                                 "cost_dec", "cost")]
 
   # Re-set rownames:
-  rownames(results) <- 1:nrow(results)
+  # rownames(results) <- 1:nrow(results)  # NOT needed and potentially confusing (when comparing results).
 
   # Remove invalid directions:
   results[results$direction %in% directions, ]

--- a/R/fftrees_threshold_numeric_grid.R
+++ b/R/fftrees_threshold_numeric_grid.R
@@ -98,12 +98,15 @@ fftrees_threshold_numeric_grid <- function(thresholds,
 
   # Clean up results: ----
 
+
   # Arrange rows by goal.threshold and change column order:
   ord_new <- order(results[, goal.threshold], decreasing = TRUE)
 
   results <- results[ord_new, c("threshold", "direction",
                                 "n", "hi", "fa", "mi", "cr",
-                                "sens", "spec", "ppv", "npv", "bacc", "acc", "wacc",
+                                "sens", "spec", "ppv", "npv",
+                                "bacc", "acc", "wacc",
+                                "dprime",
                                 "cost_dec", "cost")]
 
   # Re-set rownames:

--- a/R/helper.R
+++ b/R/helper.R
@@ -969,7 +969,7 @@ fact_clean <- function(data.train,
 #' Add decision statistics to data (containing counts of a 2x2 contingency table)
 #'
 #' \code{add_stats} assumes the input of essential 2x2 frequency counts
-#' (as a data frame \code{data} with variable names \code{"hi"}, \code{"fa"}, \code{"mi"}, and \code{"cr"})
+#' (as a data frame \code{"data"} with variable names \code{"hi"}, \code{"fa"}, \code{"mi"}, and \code{"cr"})
 #' and uses them to compute various decision accuracy measures.
 #'
 #' Providing numeric values for \code{cost.each} (as a vector) and \code{cost.outcomes} (as a named list)

--- a/man/add_stats.Rd
+++ b/man/add_stats.Rd
@@ -8,7 +8,8 @@ add_stats(
   data,
   sens.w = 0.5,
   cost.each = NULL,
-  cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0)
+  cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0),
+  correction = 0.25
 )
 }
 \arguments{
@@ -16,19 +17,22 @@ add_stats(
 
 \item{sens.w}{numeric. Sensitivity weight (for computing weighted accuracy, \code{wacc}). Default: \code{sens.w = .50}.}
 
-\item{cost.each}{numeric. An optional fixed cost added to all outputs (e.g.; the cost of the cue).}
+\item{cost.each}{numeric. An optional fixed cost added to all outputs (e.g., the cost of using the cue).}
 
 \item{cost.outcomes}{list. A list of length 4 named \code{"hi"}, \code{"fa"}, \code{"mi"}, \code{"cr"}, and
 specifying the costs of a hit, false alarm, miss, and correct rejection, respectively.
 E.g.; \code{cost.outcomes = listc("hi" = 0, "fa" = 10, "mi" = 20, "cr" = 0)} means that a
 false alarm and miss cost 10 and 20 units, respectively, while correct decisions incur no costs.}
+
+\item{correction}{numeric. Correction added to all counts for calculating \code{dprime}.
+Default: \code{correction = .25}.}
 }
 \value{
 A data frame with variables of computed accuracy and cost measures (but dropping inputs).
 }
 \description{
 \code{add_stats} assumes the input of essential 2x2 frequency counts
-(as a data frame \code{data} with variable names \code{"hi"}, \code{"fa"}, \code{"mi"}, and \code{"cr"})
+(as a data frame \code{"data"} with variable names \code{"hi"}, \code{"fa"}, \code{"mi"}, and \code{"cr"})
 and uses them to compute various decision accuracy measures.
 }
 \details{

--- a/man/classtable.Rd
+++ b/man/classtable.Rd
@@ -24,7 +24,8 @@ Default: \code{sens.w = NULL} (to enforce that actual value is being passed by t
 
 \item{cost.v}{list. An optional list of additional costs to be added to each case.}
 
-\item{correction}{numeric. Correction added to all counts for calculating \code{dprime}.}
+\item{correction}{numeric. Correction added to all counts for calculating \code{dprime}.
+Default: \code{correction = .25}.}
 
 \item{cost.outcomes}{list. A list of length 4 with names 'hi', 'fa', 'mi', and 'cr' specifying
 the costs of a hit, false alarm, miss, and correct rejection, respectively.


### PR DESCRIPTION
This PR mostly enables optimizing for `dprime` (as `goal.threshold`, `goal.chase`, and `goal`).  Changes include: 

- computing `dprime` values in `add_stats()` helper (with `correction`)
- include `dprime` values in cue level statistics (in `x$cues$thresholds` and `x$cues$stats`)
- minor cleanups in `fftrees_cuerank()`, `fftrees_threshold_factor_grid()` and `fftrees_threshold_numeric_grid()` 

This mostly resolves Issue #93, but the new functionality is not thoroughly tested yet.  Initial tests suggest that optimizing for `dprime` can substantially lower other accuracy measures. 