### PR TITLE
Enable a user-defined goal measure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.8.0.9007
-Date: 2023-01-19
+Version: 1.8.0.9008
+Date: 2023-01-20
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.8
 
-## 1.8.0.9007
+## 1.8.0.9008
 
 This is the current development version of **FFTrees**, available at <https://github.com/ndphillips/FFTrees>. 
 
@@ -16,8 +16,9 @@ Changes since last release:
 
 ### Major changes 
 
+- Added support for user-defined `my.goal` (as DV, as defined by `my.goal.fun`). 
 - Added support for optimizing `dprime` values of cues and trees (by using `"dprime"` as `goal.threshold`, `goal.chase`, or `goal` values). 
-- Added hypothetical outcome and cue costs to `asif_results` (in `fftrees_grow_fan()`). 
+- Added decision outcome and cue costs to `asif_results` (in `fftrees_grow_fan()`). 
 
 
 <!-- Minor: --> 
@@ -401,6 +402,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2023-01-19.]
+[File `NEWS.md` last updated on 2023-01-20.]
 
 <!-- eof. -->

--- a/R/FFTrees.R
+++ b/R/FFTrees.R
@@ -39,7 +39,7 @@
 #' @param goal.chase A character string indicating the statistic to maximize when \emph{constructing trees}:
 #' \code{"acc"} = overall accuracy, \code{"bacc"} = balanced accuracy, \code{"wacc"} = weighted accuracy,
 #' \code{"dprime"} = discriminability, \code{"cost"} = costs (based on \code{cost.outcomes} and \code{cost.cues}).
-#' @param goal.threshold A character string indicating the statistic to maximize when \emph{optimizing cue thresholds}:
+#' @param goal.threshold A character string indicating the criterion to maximize when \emph{optimizing cue thresholds}:
 #' \code{"acc"} = overall accuracy, \code{"bacc"} = balanced accuracy, \code{"wacc"} = weighted accuracy,
 #' \code{"dprime"} = discriminability, \code{"cost"} = costs (based only on \code{cost.outcomes}, as \code{cost.cues} are constant per cue).
 #' Default: \code{goal.threshold = "bacc"}.

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -108,6 +108,43 @@ fftrees_apply <- function(x,
   level_stats_ls <- vector("list", length = n_trees)
 
 
+  # 3. Define the set of critical stats (as vector): ----
+
+  if (!is.null(x$params$my.goal)){ # include my.goal:
+
+    critical_stats_v <- c(
+      # freq:
+      "n",  "hi", "fa", "mi", "cr",
+      # cond prob:
+      "sens", "spec",  "far",  "ppv", "npv",
+      # from prob:
+      "dprime",
+      # accuracy:
+      "acc", "bacc", "wacc",
+      # my.goal:
+      x$params$my.goal,       # include my.goal (name and value)
+      # costs:
+      "cost_dec"  # Note: "cost_cue" and "cost" are added below.
+    )
+
+  } else { # set critical stats default:
+
+    critical_stats_v <- c(
+      # freq:
+      "n",  "hi", "fa", "mi", "cr",
+      # cond prob:
+      "sens", "spec",  "far",  "ppv", "npv",
+      # from prob:
+      "dprime",
+      # accuracy:
+      "acc", "bacc", "wacc",
+      # my.goal:                    (NO my.goal here)
+      # costs:
+      "cost_dec"  # Note: "cost_cue" and "cost" are added below.
+    )
+
+  }
+
   # LOOPs: ------
 
   #  Loop 1 (over trees): ----
@@ -167,43 +204,6 @@ fftrees_apply <- function(x,
       exit = exit_v,
       stringsAsFactors = FALSE
     )
-
-    # Define the set of critical stats (as vector): ----
-
-    if (!is.null(x$params$my.goal)){ # include my.goal:
-
-      critical_stats_v <- c(
-        # freq:
-        "n",  "hi", "fa", "mi", "cr",
-        # cond prob:
-        "sens", "spec",  "far",  "ppv", "npv",
-        # from prob:
-        "dprime",
-        # accuracy:
-        "acc", "bacc", "wacc",
-        # my.goal:
-        x$params$my.goal,       # include my.goal (name and value)
-        # costs:
-        "cost_dec"  # Note: "cost_cue" and "cost" are added below.
-      )
-
-    } else { # set default critical stats:
-
-      critical_stats_v <- c(
-        # freq:
-        "n",  "hi", "fa", "mi", "cr",
-        # cond prob:
-        "sens", "spec",  "far",  "ppv", "npv",
-        # from prob:
-        "dprime",
-        # accuracy:
-        "acc", "bacc", "wacc",
-        # my.goal:                    (NO my.goal here)
-        # costs:
-        "cost_dec"  # Note: "cost_cue" and "cost" are added below.
-      )
-
-    }
 
     # Add stats names to level_stats_i: ----
     level_stats_i[critical_stats_v] <- NA

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -108,7 +108,8 @@ fftrees_apply <- function(x,
   level_stats_ls <- vector("list", length = n_trees)
 
 
-  # 3. Define the set of critical stats (as vector): ----
+  # 3. Critical stats [critical_stats_v]: ----
+  #    Define the set of critical stats (as vector):
 
   if (!is.null(x$params$my.goal)){ # include my.goal:
 

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -304,6 +304,12 @@ fftrees_apply <- function(x,
         cost_v = decisions_df$cost_cue[non_na_decision_ix]  # cue cost (per decision at level)
       )
 
+      # Compute my.goal via my.goal.fun:   +++ here now +++
+      xyz <- mapply(FUN = x$params$my.goal.fun,
+                    hi = my_level_stats_i$hi, fa = my_level_stats_i$fa,
+                    mi = my_level_stats_i$mi, cr = my_level_stats_i$cr)
+      print(paste0(x$params$my.goal, " = ", round(xyz, 3)))
+
       # level_stats_i$costc <- sum(cost_cue[,tree_i], na.rm = TRUE)
       level_stats_i[level_i, critical_stats_v] <- my_level_stats_i[ , critical_stats_v]
 
@@ -313,7 +319,7 @@ fftrees_apply <- function(x,
       level_stats_i$cost_cue[level_i] <- mean(decisions_df$cost_cue[non_na_decision_ix])
       level_stats_i$cost[level_i]     <- level_stats_i$cost_cue[level_i] + level_stats_i$cost_dec[level_i]
 
-    }
+    } # Loop 2: level_i.
 
     # Add final tree results to level_stats_ls and decisions_ls: ----
 
@@ -321,11 +327,11 @@ fftrees_apply <- function(x,
 
     decisions_ls[[tree_i]] <- decisions_df[, names(decisions_df) %in% c("current_decision", "current_cue_values") == FALSE]
 
-  }
+  } # Loop 1: tree_i.
 
   # Aggregate results: ----
 
-  # Combine all levelstats into one dataframe:
+  # Combine all level_stats into one data.frame:
   level_stats <- do.call("rbind", args = level_stats_ls)
 
   #  3. Cumulative tree stats [tree_stats]: ----

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -391,9 +391,9 @@ fftrees_create <- function(formula = NULL,
 
   # stopping.rule: ----
 
-  valid_stopping_rules <- c("exemplars", "levels")
+  stopping_rule_valid <- c("exemplars", "levels")
 
-  testthat::expect_true(stopping.rule %in% valid_stopping_rules)
+  testthat::expect_true(stopping.rule %in% stopping_rule_valid)
 
 
   # stopping.par: ----
@@ -424,21 +424,21 @@ fftrees_create <- function(formula = NULL,
   testthat::expect_true(is.function(my.goal.fun),  info = "Provided 'my.goal.fun' is not of type 'function'")
 
   # my.goal.fun must only use 4 freq arguments:
-  valid_args <- c("hi", "fa", "mi", "cr")
+  my_goal_arg_valid <- c("hi", "fa", "mi", "cr")
   fn_arg_names <- names(formals(my.goal.fun))
   # print(fn_arg_names)  # 4debugging
 
-  if (any(fn_arg_names %in% valid_args == FALSE)){
+  if (any(fn_arg_names %in% my_goal_arg_valid == FALSE)){
 
-    invalid_args <- setdiff(fn_arg_names, valid_args)
+    invalid_args <- setdiff(fn_arg_names, my_goal_arg_valid)
     invalid_avec <- paste(invalid_args, collapse = ", ")
 
     stop("my.goal.fun must contain 4 arguments (hi, fa, mi, cr), but not ", invalid_avec)
   }
 
-  if (any(valid_args %in% fn_arg_names == FALSE)){
+  if (any(my_goal_arg_valid %in% fn_arg_names == FALSE)){
 
-    missing_args <- setdiff(valid_args, fn_arg_names)
+    missing_args <- setdiff(my_goal_arg_valid, fn_arg_names)
     missing_avec <- paste(missing_args, collapse = ", ")
     if (length(missing_args) < 2) {be <- "is"} else { be <- "are"}
 

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -140,7 +140,7 @@ fftrees_create <- function(formula = NULL,
   # goal: ----
 
   # Define a (constant) set of valid goals (for FFT selection via 'goal'):
-  valid_goals <- c("acc", "bacc", "wacc", "dprime", "cost")
+  goal_valid <- c("acc", "bacc", "wacc", "dprime", "cost")
 
   if (is.null(goal)) { # goal NOT set by user:
 
@@ -176,7 +176,7 @@ fftrees_create <- function(formula = NULL,
 
   # Verify goal:
   testthat::expect_true(!is.null(goal), info = "goal is NULL")
-  testthat::expect_true(goal %in% valid_goals)
+  testthat::expect_true(goal %in% goal_valid)
 
   if ((goal == "wacc") & (!enable_wacc(sens.w))){ # correct to "bacc":
 
@@ -222,7 +222,7 @@ fftrees_create <- function(formula = NULL,
   # Verify goal.chase:
 
   testthat::expect_true(!is.null(goal.chase), info = "goal.chase is NULL")
-  testthat::expect_true(goal.chase %in% valid_goals)
+  testthat::expect_true(goal.chase %in% goal_valid)
 
   if ((goal.chase == "wacc") & (!enable_wacc(sens.w))){ # correct to "bacc":
 
@@ -259,7 +259,7 @@ fftrees_create <- function(formula = NULL,
   # Verify goal.threshold:
 
   testthat::expect_true(!is.null(goal.threshold), info = "goal.threshold is NULL")
-  testthat::expect_true(goal.threshold %in% valid_goals)
+  testthat::expect_true(goal.threshold %in% goal_valid)
 
   if ((goal.threshold == "wacc") & (!enable_wacc(sens.w))){ # correct to "bacc":
 

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -320,7 +320,7 @@ fftrees_create <- function(formula = NULL,
 
     if (!quiet) {
       msg <- paste0("You set sens.w = ", sens.w, ": Did you mean to set 'goal' or 'goal.chase' to 'wacc'?\n")
-      cat(u_f_msg(msg))
+      cat(u_f_hig(msg))
     }
 
   }

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -32,10 +32,13 @@
 #' @param decision.labels string.
 #'
 #' @param my.goal The name of the optimization measure defined by \code{my.goal.fun} (as a character string).
-#' Default: \code{my.goal = "my_acc"}.
-#' @param my.goal.fun The definition of an outcome measure to optimize, defined in terms of the frequency counts of 4 basic classification outcomes \code{hi, fa, mi, cr}
-#' (as an R function of the arguments \code{hi, fa, mi, cr}).
-#' Default: \code{my.goal.fun = function(hi, fa, mi, cr){(hi + cr)/(hi + fa + mi + cr)}} (i.e., accuracy).
+#' Example: \code{my.goal = "my_acc"} (see \code{my.goal.fun} for corresponding function).
+#' Default: \code{my.goal = NULL}.
+#' @param my.goal.fun The definition of an outcome measure to optimize, defined in terms of the
+#' frequency counts of 4 basic classification outcomes \code{hi, fa, mi, cr}
+#' (i.e., an R function with 4 arguments \code{hi, fa, mi, cr}).
+#' Example: \code{my.goal.fun = function(hi, fa, mi, cr){(hi + cr)/(hi + fa + mi + cr)}} (i.e., accuracy).
+#' Default: \code{my.goal.fun = NULL}.
 #' @param my.tree A verbal description of an FFT, i.e., an "FFT in words" (as character string).
 #' For example, \code{my.tree = "If age > 20, predict TRUE. If sex = {m}, predict FALSE. Otherwise, predict TRUE."}.
 #'
@@ -86,7 +89,7 @@ fftrees_create <- function(formula = NULL,
                            main = NULL,
                            decision.labels = NULL,
                            #
-                           my.goal = "my_acc",  # name of my.goal
+                           my.goal = "my_acc",  # name of my.goal (as character)
                            my.goal.fun = function(hi, fa, mi, cr){(hi + cr)/(hi + fa + mi + cr)},  # a function of (hi, fa, mi, cr)
                            my.tree = NULL,
                            #
@@ -277,6 +280,39 @@ fftrees_create <- function(formula = NULL,
   }
 
 
+  # my.goal and my.goal.fun: ----
+
+  if (!is.null(my.goal)){
+
+    testthat::expect_true(is.character(my.goal), info = "Provided 'my.goal' is not of type 'character'")
+    testthat::expect_true(length(my.goal) == 1,  info = "Provided 'my.goal' is not of length 1")
+    testthat::expect_true(is.function(my.goal.fun),  info = "Provided 'my.goal.fun' is not of type 'function'")
+
+    # my.goal.fun must only use 4 freq arguments:
+    my_goal_arg_valid <- c("hi", "fa", "mi", "cr")
+    fn_arg_names <- names(formals(my.goal.fun))
+    # print(fn_arg_names)  # 4debugging
+
+    if (any(fn_arg_names %in% my_goal_arg_valid == FALSE)){
+
+      invalid_args <- setdiff(fn_arg_names, my_goal_arg_valid)
+      invalid_avec <- paste(invalid_args, collapse = ", ")
+
+      stop("my.goal.fun must contain 4 arguments (hi, fa, mi, cr), but not ", invalid_avec)
+    }
+
+    if (any(my_goal_arg_valid %in% fn_arg_names == FALSE)){
+
+      missing_args <- setdiff(my_goal_arg_valid, fn_arg_names)
+      missing_avec <- paste(missing_args, collapse = ", ")
+      if (length(missing_args) < 2) {be <- "is"} else { be <- "are"}
+
+      message("my.goal.fun usually contains 4 arguments (hi, fa, mi, cr), but (", missing_avec, ") ", be, " missing")
+    }
+
+  } # if (my.goal).
+
+
   # Verify consistency of sens.w and bacc_wacc choices: ----
 
   # If a non-default sens.w has been set, but 'wacc' is neither used in 'goal' nor in 'goal.chase':
@@ -411,40 +447,6 @@ fftrees_create <- function(formula = NULL,
   # repeat.cues: ----
 
   testthat::expect_type(repeat.cues, type = "logical")
-
-
-  # my.goal: ----
-
-  testthat::expect_true(is.character(my.goal), info = "Provided 'my.goal' is not of type 'character'")
-  testthat::expect_true(length(my.goal) == 1,  info = "Provided 'my.goal' is not of length 1")
-
-
-  # my.goal.fun: ----
-
-  testthat::expect_true(is.function(my.goal.fun),  info = "Provided 'my.goal.fun' is not of type 'function'")
-
-  # my.goal.fun must only use 4 freq arguments:
-  my_goal_arg_valid <- c("hi", "fa", "mi", "cr")
-  fn_arg_names <- names(formals(my.goal.fun))
-  # print(fn_arg_names)  # 4debugging
-
-  if (any(fn_arg_names %in% my_goal_arg_valid == FALSE)){
-
-    invalid_args <- setdiff(fn_arg_names, my_goal_arg_valid)
-    invalid_avec <- paste(invalid_args, collapse = ", ")
-
-    stop("my.goal.fun must contain 4 arguments (hi, fa, mi, cr), but not ", invalid_avec)
-  }
-
-  if (any(my_goal_arg_valid %in% fn_arg_names == FALSE)){
-
-    missing_args <- setdiff(my_goal_arg_valid, fn_arg_names)
-    missing_avec <- paste(missing_args, collapse = ", ")
-    if (length(missing_args) < 2) {be <- "is"} else { be <- "are"}
-
-    message("my.goal.fun usually contains 4 arguments (hi, fa, mi, cr), but (", missing_avec, ") ", be, " missing")
-  }
-
 
 
   # 2. Data quality checks: ------

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -224,6 +224,9 @@ fftrees_cuerank <- function(x = NULL,
             #
             sens.w = sens.w,
             #
+            my.goal = x$params$my.goal,
+            my.goal.fun = x$params$my.goal.fun,
+            #
             cost.each = cue_i_cost,
             cost.outcomes = cost.outcomes
           )
@@ -241,6 +244,9 @@ fftrees_cuerank <- function(x = NULL,
             directions = directions,
             #
             goal.threshold = goal.threshold,
+            #
+            my.goal = x$params$my.goal,
+            my.goal.fun = x$params$my.goal.fun,
             #
             sens.w = sens.w,
             #
@@ -298,6 +304,9 @@ fftrees_cuerank <- function(x = NULL,
           goal.threshold = goal.threshold,
           #
           sens.w = sens.w,
+          #
+          my.goal = x$params$my.goal,
+          my.goal.fun = x$params$my.goal.fun,
           #
           # Note: NO cost.each.
           cost.outcomes = cost.outcomes

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -213,15 +213,19 @@ fftrees_cuerank <- function(x = NULL,
         # a. Numeric/integer cue: ----
         if (substr(cue_i_class, 1, 1) %in% c("n", "i")) {
 
+          # Compute stats for numeric cue:
           cue_i_stats <- fftrees_threshold_numeric_grid(
             thresholds = cue_i_levels,
             cue_v = cue_i_v,
             criterion_v = criterion_v,
-            sens.w = sens.w,
             directions = directions,
+            #
+            goal.threshold = goal.threshold,
+            #
+            sens.w = sens.w,
+            #
             cost.each = cue_i_cost,
-            cost.outcomes = cost.outcomes,
-            goal.threshold = goal.threshold
+            cost.outcomes = cost.outcomes
           )
 
         } # if a. numeric/integer cue.
@@ -229,15 +233,19 @@ fftrees_cuerank <- function(x = NULL,
         # b. Factor, character, or logical cue: ----
         if (substr(cue_i_class, 1, 1) %in% c("f", "c", "l")) {
 
+          # Compute stats for factor cue:
           cue_i_stats <- fftrees_threshold_factor_grid(
             thresholds = cue_i_levels,
             cue_v = cue_i_v,
             criterion_v = criterion_v,
             directions = directions,
+            #
+            goal.threshold = goal.threshold,
+            #
             sens.w = sens.w,
+            #
             cost.each = cue_i_cost,
-            cost.outcomes = cost.outcomes,
-            goal.threshold = goal.threshold
+            cost.outcomes = cost.outcomes
           )
 
         } # if b. factor/character/logical cue.
@@ -277,16 +285,22 @@ fftrees_cuerank <- function(x = NULL,
 
     } else { # (B) All cue values are NA:
 
-      # Step 3: Set best cue direction and threshold to NULL [cue_i_best]: ----
+      # Step 3: Set cue direction and threshold of BEST cue to NULL [cue_i_best]: ----
       {
 
+        # Compute stats for best factor cue:
         cue_i_best <- fftrees_threshold_factor_grid(
           thresholds = NULL,
           cue_v = NULL,
           criterion_v = NULL,
+          # NOTE: NO directions = directions.
+          #
+          goal.threshold = goal.threshold,
+          #
           sens.w = sens.w,
-          cost.outcomes = cost.outcomes,
-          goal.threshold = goal.threshold
+          #
+          # Note: NO cost.each.
+          cost.outcomes = cost.outcomes
         )
 
       } # Step 3.

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -283,7 +283,10 @@ fftrees_grow_fan <- function(x,
           sens.w = x$params$sens.w,
           #
           cost.outcomes = x$params$cost.outcomes,  # add outcome cost
-          cost_v = asif_cuecost_v                  # add cue cost
+          cost_v = asif_cuecost_v,                 # add cue cost
+          #
+          my.goal = x$params$my.goal,
+          my.goal.fun = x$params$my.goal.fun
         )
         # Note: The 2 cost arguments cost.outcomes and cost_v were NOT being used to compute asif_results.
         # DONE: ADDED asif_cuecost_v to call to classtable() here (on 2023-01-19, +++ here now +++)
@@ -400,7 +403,10 @@ fftrees_grow_fan <- function(x,
           sens.w = x$params$sens.w,
           #
           cost.outcomes = x$params$cost.outcomes,
-          cost_v = cuecost_v[case_remaining_ix == FALSE]
+          cost_v = cuecost_v[case_remaining_ix == FALSE],
+          #
+          my.goal = x$params$my.goal,
+          my.goal.fun = x$params$my.goal.fun
         )
 
         # Update level stats:
@@ -505,7 +511,10 @@ fftrees_grow_fan <- function(x,
           sens.w = x$params$sens.w,
           #
           cost.outcomes = x$params$cost.outcomes,
-          cost_v = cuecost_v
+          cost_v = cuecost_v,
+          #
+          my.goal = x$params$my.goal,
+          my.goal.fun = x$params$my.goal.fun
         )
 
         level_stats_i$exit[last_level_nr] <- .5

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -329,10 +329,10 @@ fftrees_grow_fan <- function(x,
 
         } else { # note an unknown/invalid goal.chase value:
 
-          valid_goals <- c("acc", "bacc", "wacc", "dprime", "cost")  # See fftrees_create()!
-          valid_goals_str <- paste(valid_goals, collapse = ", ")
+          goal_valid <- c("acc", "bacc", "wacc", "dprime", "cost")  # See fftrees_create()!
+          goal_valid_str <- paste(goal_valid, collapse = ", ")
 
-          stop(paste0("The current goal.chase value '", x$params$goal.chase, "' is not in '", valid_goals_str, "'"))
+          stop(paste0("The current goal.chase value '", x$params$goal.chase, "' is not in '", goal_valid_str, "'"))
 
         } # If stop?
 

--- a/R/fftrees_threshold_factor_grid.R
+++ b/R/fftrees_threshold_factor_grid.R
@@ -13,11 +13,11 @@
 #' @param sens.w numeric. Sensitivity weight parameter (from 0 to 1, for computing \code{wacc}).
 #' Default: \code{sens.w = .50}.
 #'
+#' @param cost.each numeric. Cost to add to each value (e.g.; cost of the cue).
 #' @param cost.outcomes list. A list of length 4 with names 'hi', 'fa', 'mi', and 'cr' specifying
 #' the costs of a hit, false alarm, miss, and correct rejection, respectively.
 #' For instance, \code{cost.outcomes = listc("hi" = 0, "fa" = 10, "mi" = 20, "cr" = 0)} means that
 #' a false alarm and miss cost 10 and 20, respectively, while correct decisions have no cost.
-#' @param cost.each numeric. Cost to add to each value (e.g.; cost of the cue).
 #'
 #' @import testthat
 #' @importFrom  magrittr "%>%"
@@ -37,8 +37,8 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
                                           #
                                           sens.w = .50,  # ToDo: set to NULL (to enforce that value is passed from calling function)?
                                           #
-                                          cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0),
-                                          cost.each = 0
+                                          cost.each = 0,
+                                          cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0)
 ) {
 
   # Assertions:

--- a/R/fftrees_threshold_factor_grid.R
+++ b/R/fftrees_threshold_factor_grid.R
@@ -13,6 +13,9 @@
 #' @param sens.w numeric. Sensitivity weight parameter (from 0 to 1, for computing \code{wacc}).
 #' Default: \code{sens.w = .50}.
 #'
+#' @param my.goal Name of an optional, user-defined goal (as character string). Default: \code{my.goal = NULL}.
+#' @param my.goal.fun User-defined goal function (with 4 arguments \code{hi fa mi cr}). Default: \code{my.goal.fun = NULL}.
+#'
 #' @param cost.each numeric. Cost to add to each value (e.g.; cost of the cue).
 #' @param cost.outcomes list. A list of length 4 with names 'hi', 'fa', 'mi', and 'cr' specifying
 #' the costs of a hit, false alarm, miss, and correct rejection, respectively.
@@ -36,6 +39,9 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
                                           goal.threshold = "bacc",
                                           #
                                           sens.w = .50,  # ToDo: set to NULL (to enforce that value is passed from calling function)?
+                                          #
+                                          my.goal = NULL,
+                                          my.goal.fun = NULL,
                                           #
                                           cost.each = 0,
                                           cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0)
@@ -86,6 +92,9 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
     new_stats <- add_stats(data = results,
                            #
                            sens.w = sens.w,
+                           #
+                           my.goal     = my.goal,         # (just passing to helper)
+                           my.goal.fun = my.goal.fun,
                            #
                            # cost.each = cost.each,       # ToDo: WHY not used here?
                            cost.outcomes = cost.outcomes
@@ -149,6 +158,9 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
                            #
                            sens.w = sens.w,
                            #
+                           my.goal     = my.goal,         # (just passing to helper)
+                           my.goal.fun = my.goal.fun,
+                           #
                            cost.each = cost.each,
                            cost.outcomes = cost.outcomes
     )
@@ -159,18 +171,33 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
 
     # Clean up results: ----
 
-
     # Arrange rows by goal.threshold and change column order:
     row_order <- order(results[, goal.threshold], decreasing = TRUE)
 
-    col_order <- c("threshold", "direction",
-                   "n", "hi", "fa", "mi", "cr",
-                   "sens", "spec", "ppv", "npv",
-                   "acc", "bacc", "wacc",
-                   "dprime",
-                   "cost_dec", "cost")
+    # Define the set of reported stats [rep_stats_v]: ----
+    if (!is.null(my.goal)){ # include my.goal (name and value):
 
-    results <- results[row_order, col_order]
+      rep_stats_v <- c("threshold", "direction",
+                       "n",  "hi", "fa", "mi", "cr",
+                       "sens", "spec",  "ppv", "npv",
+                       "acc", "bacc", "wacc",
+                       my.goal,  # (+)
+                       "dprime",
+                       "cost_dec", "cost")
+
+    } else { # default set of reported stats:
+
+      rep_stats_v <- c("threshold", "direction",
+                       "n",  "hi", "fa", "mi", "cr",
+                       "sens", "spec",  "ppv", "npv",
+                       "acc", "bacc", "wacc",
+                       "dprime",
+                       "cost_dec", "cost")
+
+    } # if my.goal().
+
+    # Arrange rows and select columns:
+    results <- results[row_order, rep_stats_v]
 
     # Re-set rownames:
     # rownames(results) <- 1:nrow(results)  # NOT needed and potentially confusing (when comparing results).
@@ -181,30 +208,26 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
 
   } else { # no thresholds exist: ----
 
-    results <- data.frame(
-      "threshold" = NA,
-      "direction" = NA,
-      #
-      "n" = NA,
-      "hi" = NA,
-      "fa" = NA,
-      "mi" = NA,
-      "cr" = NA,
-      #
-      "sens" = NA,
-      "spec" = NA,
-      "ppv"  = NA,
-      "npv"  = NA,
-      #
-      "acc"  = NA,
-      "bacc" = NA,
-      "wacc" = NA,
-      #
-      "dprime" = NA,
-      #
-      "cost_dec" = NA,
-      "cost" = NA
-    )
+    if (!is.null(my.goal)){ # include my.goal (name and value):
+
+      results <- data.frame("threshold" = NA, "direction" = NA,
+                            "n" = NA,  "hi" = NA, "fa" = NA, "mi" = NA, "cr" = NA,
+                            "sens" = NA, "spec" = NA,  "ppv"  = NA, "npv"  = NA,
+                            "acc"  = NA, "bacc" = NA, "wacc" = NA,
+                            my.goal = NA,  # (+)
+                            "dprime" = NA,
+                            "cost_dec" = NA, "cost" = NA)
+
+    } else { # default set of reported stats:
+
+      results <- data.frame("threshold" = NA, "direction" = NA,
+                            "n" = NA,  "hi" = NA, "fa" = NA, "mi" = NA, "cr" = NA,
+                            "sens" = NA, "spec" = NA,  "ppv"  = NA, "npv"  = NA,
+                            "acc"  = NA, "bacc" = NA, "wacc" = NA,
+                            "dprime" = NA,
+                            "cost_dec" = NA, "cost" = NA)
+
+    } # if my.goal().
 
   } # if (!is.null(thresholds)).
 

--- a/R/fftrees_threshold_factor_grid.R
+++ b/R/fftrees_threshold_factor_grid.R
@@ -4,14 +4,20 @@
 #' @param cue_v numeric. Feature/cue values.
 #' @param criterion_v logical. A logical vector of (TRUE) criterion values.
 #' @param directions character. Character vector of threshold directions to consider.
+#'
+#' @param goal.threshold A character string indicating the criterion to maximize when \emph{optimizing cue thresholds}:
+#' \code{"acc"} = overall accuracy, \code{"bacc"} = balanced accuracy, \code{"wacc"} = weighted accuracy,
+#' \code{"dprime"} = discriminability, \code{"cost"} = costs (based only on \code{cost.outcomes}, as \code{cost.cues} are constant per cue).
+#' Default: \code{goal.threshold = "bacc"}.
+#'
 #' @param sens.w numeric. Sensitivity weight parameter (from 0 to 1, for computing \code{wacc}).
 #' Default: \code{sens.w = .50}.
+#'
 #' @param cost.outcomes list. A list of length 4 with names 'hi', 'fa', 'mi', and 'cr' specifying
 #' the costs of a hit, false alarm, miss, and correct rejection, respectively.
 #' For instance, \code{cost.outcomes = listc("hi" = 0, "fa" = 10, "mi" = 20, "cr" = 0)} means that
 #' a false alarm and miss cost 10 and 20, respectively, while correct decisions have no cost.
-#' @param cost.each numeric.
-#' @param goal.threshold character.
+#' @param cost.each numeric. Cost to add to each value (e.g.; cost of the cue).
 #'
 #' @import testthat
 #' @importFrom  magrittr "%>%"
@@ -26,10 +32,14 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
                                           cue_v = NULL,
                                           criterion_v = NULL,
                                           directions = "=",
-                                          sens.w = .50,
+                                          #
+                                          goal.threshold = "bacc",
+                                          #
+                                          sens.w = .50,  # ToDo: set to NULL (to enforce that value is passed from calling function)?
+                                          #
                                           cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0),
-                                          cost.each = 0,
-                                          goal.threshold = "bacc") {
+                                          cost.each = 0
+) {
 
   # Assertions:
   testthat::expect_true(!any(is.na(criterion_v)))

--- a/R/fftrees_threshold_factor_grid.R
+++ b/R/fftrees_threshold_factor_grid.R
@@ -72,11 +72,17 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
     # Add thresholds and directions:
     results$threshold <- thresholds
 
-    # Add accuracy statistics:
-    results <- cbind(results, add_stats(results,
-                                        sens.w = sens.w,
-                                        cost.outcomes = cost.outcomes
-    ))
+    # Add statistics to results: ----
+    new_stats <- add_stats(data = results,
+                           #
+                           sens.w = sens.w,
+                           #
+                           # cost.each = cost.each,       # ToDo: WHY not used here?
+                           cost.outcomes = cost.outcomes
+    )
+
+    # Add new statistics (to previous results): ----
+    results <- cbind(results, new_stats)
 
     # Order by goal.threshold and change column order:
     row_order <- order(results[ , goal.threshold], decreasing = TRUE)
@@ -128,15 +134,16 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
 
     results <- results_cum
 
-    # Compute accuracy statistics: ----
-    new_stats <- add_stats(
-      data = results,
-      sens.w = sens.w,
-      cost.outcomes = cost.outcomes,
-      cost.each = cost.each
+    # Add statistics to results: ----
+    new_stats <- add_stats(data = results,
+                           #
+                           sens.w = sens.w,
+                           #
+                           cost.each = cost.each,
+                           cost.outcomes = cost.outcomes
     )
 
-    # Add accuracy statistics (to previous results): ----
+    # Add new statistics (to previous results): ----
     results <- cbind(results, new_stats)
 
 

--- a/R/fftrees_threshold_numeric_grid.R
+++ b/R/fftrees_threshold_numeric_grid.R
@@ -59,16 +59,16 @@ fftrees_threshold_numeric_grid <- function(thresholds,
   # Convert to named dataframe: ----
 
   results_gt <- as.data.frame(results_gt)
-  names(results_gt) <- c("n", "hi", "fa", "mi", "cr")
+  names(results_gt) <- c("n",  "hi", "fa", "mi", "cr")
   results_gt$direction <- ">"
   results_gt$threshold <- thresholds
 
 
   # Get results if using <= threshold: ----
 
-  results_lt <- results_gt[, c(1, 4, 5, 2, 3)]
-  names(results_lt) <- c("n", "hi", "fa", "mi", "cr")
-  results_lt        <- results_lt[, c("n", "hi", "fa", "mi", "cr")]
+  results_lt <- results_gt[ , c(1,  4, 5, 2, 3)]
+  names(results_lt) <- c("n",  "hi", "fa", "mi", "cr")
+  results_lt        <- results_lt[ , c("n",  "hi", "fa", "mi", "cr")]
 
   results_lt$direction <- "<="
   results_lt$threshold <- thresholds
@@ -86,13 +86,16 @@ fftrees_threshold_numeric_grid <- function(thresholds,
   }
 
 
-  new_stats <- add_stats(results,
+  # Add statistics to results: ----
+  new_stats <- add_stats(data = results,
+                         #
                          sens.w = sens.w,
-                         cost.outcomes = cost.outcomes,
-                         cost.each = cost.each
+                         #
+                         cost.each = cost.each,
+                         cost.outcomes = cost.outcomes
   )
 
-  # Add accuracy statistics (to previous results): ----
+  # Add new accuracy statistics (to previous results): ----
   results <- cbind(results, new_stats)
 
 
@@ -103,8 +106,8 @@ fftrees_threshold_numeric_grid <- function(thresholds,
   row_order <- order(results[ , goal.threshold], decreasing = TRUE)
 
   col_order <- c("threshold", "direction",
-                 "n", "hi", "fa", "mi", "cr",
-                 "sens", "spec", "ppv", "npv",
+                 "n",  "hi", "fa", "mi", "cr",
+                 "sens", "spec",  "ppv", "npv",
                  "acc", "bacc", "wacc",
                  "dprime",
                  "cost_dec", "cost")

--- a/R/fftrees_threshold_numeric_grid.R
+++ b/R/fftrees_threshold_numeric_grid.R
@@ -4,14 +4,20 @@
 #' @param cue_v numeric. Feature values.
 #' @param criterion_v logical. A logical vector of (TRUE) criterion values.
 #' @param directions character. Possible directions to consider.
+#'
+#' @param goal.threshold A character string indicating the criterion to maximize when \emph{optimizing cue thresholds}:
+#' \code{"acc"} = overall accuracy, \code{"bacc"} = balanced accuracy, \code{"wacc"} = weighted accuracy,
+#' \code{"dprime"} = discriminability, \code{"cost"} = costs (based only on \code{cost.outcomes}, as \code{cost.cues} are constant per cue).
+#' Default: \code{goal.threshold = "bacc"}.
+#'
 #' @param sens.w numeric. Sensitivity weight parameter (from 0 to 1, for computing \code{wacc}).
 #' Default: \code{sens.w = .50}.
-#' @param cost.each numeric. Cost to add to each value (e.g.; cost of  the cue).
+#'
 #' @param cost.outcomes list. A list of length 4 with names 'hi', 'fa', 'mi', and 'cr' specifying
 #' the costs of a hit, false alarm, miss, and correct rejection, respectively.
 #' For instance, \code{cost.outcomes = listc("hi" = 0, "fa" = 10, "mi" = 20, "cr" = 0)} means that
 #' a false alarm and miss cost 10 and 20, respectively, while correct decisions have no cost.
-#' @param goal.threshold character. A string indicating the statistic to maximize when calculting cue thresholds: "acc" = overall accuracy, "wacc" = weighted accuracy, "bacc" = balanced accuracy.
+#' @param cost.each numeric. Cost to add to each value (e.g.; cost of the cue).
 #'
 #' @return A data frame containing accuracy statistics for several numeric thresholds.
 #'
@@ -23,10 +29,14 @@ fftrees_threshold_numeric_grid <- function(thresholds,
                                            cue_v,
                                            criterion_v,
                                            directions = c(">", "<="),
-                                           sens.w = .50,
-                                           cost.each = 0,
+                                           #
+                                           goal.threshold = "bacc",
+                                           #
+                                           sens.w = .50,  # ToDo: set to NULL (to enforce that value is passed from calling function)?
+                                           #
                                            cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0),
-                                           goal.threshold = "bacc") {
+                                           cost.each = 0
+) {
 
   thresholds_n <- length(thresholds)
 

--- a/R/fftrees_threshold_numeric_grid.R
+++ b/R/fftrees_threshold_numeric_grid.R
@@ -13,11 +13,11 @@
 #' @param sens.w numeric. Sensitivity weight parameter (from 0 to 1, for computing \code{wacc}).
 #' Default: \code{sens.w = .50}.
 #'
+#' @param cost.each numeric. Cost to add to each value (e.g.; cost of the cue).
 #' @param cost.outcomes list. A list of length 4 with names 'hi', 'fa', 'mi', and 'cr' specifying
 #' the costs of a hit, false alarm, miss, and correct rejection, respectively.
 #' For instance, \code{cost.outcomes = listc("hi" = 0, "fa" = 10, "mi" = 20, "cr" = 0)} means that
 #' a false alarm and miss cost 10 and 20, respectively, while correct decisions have no cost.
-#' @param cost.each numeric. Cost to add to each value (e.g.; cost of the cue).
 #'
 #' @return A data frame containing accuracy statistics for several numeric thresholds.
 #'
@@ -34,8 +34,8 @@ fftrees_threshold_numeric_grid <- function(thresholds,
                                            #
                                            sens.w = .50,  # ToDo: set to NULL (to enforce that value is passed from calling function)?
                                            #
-                                           cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0),
-                                           cost.each = 0
+                                           cost.each = 0,
+                                           cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0)
 ) {
 
   thresholds_n <- length(thresholds)

--- a/R/fftrees_threshold_numeric_grid.R
+++ b/R/fftrees_threshold_numeric_grid.R
@@ -13,6 +13,9 @@
 #' @param sens.w numeric. Sensitivity weight parameter (from 0 to 1, for computing \code{wacc}).
 #' Default: \code{sens.w = .50}.
 #'
+#' @param my.goal Name of an optional, user-defined goal (as character string). Default: \code{my.goal = NULL}.
+#' @param my.goal.fun User-defined goal function (with 4 arguments \code{hi fa mi cr}). Default: \code{my.goal.fun = NULL}.
+#'
 #' @param cost.each numeric. Cost to add to each value (e.g.; cost of the cue).
 #' @param cost.outcomes list. A list of length 4 with names 'hi', 'fa', 'mi', and 'cr' specifying
 #' the costs of a hit, false alarm, miss, and correct rejection, respectively.
@@ -33,6 +36,9 @@ fftrees_threshold_numeric_grid <- function(thresholds,
                                            goal.threshold = "bacc",
                                            #
                                            sens.w = .50,  # ToDo: set to NULL (to enforce that value is passed from calling function)?
+                                           #
+                                           my.goal = NULL,
+                                           my.goal.fun = NULL,
                                            #
                                            cost.each = 0,
                                            cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0)
@@ -101,6 +107,9 @@ fftrees_threshold_numeric_grid <- function(thresholds,
                          #
                          sens.w = sens.w,
                          #
+                         my.goal     = my.goal,         # (just passing to helper)
+                         my.goal.fun = my.goal.fun,
+                         #
                          cost.each = cost.each,
                          cost.outcomes = cost.outcomes
   )
@@ -111,18 +120,33 @@ fftrees_threshold_numeric_grid <- function(thresholds,
 
   # Clean up results: ----
 
-
   # Arrange rows by goal.threshold and change column order:
   row_order <- order(results[ , goal.threshold], decreasing = TRUE)
 
-  col_order <- c("threshold", "direction",
-                 "n",  "hi", "fa", "mi", "cr",
-                 "sens", "spec",  "ppv", "npv",
-                 "acc", "bacc", "wacc",
-                 "dprime",
-                 "cost_dec", "cost")
+  # Define the set of reported stats [rep_stats_v]: ----
+  if (!is.null(my.goal)){ # include my.goal (name and value):
 
-  results <- results[row_order, col_order]
+    rep_stats_v <- c("threshold", "direction",
+                     "n",  "hi", "fa", "mi", "cr",
+                     "sens", "spec",  "ppv", "npv",
+                     "acc", "bacc", "wacc",
+                     my.goal,  # (+)
+                     "dprime",
+                     "cost_dec", "cost")
+
+  } else { # default set of reported stats:
+
+    rep_stats_v <- c("threshold", "direction",
+                     "n",  "hi", "fa", "mi", "cr",
+                     "sens", "spec",  "ppv", "npv",
+                     "acc", "bacc", "wacc",
+                     "dprime",
+                     "cost_dec", "cost")
+
+  } # if my.goal().
+
+  # Arrange rows and select columns:
+  results <- results[row_order, rep_stats_v]
 
   # Re-set rownames:
   # rownames(results) <- 1:nrow(results)  # NOT needed and potentially confusing (when comparing results).

--- a/R/helper_stats.R
+++ b/R/helper_stats.R
@@ -32,7 +32,7 @@
 #' specifying the costs of a hit, false alarm, miss, and correct rejection, respectively.
 #' E.g.; \code{cost.outcomes = listc("hi" = 0, "fa" = 10, "mi" = 20, "cr" = 0)} means that a
 #' false alarm and miss cost 10 and 20 units, respectively, while correct decisions incur no costs.
-
+#'
 #'
 #' @return A data frame with variables of computed accuracy and cost measures (but dropping inputs).
 

--- a/R/helper_stats.R
+++ b/R/helper_stats.R
@@ -45,31 +45,37 @@ add_stats <- function(data, # df with frequency counts of 'hi fa mi cr' classifi
     cost.each <- 0
   }
 
+  # Get the 4 key freq counts (from data):
+
+  hi <- data$hi
+  fa <- data$fa
+  mi <- data$mi
+  cr <- data$cr
+
 
   # Compute measures: ----
 
-  N <- with(data, (hi + cr + fa + mi))
+  N <- hi + cr + fa + mi
 
   # Sensitivity:
-  data$sens <- with(data, hi / (hi + mi))
+  data$sens <- hi / (hi + mi)
 
   # Specificity:
-  data$spec <- with(data, cr / (cr + fa))
-
+  data$spec <- cr / (cr + fa)
 
   # False alarm rate:
-  data$far <- with(data, 1 - spec)
+  data$far <- 1 - data$spec
 
 
   # Positive predictive value (PPV):
-  data$ppv <- with(data, hi / (hi + fa))
+  data$ppv <- hi / (hi + fa)
 
   # Negative predictive value (NPV):
-  data$npv <- with(data, cr / (cr + mi))
+  data$npv <- cr / (cr + mi)
 
 
   # Accuracy:
-  data$acc <- with(data, (hi + cr) / N)
+  data$acc <- (hi + cr) / N
 
   # Balanced accuracy:
   data$bacc <- with(data, (sens + spec) / 2)  # = (sens * .50) + (spec * .50)
@@ -81,10 +87,10 @@ add_stats <- function(data, # df with frequency counts of 'hi fa mi cr' classifi
   # dprime:
 
   # a. Corrected freq values:
-  hi_c <- with(data, (hi)) + correction
-  mi_c <- with(data, (mi)) + correction
-  fa_c <- with(data, (fa)) + correction
-  cr_c <- with(data, (cr)) + correction
+  hi_c <- hi + correction
+  fa_c <- fa + correction
+  mi_c <- mi + correction
+  cr_c <- cr + correction
 
   # b. dprime (corrected):
   data$dprime <- qnorm(hi_c / (hi_c + mi_c)) - qnorm(fa_c / (fa_c + cr_c))
@@ -93,8 +99,8 @@ add_stats <- function(data, # df with frequency counts of 'hi fa mi cr' classifi
   # Cost:
 
   # Outcome cost (using NEGATIVE costs, to allow maximizing value to minimize cost):
-  data$cost_dec <- with(data, -1 * ((hi * cost.outcomes$hi) + (fa * cost.outcomes$fa)
-                                    + (mi * cost.outcomes$mi) + (cr * cost.outcomes$cr))) / data$n  # Why data$n, not N?
+  data$cost_dec <- -1 * ((hi * cost.outcomes$hi) + (fa * cost.outcomes$fa)
+                         + (mi * cost.outcomes$mi) + (cr * cost.outcomes$cr)) / data$n  # Why data$n, not N?
 
   # Total cost:
   data$cost <- data$cost_dec - cost.each  # Note: cost.each is a constant and deducted (i.e., negative cost).
@@ -102,12 +108,14 @@ add_stats <- function(data, # df with frequency counts of 'hi fa mi cr' classifi
 
   # Output: ----
 
-  # Drop inputs and order columns (of df):
-  data <- data[, c("sens", "spec",
+  add_stats_v <- c("sens", "spec",
                    "far",  "ppv", "npv",
                    "acc", "bacc", "wacc",
                    "dprime",
-                   "cost_dec", "cost")]
+                   "cost_dec", "cost")
+
+  # Drop inputs and re-arrange columns (of df):
+  data <- data[, add_stats_v]
 
   return(data)
 

--- a/R/helper_stats.R
+++ b/R/helper_stats.R
@@ -21,22 +21,28 @@
 #' allows computing cost information for the counts of corresponding classification decisions.
 #'
 #' @param data A data frame with 4 frequency counts (as integer values, named \code{"hi"}, \code{"fa"}, \code{"mi"}, and \code{"cr"}).
-#' @param sens.w numeric. Sensitivity weight (for computing weighted accuracy, \code{wacc}). Default: \code{sens.w = .50}.
+#'
+#' @param correction numeric. Correction added to all counts for calculating \code{dprime}.
+#' Default: \code{correction = .25}.
+#' @param sens.w numeric. Sensitivity weight (for computing weighted accuracy, \code{wacc}).
+#' Default: \code{sens.w = .50}.
+#'
 #' @param cost.each numeric. An optional fixed cost added to all outputs (e.g., the cost of using the cue).
 #' @param cost.outcomes list. A list of length 4 named \code{"hi"}, \code{"fa"}, \code{"mi"}, \code{"cr"}, and
 #' specifying the costs of a hit, false alarm, miss, and correct rejection, respectively.
 #' E.g.; \code{cost.outcomes = listc("hi" = 0, "fa" = 10, "mi" = 20, "cr" = 0)} means that a
 #' false alarm and miss cost 10 and 20 units, respectively, while correct decisions incur no costs.
-#' @param correction numeric. Correction added to all counts for calculating \code{dprime}.
-#' Default: \code{correction = .25}.
+
 #'
 #' @return A data frame with variables of computed accuracy and cost measures (but dropping inputs).
 
 add_stats <- function(data, # df with frequency counts of 'hi fa mi cr' classification outcomes (as integers)
-                      sens.w = .50,
+                      #
+                      correction = .25,  # used to compute dprime
+                      sens.w = .50,      # used to compute wacc
+                      #
                       cost.each = NULL,
-                      cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0),
-                      correction = .25 # used for dprime calculation
+                      cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0)
 ) {
 
   # Prepare: ----

--- a/R/helper_stats.R
+++ b/R/helper_stats.R
@@ -25,7 +25,7 @@
 #' @param correction numeric. Correction added to all counts for calculating \code{dprime}.
 #' Default: \code{correction = .25}.
 #' @param sens.w numeric. Sensitivity weight (for computing weighted accuracy, \code{wacc}).
-#' Default: \code{sens.w = .50}.
+#' Default: \code{sens.w = NULL} (to enforce that value is passed from calling function).
 #'
 #' @param cost.each numeric. An optional fixed cost added to all outputs (e.g., the cost of using the cue).
 #' @param cost.outcomes list. A list of length 4 named \code{"hi"}, \code{"fa"}, \code{"mi"}, \code{"cr"}, and
@@ -36,10 +36,10 @@
 #'
 #' @return A data frame with variables of computed accuracy and cost measures (but dropping inputs).
 
-add_stats <- function(data, # df with frequency counts of 'hi fa mi cr' classification outcomes (as integers)
+add_stats <- function(data,  # df with frequency counts of classification outcomes ('hi fa mi cr', as integers)
                       #
                       correction = .25,  # used to compute dprime
-                      sens.w = .50,      # used to compute wacc
+                      sens.w = NULL,     # used to compute wacc
                       #
                       cost.each = NULL,
                       cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0)

--- a/R/helper_stats.R
+++ b/R/helper_stats.R
@@ -1,6 +1,6 @@
 # helper_stats.R:
 # Statistical helper/utility functions.
-# --------------------------
+# -------------------------------------
 
 # Statistical calculations (based on classification outcomes in 2x2 matrix and models): ------
 
@@ -8,7 +8,7 @@
 # add_stats (from frequency of 4 classification outcomes): ------
 
 # Outcome statistics based on frequency counts (of 4 classification outcomes)
-# [called to get cue thresholds in fftrees_threshold_factor_grid() and fftrees_threshold_numeric_grid()]:
+# [used to set cue thresholds in fftrees_threshold_factor_grid() and fftrees_threshold_numeric_grid()]:
 
 
 #' Add decision statistics to data (based on frequency counts of a 2x2 classification outcomes)
@@ -140,7 +140,7 @@ add_stats <- function(data, # df with frequency counts of 'hi fa mi cr' classifi
 #' @param correction numeric. Correction added to all counts for calculating \code{dprime}.
 #' Default: \code{correction = .25}.
 #' @param sens.w numeric. Sensitivity weight parameter (from 0 to 1, for computing \code{wacc}).
-#' Default: \code{sens.w = NULL} (to enforce that actual value is being passed by the calling function).
+#' Default: \code{sens.w = NULL} (to enforce that the current value is passed by the calling function).
 #'
 #' @param cost.outcomes list. A list of length 4 with names 'hi', 'fa', 'mi', and 'cr' specifying
 #' the costs of a hit, false alarm, miss, and correct rejection, respectively.

--- a/R/helper_stats.R
+++ b/R/helper_stats.R
@@ -108,14 +108,16 @@ add_stats <- function(data, # df with frequency counts of 'hi fa mi cr' classifi
 
   # Output: ----
 
+  # Define the set of critical stats [add_stats_v]: ----
   add_stats_v <- c("sens", "spec",
                    "far",  "ppv", "npv",
-                   "acc", "bacc", "wacc",
                    "dprime",
+                   "acc", "bacc", "wacc",
                    "cost_dec", "cost")
 
-  # Drop inputs and re-arrange columns (of df):
-  data <- data[, add_stats_v]
+  # Drop inputs and re-arrange columns (of df): ----
+  data <- data[ , add_stats_v]
+
 
   return(data)
 

--- a/R/helper_stats.R
+++ b/R/helper_stats.R
@@ -149,6 +149,9 @@ add_stats <- function(data, # df with frequency counts of 'hi fa mi cr' classifi
 #' @param cost_v numeric. Additional cost value of each decision (as an optional vector of numeric values).
 #' Typically used to include the cue cost of each decision (as a constant for the current level of an FFT).
 #'
+#' @param my.goal Name of an optional, user-defined goal (as character string). Default: \code{my.goal = NULL}.
+#' @param my.goal.fun User-defined goal function (with 4 arguments \code{hi fa mi cr}). Default: \code{my.goal.fun = NULL}.
+#'
 #' @param na_prediction_action What happens when no prediction is possible? (experimental).
 #'
 #' @importFrom stats qnorm
@@ -163,7 +166,11 @@ classtable <- function(prediction_v = NULL,
                        cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0),
                        cost_v = NULL,          # cost value of each decision (at current level, as a constant)
                        #
-                       na_prediction_action = "ignore") {
+                       my.goal = NULL,
+                       my.goal.fun = NULL,
+                       #
+                       na_prediction_action = "ignore"
+){
 
   #   prediction_v <- sample(c(TRUE, FALSE), size = 20, replace = TRUE)
   #   criterion_v  <- sample(c(TRUE, FALSE), size = 20, replace = TRUE)
@@ -284,6 +291,11 @@ classtable <- function(prediction_v = NULL,
       cost_dec <- (as.numeric(c(hi, fa, mi, cr) %*% c(cost.outcomes$hi, cost.outcomes$fa, cost.outcomes$mi, cost.outcomes$cr))) / N
       cost     <- (as.numeric(c(hi, fa, mi, cr) %*% c(cost.outcomes$hi, cost.outcomes$fa, cost.outcomes$mi, cost.outcomes$cr)) + sum(cost_v)) / N
 
+      # Compute my.goal value (by my.goal.fun):
+      if (!is.null(my.goal)){
+        my_goal_value <- mapply(FUN = my.goal.fun, hi = hi, fa = fa, mi = mi, cr = cr)
+        # print(paste0(my.goal, " = ", round(my_goal_value, 3)))  # 4debugging
+      }
 
     } else { # Case 2. Compute stats from freq combinations: ----
 
@@ -321,10 +333,15 @@ classtable <- function(prediction_v = NULL,
       # auc <- as.numeric(pROC::roc(response = as.numeric(criterion_v),
       #                             predictor = as.numeric(prediction_v))$auc)
 
-
       # Cost per case:
       cost_dec <- (as.numeric(c(hi, fa, mi, cr) %*% c(cost.outcomes$hi, cost.outcomes$fa, cost.outcomes$mi, cost.outcomes$cr))) / N
       cost <- (as.numeric(c(hi, fa, mi, cr) %*% c(cost.outcomes$hi, cost.outcomes$fa, cost.outcomes$mi, cost.outcomes$cr)) + sum(cost_v)) / N
+
+      # Compute my.goal value (by my.goal.fun):
+      if (!is.null(my.goal)){
+        my_goal_value <- mapply(FUN = my.goal.fun, hi = hi, fa = fa, mi = mi, cr = cr)
+        # print(paste0(my.goal, " = ", round(my_goal_value, 3)))  # 4debugging
+      }
 
     } # else if ((var(prediction_v) > 0) & (var(criterion_v) > 0)).
 
@@ -351,10 +368,13 @@ classtable <- function(prediction_v = NULL,
     wacc  <- NA
 
     dprime <- NA
+
     # auc  <- NA
 
     cost_dec <- NA
     cost     <- NA
+
+    my_goal_val <- NA
 
   }
 
@@ -390,6 +410,12 @@ classtable <- function(prediction_v = NULL,
     cost = cost
 
   )
+
+  # Add my.goal name and value:
+  if (!is.null(my.goal)){
+    result[[my.goal]] <- my_goal_value
+    # print(result) # 4debugging
+  }
 
   return(result)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,6 +39,7 @@ url_JDM_pdf   <- "https://journal.sjdm.org/17/17217/jdm17217.pdf"
 <!-- Devel badges end. -->
 
 
+
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color=blue)](https://www.r-pkg.org/pkg/FFTrees) -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.8.0.9007 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.8.0.9008 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -328,6 +328,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-01-18.\]
+\[File `README.Rmd` last updated on 2023-01-20.\]
 
 <!-- eof. -->

--- a/man/FFTrees.Rd
+++ b/man/FFTrees.Rd
@@ -64,7 +64,7 @@ Default: \code{train.p = 1} (i.e., using all data for training).}
 \code{"acc"} = overall accuracy, \code{"bacc"} = balanced accuracy, \code{"wacc"} = weighted accuracy,
 \code{"dprime"} = discriminability, \code{"cost"} = costs (based on \code{cost.outcomes} and \code{cost.cues}).}
 
-\item{goal.threshold}{A character string indicating the statistic to maximize when \emph{optimizing cue thresholds}:
+\item{goal.threshold}{A character string indicating the criterion to maximize when \emph{optimizing cue thresholds}:
 \code{"acc"} = overall accuracy, \code{"bacc"} = balanced accuracy, \code{"wacc"} = weighted accuracy,
 \code{"dprime"} = discriminability, \code{"cost"} = costs (based only on \code{cost.outcomes}, as \code{cost.cues} are constant per cue).
 Default: \code{goal.threshold = "bacc"}.}

--- a/man/add_stats.Rd
+++ b/man/add_stats.Rd
@@ -7,7 +7,9 @@
 add_stats(
   data,
   correction = 0.25,
-  sens.w = 0.5,
+  sens.w = NULL,
+  my.goal = NULL,
+  my.goal.fun = NULL,
   cost.each = NULL,
   cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0)
 )
@@ -19,7 +21,11 @@ add_stats(
 Default: \code{correction = .25}.}
 
 \item{sens.w}{numeric. Sensitivity weight (for computing weighted accuracy, \code{wacc}).
-Default: \code{sens.w = .50}.}
+Default: \code{sens.w = NULL} (to enforce that value is passed from calling function).}
+
+\item{my.goal}{Name of an optional, user-defined goal (as character string). Default: \code{my.goal = NULL}.}
+
+\item{my.goal.fun}{User-defined goal function (with 4 arguments \code{hi fa mi cr}). Default: \code{my.goal.fun = NULL}.}
 
 \item{cost.each}{numeric. An optional fixed cost added to all outputs (e.g., the cost of using the cue).}
 

--- a/man/add_stats.Rd
+++ b/man/add_stats.Rd
@@ -6,16 +6,20 @@
 \usage{
 add_stats(
   data,
+  correction = 0.25,
   sens.w = 0.5,
   cost.each = NULL,
-  cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0),
-  correction = 0.25
+  cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0)
 )
 }
 \arguments{
 \item{data}{A data frame with 4 frequency counts (as integer values, named \code{"hi"}, \code{"fa"}, \code{"mi"}, and \code{"cr"}).}
 
-\item{sens.w}{numeric. Sensitivity weight (for computing weighted accuracy, \code{wacc}). Default: \code{sens.w = .50}.}
+\item{correction}{numeric. Correction added to all counts for calculating \code{dprime}.
+Default: \code{correction = .25}.}
+
+\item{sens.w}{numeric. Sensitivity weight (for computing weighted accuracy, \code{wacc}).
+Default: \code{sens.w = .50}.}
 
 \item{cost.each}{numeric. An optional fixed cost added to all outputs (e.g., the cost of using the cue).}
 
@@ -23,9 +27,6 @@ add_stats(
 specifying the costs of a hit, false alarm, miss, and correct rejection, respectively.
 E.g.; \code{cost.outcomes = listc("hi" = 0, "fa" = 10, "mi" = 20, "cr" = 0)} means that a
 false alarm and miss cost 10 and 20 units, respectively, while correct decisions incur no costs.}
-
-\item{correction}{numeric. Correction added to all counts for calculating \code{dprime}.
-Default: \code{correction = .25}.}
 }
 \value{
 A data frame with variables of computed accuracy and cost measures (but dropping inputs).

--- a/man/classtable.Rd
+++ b/man/classtable.Rd
@@ -11,6 +11,8 @@ classtable(
   sens.w = NULL,
   cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0),
   cost_v = NULL,
+  my.goal = NULL,
+  my.goal.fun = NULL,
   na_prediction_action = "ignore"
 )
 }
@@ -23,7 +25,7 @@ classtable(
 Default: \code{correction = .25}.}
 
 \item{sens.w}{numeric. Sensitivity weight parameter (from 0 to 1, for computing \code{wacc}).
-Default: \code{sens.w = NULL} (to enforce that actual value is being passed by the calling function).}
+Default: \code{sens.w = NULL} (to enforce that the current value is passed by the calling function).}
 
 \item{cost.outcomes}{list. A list of length 4 with names 'hi', 'fa', 'mi', and 'cr' specifying
 the costs of a hit, false alarm, miss, and correct rejection, respectively.
@@ -32,6 +34,10 @@ a false alarm and miss cost 10 and 20, respectively, while correct decisions hav
 
 \item{cost_v}{numeric. Additional cost value of each decision (as an optional vector of numeric values).
 Typically used to include the cue cost of each decision (as a constant for the current level of an FFT).}
+
+\item{my.goal}{Name of an optional, user-defined goal (as character string). Default: \code{my.goal = NULL}.}
+
+\item{my.goal.fun}{User-defined goal function (with 4 arguments \code{hi fa mi cr}). Default: \code{my.goal.fun = NULL}.}
 
 \item{na_prediction_action}{What happens when no prediction is possible? (experimental).}
 }

--- a/man/fftrees_create.Rd
+++ b/man/fftrees_create.Rd
@@ -74,11 +74,14 @@ fftrees_create(
 \item{decision.labels}{string.}
 
 \item{my.goal}{The name of the optimization measure defined by \code{my.goal.fun} (as a character string).
-Default: \code{my.goal = "my_acc"}.}
+Example: \code{my.goal = "my_acc"} (see \code{my.goal.fun} for corresponding function).
+Default: \code{my.goal = NULL}.}
 
-\item{my.goal.fun}{The definition of an outcome measure to optimize, defined in terms of the frequency counts of 4 basic classification outcomes \code{hi, fa, mi, cr}
-(as an R function of the arguments \code{hi, fa, mi, cr}).
-Default: \code{my.goal.fun = function(hi, fa, mi, cr){(hi + cr)/(hi + fa + mi + cr)}} (i.e., accuracy).}
+\item{my.goal.fun}{The definition of an outcome measure to optimize, defined in terms of the
+frequency counts of 4 basic classification outcomes \code{hi, fa, mi, cr}
+(i.e., an R function with 4 arguments \code{hi, fa, mi, cr}).
+Example: \code{my.goal.fun = function(hi, fa, mi, cr){(hi + cr)/(hi + fa + mi + cr)}} (i.e., accuracy).
+Default: \code{my.goal.fun = NULL}.}
 
 \item{my.tree}{A verbal description of an FFT, i.e., an "FFT in words" (as character string).
 For example, \code{my.tree = "If age > 20, predict TRUE. If sex = {m}, predict FALSE. Otherwise, predict TRUE."}.}

--- a/man/fftrees_threshold_factor_grid.Rd
+++ b/man/fftrees_threshold_factor_grid.Rd
@@ -9,10 +9,12 @@ fftrees_threshold_factor_grid(
   cue_v = NULL,
   criterion_v = NULL,
   directions = "=",
+  goal.threshold = "bacc",
   sens.w = 0.5,
-  cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0),
+  my.goal = NULL,
+  my.goal.fun = NULL,
   cost.each = 0,
-  goal.threshold = "bacc"
+  cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0)
 )
 }
 \arguments{
@@ -24,17 +26,24 @@ fftrees_threshold_factor_grid(
 
 \item{directions}{character. Character vector of threshold directions to consider.}
 
+\item{goal.threshold}{A character string indicating the criterion to maximize when \emph{optimizing cue thresholds}:
+\code{"acc"} = overall accuracy, \code{"bacc"} = balanced accuracy, \code{"wacc"} = weighted accuracy,
+\code{"dprime"} = discriminability, \code{"cost"} = costs (based only on \code{cost.outcomes}, as \code{cost.cues} are constant per cue).
+Default: \code{goal.threshold = "bacc"}.}
+
 \item{sens.w}{numeric. Sensitivity weight parameter (from 0 to 1, for computing \code{wacc}).
 Default: \code{sens.w = .50}.}
+
+\item{my.goal}{Name of an optional, user-defined goal (as character string). Default: \code{my.goal = NULL}.}
+
+\item{my.goal.fun}{User-defined goal function (with 4 arguments \code{hi fa mi cr}). Default: \code{my.goal.fun = NULL}.}
+
+\item{cost.each}{numeric. Cost to add to each value (e.g.; cost of the cue).}
 
 \item{cost.outcomes}{list. A list of length 4 with names 'hi', 'fa', 'mi', and 'cr' specifying
 the costs of a hit, false alarm, miss, and correct rejection, respectively.
 For instance, \code{cost.outcomes = listc("hi" = 0, "fa" = 10, "mi" = 20, "cr" = 0)} means that
 a false alarm and miss cost 10 and 20, respectively, while correct decisions have no cost.}
-
-\item{cost.each}{numeric.}
-
-\item{goal.threshold}{character.}
 }
 \value{
 A data frame containing accuracy statistics for several factor thresholds

--- a/man/fftrees_threshold_numeric_grid.Rd
+++ b/man/fftrees_threshold_numeric_grid.Rd
@@ -9,10 +9,12 @@ fftrees_threshold_numeric_grid(
   cue_v,
   criterion_v,
   directions = c(">", "<="),
+  goal.threshold = "bacc",
   sens.w = 0.5,
+  my.goal = NULL,
+  my.goal.fun = NULL,
   cost.each = 0,
-  cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0),
-  goal.threshold = "bacc"
+  cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0)
 )
 }
 \arguments{
@@ -24,17 +26,24 @@ fftrees_threshold_numeric_grid(
 
 \item{directions}{character. Possible directions to consider.}
 
+\item{goal.threshold}{A character string indicating the criterion to maximize when \emph{optimizing cue thresholds}:
+\code{"acc"} = overall accuracy, \code{"bacc"} = balanced accuracy, \code{"wacc"} = weighted accuracy,
+\code{"dprime"} = discriminability, \code{"cost"} = costs (based only on \code{cost.outcomes}, as \code{cost.cues} are constant per cue).
+Default: \code{goal.threshold = "bacc"}.}
+
 \item{sens.w}{numeric. Sensitivity weight parameter (from 0 to 1, for computing \code{wacc}).
 Default: \code{sens.w = .50}.}
 
-\item{cost.each}{numeric. Cost to add to each value (e.g.; cost of  the cue).}
+\item{my.goal}{Name of an optional, user-defined goal (as character string). Default: \code{my.goal = NULL}.}
+
+\item{my.goal.fun}{User-defined goal function (with 4 arguments \code{hi fa mi cr}). Default: \code{my.goal.fun = NULL}.}
+
+\item{cost.each}{numeric. Cost to add to each value (e.g.; cost of the cue).}
 
 \item{cost.outcomes}{list. A list of length 4 with names 'hi', 'fa', 'mi', and 'cr' specifying
 the costs of a hit, false alarm, miss, and correct rejection, respectively.
 For instance, \code{cost.outcomes = listc("hi" = 0, "fa" = 10, "mi" = 20, "cr" = 0)} means that
 a false alarm and miss cost 10 and 20, respectively, while correct decisions have no cost.}
-
-\item{goal.threshold}{character. A string indicating the statistic to maximize when calculting cue thresholds: "acc" = overall accuracy, "wacc" = weighted accuracy, "bacc" = balanced accuracy.}
 }
 \value{
 A data frame containing accuracy statistics for several numeric thresholds.


### PR DESCRIPTION
This PR enables setting a user-defined goal (`my.goal`, as defined by `my.goal.fun`) and — if defined — computes the corresponding measure and reports it in both cue level and tree level statistics. 

Note that the status of the `my.goal` measure is currently **experimental**: 

- the values are only _computed_ and _reported_ (as a dependent variable), but, not yet _used_ as a criterion _for optimization_ purposes (in goals)
- the 2 new arguments are currently defined and set by `fftrees_create()`, but not yet by main `FFTrees()` function 