### PR TITLE
Enabling user-defined goal & general maintenance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.8.0.9008
+Version: 1.8.0.9009
 Date: 2023-01-20
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.8.0.9009
-Date: 2023-01-20
+Version: 1.8.0.9010
+Date: 2023-01-21
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,12 @@
 
 # FFTrees 1.8
 
-## 1.8.0.9008
+## 1.8.0.9009
 
 This is the current development version of **FFTrees**, available at <https://github.com/ndphillips/FFTrees>. 
 
 **FFTrees** version 1.9.0 is to be released [on CRAN](https://CRAN.R-project.org/package=FFTrees) [in 2023-02]. 
-This version adds functionality, improves robustness, and fixes some bugs.
+This version adds functionality, improves user feedback and robustness, and fixes minor bugs.
 
 <!-- Log of changes: --> 
 
@@ -16,8 +16,8 @@ Changes since last release:
 
 ### Major changes 
 
-- Added support for user-defined `my.goal` (as DV, as defined by `my.goal.fun`). 
-- Added support for optimizing `dprime` values of cues and trees (by using `"dprime"` as `goal.threshold`, `goal.chase`, or `goal` values). 
+- Enabled user-defined `my.goal` on cue and tree levels (as defined by `my.goal.fun`). 
+- Enabled optimizing `dprime` on cue and tree levels (by using `"dprime"` as `goal.threshold`, `goal.chase`, or `goal` values). 
 - Added decision outcome and cue costs to `asif_results` (in `fftrees_grow_fan()`). 
 
 
@@ -27,8 +27,8 @@ Changes since last release:
 
 - Included `dprime` values in cue level statistics (`x$cues$thresholds` and `x$cues$stats`). 
 - Included `dprime` values in competition statistics (`x$competition$train` and `x$competition$test`). 
-- Improved user feedback on combinations of goal and cost values.
 - Improved `summar()`: Include current goal and cost values (if `"cost"` used in goals).
+- Improved user feedback on combinations of goal and cost values.
 
 
 <!-- Details: --> 

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -64,7 +64,7 @@ fftrees_apply <- function(x,
 
     }
 
-    valid_train_test_data(train_data = x$data$train, test_data = x$data$test)  # verify (without consequences)
+    verify_train_test_data(train_data = x$data$train, test_data = x$data$test)  # verify (without consequences)
 
     data <- x$data$test
 

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -380,8 +380,10 @@ fftrees_create <- function(formula = NULL,
 
   # cost.outcomes: ----
 
-  if (!is.null(cost.outcomes) & goal != "cost") {
-    msg <- paste0("Specified 'cost.outcomes', but goal = '", goal, "' (not 'cost'):\nFFT creation will ignore costs, but report them in tree statistics.\n")
+  cur_goals <- c(goal, goal.chase, goal.threshold)
+
+  if (!is.null(cost.outcomes) & (!"cost" %in% cur_goals)) {
+    msg <- paste0("Specified 'cost.outcomes', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.\n")
     cat(u_f_hig(msg))
   }
 
@@ -407,8 +409,8 @@ fftrees_create <- function(formula = NULL,
 
   # cost.cues: ----
 
-  if (!is.null(cost.cues) & goal != "cost") {
-    msg <- paste0("Specified 'cost.cues', but goal = '", goal, "' (not 'cost'):\nFFT creation will ignore costs, but report them in tree statistics.\n")
+  if (!is.null(cost.cues) & (!"cost" %in% cur_goals)) {
+    msg <- paste0("Specified 'cost.cues', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.\n")
     cat(u_f_hig(msg))
   }
 

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -145,6 +145,10 @@ fftrees_create <- function(formula = NULL,
   # Define a (constant) set of valid goals (for FFT selection via 'goal'):
   goal_valid <- c("acc", "bacc", "wacc", "dprime", "cost")
 
+  if (!is.null(my.goal)){  # include my.goal (name):
+    goal_valid <- c(goal_valid, my.goal)
+  }
+
   if (is.null(goal)) { # goal NOT set by user:
 
     if (!is.null(cost.outcomes) | !is.null(cost.cues)) { # use cost goal:

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -188,7 +188,7 @@ fftrees_create <- function(formula = NULL,
   if ((goal == "wacc") & (!enable_wacc(sens.w))){ # correct to "bacc":
 
     if (!quiet) {
-      cat(u_f_msg("\u2014 The goal was set to 'wacc', but 'sens.w = 0.50': Setting 'goal = bacc'\n"))
+      cat(u_f_hig("\u2014 User set 'goal = wacc', but 'sens.w = 0.50': Setting 'goal = bacc'\n"))
     }
     goal <- "bacc"
 
@@ -234,7 +234,7 @@ fftrees_create <- function(formula = NULL,
   if ((goal.chase == "wacc") & (!enable_wacc(sens.w))){ # correct to "bacc":
 
     if (!quiet) {
-      cat(u_f_msg("\u2014 The goal.chase was set to 'wacc', but 'sens.w = 0.50': Setting 'goal.chase = bacc'\n"))
+      cat(u_f_hig("\u2014 User set 'goal.chase = wacc', but 'sens.w = 0.50': Setting 'goal.chase = bacc'\n"))
     }
     goal.chase <- "bacc"
 
@@ -271,7 +271,7 @@ fftrees_create <- function(formula = NULL,
   if ((goal.threshold == "wacc") & (!enable_wacc(sens.w))){ # correct to "bacc":
 
     if (!quiet) {
-      cat(u_f_msg("\u2014 The goal.threshold was set to 'wacc', but 'sens.w = 0.50': Setting 'goal.threshold = bacc'\n"))
+      cat(u_f_hig("\u2014 User set 'goal.threshold = wacc', but 'sens.w = 0.50': Setting 'goal.threshold = bacc'\n"))
     }
     goal.threshold <- "bacc"
   }
@@ -317,16 +317,18 @@ fftrees_create <- function(formula = NULL,
   } # if (my.goal).
 
 
+  cur_goals <- c(goal, goal.chase, goal.threshold)  # IFF all goals are set.
+
+
   # Verify consistency of sens.w and bacc_wacc choices: ----
 
-  # If a non-default sens.w has been set, but 'wacc' is neither used in 'goal' nor in 'goal.chase':
-  if ((enable_wacc(sens.w)) & (goal != "wacc") & (goal.chase != "wacc")){ # provide feedback:
+  # If a non-default sens.w has been set, but 'wacc' is not a goal:
+  if ((enable_wacc(sens.w)) & (!"wacc" %in% cur_goals)) { # provide feedback:
 
     if (!quiet) {
-      msg <- paste0("You set sens.w = ", sens.w, ": Did you mean to set 'goal' or 'goal.chase' to 'wacc'?\n")
+      msg <- paste0("You set 'sens.w = ", sens.w, "': Did you mean to set a goal to 'wacc'?\n")
       cat(u_f_hig(msg))
     }
-
   }
 
 
@@ -380,11 +382,12 @@ fftrees_create <- function(formula = NULL,
 
   # cost.outcomes: ----
 
-  cur_goals <- c(goal, goal.chase, goal.threshold)
-
   if (!is.null(cost.outcomes) & (!"cost" %in% cur_goals)) {
-    msg <- paste0("Specified 'cost.outcomes', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.\n")
-    cat(u_f_hig(msg))
+
+    if (!quiet) {
+      msg <- paste0("Specified 'cost.outcomes', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.\n")
+      cat(u_f_hig(msg))
+    }
   }
 
   if (is.null(cost.outcomes)) { # set defaults:
@@ -410,8 +413,11 @@ fftrees_create <- function(formula = NULL,
   # cost.cues: ----
 
   if (!is.null(cost.cues) & (!"cost" %in% cur_goals)) {
-    msg <- paste0("Specified 'cost.cues', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.\n")
-    cat(u_f_hig(msg))
+
+    if (!quiet) {
+      msg <- paste0("Specified 'cost.cues', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.\n")
+      cat(u_f_hig(msg))
+    }
   }
 
   if ((!quiet) & (!is.null(cost.cues))) {

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -41,9 +41,13 @@ fftrees_grow_fan <- function(x,
   # Extract key variables:
   criterion_name <- x$criterion_name
   criterion_v    <- x$data$train[[criterion_name]]
+
   cues_n  <- length(x$cue_names)
   cases_n <- nrow(x$data$train)
   cue_df  <- x$data$train[, names(x$data$train) != criterion_name]
+
+  my_goal     <- x$params$my.goal          # (only ONCE)
+  my_goal_fun <- x$params$my.goal.fun  # (only ONCE)
 
 
   # Initial training of cue accuracies: ------
@@ -106,10 +110,12 @@ fftrees_grow_fan <- function(x,
     level_stats_ls <- vector("list", length = tree_n)
   }
 
-  # Loop over trees: ----
+
+  # LOOP over trees: ----
+
   for (tree_i in 1:tree_n) {
 
-    # data:
+    # Data:
     data_current   <- x$data$train
     cue_df_current <- x$cues$stats$train
 
@@ -120,19 +126,23 @@ fftrees_grow_fan <- function(x,
     ## Set up placeholders:
     cue_best_df_original <- x$cues$stats$train  # Note: Must contain current goal.chase parameter!
 
-    # Decisions, levelout, and cost vectors:
+    # Decisions, levelout, and cost vectors: ----
+
     decision_v <- rep(NA, cases_n)
     levelout_v <- rep(NA, cases_n)
     cuecost_v  <- rep(0, cases_n)
     outcomecost_v <- rep(NA, cases_n)
-    totalcost_v <- rep(0, cases_n)
+    totalcost_v   <- rep(0,  cases_n)
 
     hi_v <- rep(NA, cases_n)
     fa_v <- rep(NA, cases_n)
     mi_v <- rep(NA, cases_n)
     cr_v <- rep(NA, cases_n)
 
+
+    # level_stats_i (as df): ----
     # level_stats_i shows cumulative classification decisions statistics at each level:
+
     level_stats_i <- data.frame(
       "level" = NA,
       "cue" = NA,
@@ -145,27 +155,44 @@ fftrees_grow_fan <- function(x,
       "exit" = NA
     )
 
-    level_stat_names <- setdiff(names(fftrees_threshold_factor_grid()), c("threshold", "direction"))
-    level_stats_i[level_stat_names] <- NA
+    # HACK: Get names by calling fftrees_threshold_factor_grid()
+    threshold_factor_grid_names <- names(fftrees_threshold_factor_grid())
+    # threshold_factor_grid_names
 
+    if (!is.null(my_goal)){ # add my.goal (name):
+      threshold_factor_grid_names <- c(threshold_factor_grid_names, my_goal)
+    }
+
+    # level_stat_names (remove 2 names from threshold_factor_grid_names):
+    level_stat_names <- setdiff(threshold_factor_grid_names, c("threshold", "direction"))
+    level_stats_i[level_stat_names] <- NA  # initialize
+
+
+    # asif_stats (as df): ----
     # asif_stats stores cumulative classification statistics AS IF all exemplars were
     #            classified at the current level (i.e., if the tree stopped here/at current level):
 
-    asif_stats <- data.frame(
-      "level" = 1:level_n,
-      "sens" = NA,
-      "spec" = NA,
-      "acc" = NA,
-      "bacc" = NA,
-      "wacc" = NA,
-      "dprime" = NA,
-      "cost" = NA,
-      "goal_change" = NA
-    )
+    # Define the default set of ASIF stats:
+    asif_stats <- data.frame("level" = 1:level_n,
+                             "sens" = NA, "spec" = NA,
+                             "dprime" = NA,
+                             "acc" = NA, "bacc" = NA, "wacc" = NA,
+                             # my_goal = NA,    #  my.goal (name)
+                             "cost" = NA,
+                             "goal_change" = NA)
+
+    if (!is.null(my_goal)){ # include my.goal (name and value):
+
+      asif_stats[[my_goal]] <- NA
+
+    }
+
+    # print(asif_stats)  # 4debugging
 
     # Starting values:
     grow_tree <- TRUE
     level_current <- 0
+
 
     # GROW THE TREE: ------
 
@@ -285,24 +312,92 @@ fftrees_grow_fan <- function(x,
           cost.outcomes = x$params$cost.outcomes,  # add outcome cost
           cost_v = asif_cuecost_v,                 # add cue cost
           #
-          my.goal = x$params$my.goal,
-          my.goal.fun = x$params$my.goal.fun
+          my.goal = my_goal,
+          my.goal.fun = my_goal_fun
         )
         # Note: The 2 cost arguments cost.outcomes and cost_v were NOT being used to compute asif_results.
-        # DONE: ADDED asif_cuecost_v to call to classtable() here (on 2023-01-19, +++ here now +++)
+        # DONE: ADDED asif_cuecost_v to call to classtable() here (on 2023-01-19)     +++ here now +++
 
-        # Add key ASIF stats (to asif_stats):
-        asif_stats[level_current,
-                   c("sens", "spec", "dprime", "acc", "bacc", "wacc", "cost")] <- c(#
-                     asif_results$sens, asif_results$spec,
-                     asif_results$dprime,
-                     asif_results$acc, asif_results$bacc, asif_results$wacc,
-                     asif_results$cost
-                   )
+        # print(asif_results)  # 4debugging
+
+
+        # Define and add the set of key ASIF stats (to asif_stats): ----
+
+        # NASTY and UGLY code start: ------
+
+        # +++ here now +++
+
+        if (!is.null(my_goal)){ # include my.goal (name and value):
+
+          asif_stats[level_current,
+                     c("sens", "spec",
+                       "acc", "bacc", "wacc",
+                       "dprime",
+                       my_goal,        # my.goal (name)
+                       "cost")] <- c(#
+                         asif_results$sens, asif_results$spec,
+                         asif_results$acc, asif_results$bacc, asif_results$wacc,
+                         asif_results$dprime,
+                         asif_results[[my_goal]],  # my.goal (value)
+                         asif_results$cost
+                       )
+
+        } else { # default set of ASIF stats:
+
+          asif_stats[level_current,
+                     c("sens", "spec",
+                       "acc", "bacc", "wacc",
+                       "dprime",
+                       # my_goal,        # my.goal (name)
+                       "cost")] <- c(#
+                         asif_results$sens, asif_results$spec,
+                         asif_results$acc, asif_results$bacc, asif_results$wacc,
+                         asif_results$dprime,
+                         # asif_results[[my.goal]],  # my.goal (value)
+                         asif_results$cost
+                       )
+
+        } # if (my.goal).
         # Note: Horizontal/by-row measures (ppv, npv) are currently NOT recorded in asif_stats.
 
+        # print(asif_stats)    # 4debugging
 
-        # Stop growing tree, if ASIF classification is perfect:
+        # NASTY and UGLY code end. ------
+
+
+        # NICER code start: ------
+
+        # # Define the set of ASIF stats: ----
+        # if (!is.null(my_goal)){ # include my.goal (name and value):
+        #
+        #   asif_stats_v <- c("sens", "spec",
+        #                     "acc", "bacc", "wacc",
+        #                     "dprime",
+        #                     my_goal,        # my.goal (name)
+        #                     "cost")
+        #
+        # } else { # default set of ASIF stats:
+        #
+        #   asif_stats_v <- c("sens", "spec",
+        #                     "acc", "bacc", "wacc",
+        #                     "dprime",
+        #                     # my_goal,        # my.goal (name)
+        #                     "cost")
+        #
+        # } # if (my.goal).
+        # # Note: Horizontal/by-row measures (ppv, npv) are currently NOT recorded in asif_stats.
+        #
+        #
+        # # Update row and columns of asif_results: ----
+        #
+        # asif_stats[level_current, asif_stats_v] <- asif_results[level_current, asif_stats_v]
+        #
+        # print(asif_stats)    # 4debugging
+
+        # NICER code end. ------
+
+
+        # Stop growing tree, if ASIF classification is perfect: ----
 
         if (x$params$goal.chase %in% c("acc", "bacc", "wacc")) { # A. chasing an accuracy measure:
 
@@ -330,6 +425,11 @@ fftrees_grow_fan <- function(x,
             grow_tree <- FALSE
           }
 
+        } else if (x$params$goal.chase == my_goal){
+
+          # ToDo: What if goal.chase == my_goal?
+          message(paste0("No known limit for stopping FFT-growth when goal.chase value = '", x$params$goal.chase, "'."))
+
         } else { # note an unknown/invalid goal.chase value:
 
           goal_valid <- c("acc", "bacc", "wacc", "dprime", "cost")  # See fftrees_create()!
@@ -340,7 +440,7 @@ fftrees_grow_fan <- function(x,
         } # If stop?
 
 
-        # Calculate goal_change value:
+        # Calculate the goal_change value: ----
         {
           if (level_current == 1) {
             asif_stats$goal_change[1] <- asif_stats[[x$params$goal]][1]
@@ -405,8 +505,8 @@ fftrees_grow_fan <- function(x,
           cost.outcomes = x$params$cost.outcomes,
           cost_v = cuecost_v[case_remaining_ix == FALSE],
           #
-          my.goal = x$params$my.goal,
-          my.goal.fun = x$params$my.goal.fun
+          my.goal = my_goal,
+          my.goal.fun = my_goal_fun
         )
 
         # Update level stats:
@@ -418,14 +518,31 @@ fftrees_grow_fan <- function(x,
         level_stats_i$direction[level_current] <- cue_direction_new
         level_stats_i$exit[level_current]      <- exit_current
 
-        # Current level stats:
-        level_stats_v <- c("hi", "fa", "mi", "cr",
-                           "sens", "spec",
-                           "dprime",
-                           "bacc", "acc", "wacc",
-                           "cost_dec", "cost")
-        level_stats_i[level_current, level_stats_v] <- results_cum[, level_stats_v]
+
+        # Define the set of level stats [level_stats_v]: ----
+        if (!is.null(my_goal)){ # include my.goal (name and value):
+
+          level_stats_v <- c("hi", "fa", "mi", "cr",
+                             "sens", "spec",
+                             "dprime",
+                             "bacc", "acc", "wacc",
+                             my_goal,        # my.goal (name)
+                             "cost_dec", "cost")
+
+        } else { # default set of level stats:
+
+          level_stats_v <- c("hi", "fa", "mi", "cr",
+                             "sens", "spec",
+                             "dprime",
+                             "bacc", "acc", "wacc",
+                             # my_goal,        # my.goal (name)
+                             "cost_dec", "cost")
+
+        } # if (my.goal).
         # Note: Horizontal/by-row measures (ppv, npv) are currently NOT recorded in level_stats_i.
+
+        # Select level stats (variables):
+        level_stats_i[level_current, level_stats_v] <- results_cum[ , level_stats_v]
 
       } # Step 4.
 
@@ -513,8 +630,8 @@ fftrees_grow_fan <- function(x,
           cost.outcomes = x$params$cost.outcomes,
           cost_v = cuecost_v,
           #
-          my.goal = x$params$my.goal,
-          my.goal.fun = x$params$my.goal.fun
+          my.goal = my_goal,
+          my.goal.fun = my_goal_fun
         )
 
         level_stats_i$exit[last_level_nr] <- .5
@@ -525,7 +642,7 @@ fftrees_grow_fan <- function(x,
         #                                "sens", "spec", "bacc", "acc", "wacc", "cost_dec")] <- last_classtable[, c("hi", "fa", "mi", "cr", "sens", "spec", "bacc", "acc", "wacc", "cost_dec")]
 
         # NEW (using same level_stats_v as above) on 2022-09-23:
-        level_stats_i[last_level_nr, level_stats_v] <- last_classtable[, level_stats_v]
+        level_stats_i[last_level_nr, level_stats_v] <- last_classtable[ , level_stats_v]
 
       } # if (last_exit_direction != .5).
 

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -111,7 +111,54 @@ fftrees_grow_fan <- function(x,
   }
 
 
-  # LOOP over trees: ----
+  # Define key vectors of stats names (only once, before loop): ------
+  # +++ here now +++
+
+  # A. Define the set of ASIF stats [asif_stats_name_v]: ----
+  if (!is.null(my_goal)){ # include my.goal (name and value):
+
+    asif_stats_name_v <- c("sens", "spec",
+                           "dprime",
+                           "acc", "bacc", "wacc",
+                           my_goal,        # my.goal (name)
+                           "cost")
+
+  } else { # default set of ASIF stats:
+
+    asif_stats_name_v <- c("sens", "spec",
+                           "dprime",
+                           "acc", "bacc", "wacc",
+                           # my_goal,      # my.goal (name)
+                           "cost")
+
+  } # if (my.goal).
+  # Note: Horizontal/by-row measures (ppv, npv) are currently NOT recorded in asif_stats.
+
+
+  # B. Define the set of level stats names [level_stats_name_v]: ----
+  if (!is.null(my_goal)){ # include my.goal (name and value):
+
+    level_stats_name_v <- c("hi", "fa", "mi", "cr",
+                            "sens", "spec",
+                            "dprime",
+                            "acc", "bacc", "wacc",
+                            my_goal,        # my.goal (name)
+                            "cost_dec", "cost")
+
+  } else { # default set of level stats:
+
+    level_stats_name_v <- c("hi", "fa", "mi", "cr",
+                            "sens", "spec",
+                            "dprime",
+                            "acc", "bacc", "wacc",
+                            # my_goal,        # my.goal (name)
+                            "cost_dec", "cost")
+
+  } # if (my.goal).
+  # Note: Horizontal/by-row measures (ppv, npv) are currently NOT recorded in level_stats_i.
+
+
+  # LOOP (over trees): ----
 
   for (tree_i in 1:tree_n) {
 
@@ -323,78 +370,88 @@ fftrees_grow_fan <- function(x,
 
         # Define and add the set of key ASIF stats (to asif_stats): ----
 
-        # NASTY and UGLY code start: ------
+        { # HACKY code start: ------
 
-        # +++ here now +++
+          # if (!is.null(my_goal)){ # include my.goal (name and value):
+          #
+          #   asif_stats[level_current,
+          #              c("sens", "spec",
+          #                "acc", "bacc", "wacc",
+          #                "dprime",
+          #                my_goal,        # my.goal (name)
+          #                "cost")] <- c(#
+          #                  asif_results$sens, asif_results$spec,
+          #                  asif_results$acc, asif_results$bacc, asif_results$wacc,
+          #                  asif_results$dprime,
+          #                  asif_results[[my_goal]],  # my.goal (value)
+          #                  asif_results$cost
+          #                )
+          #
+          # } else { # default set of ASIF stats:
+          #
+          #   asif_stats[level_current,
+          #              c("sens", "spec",
+          #                "acc", "bacc", "wacc",
+          #                "dprime",
+          #                # my_goal,        # my.goal (name)
+          #                "cost")] <- c(#
+          #                  asif_results$sens, asif_results$spec,
+          #                  asif_results$acc, asif_results$bacc, asif_results$wacc,
+          #                  asif_results$dprime,
+          #                  # asif_results[[my.goal]],  # my.goal (value)
+          #                  asif_results$cost
+          #                )
+          #
+          # } # if (my.goal).
+          # # Note: Horizontal/by-row measures (ppv, npv) are currently NOT recorded in asif_stats.
+          #
+          # # print(asif_stats)          # 4debugging
+          # asif_stats_m1 <- asif_stats  # 4checking
 
-        if (!is.null(my_goal)){ # include my.goal (name and value):
-
-          asif_stats[level_current,
-                     c("sens", "spec",
-                       "acc", "bacc", "wacc",
-                       "dprime",
-                       my_goal,        # my.goal (name)
-                       "cost")] <- c(#
-                         asif_results$sens, asif_results$spec,
-                         asif_results$acc, asif_results$bacc, asif_results$wacc,
-                         asif_results$dprime,
-                         asif_results[[my_goal]],  # my.goal (value)
-                         asif_results$cost
-                       )
-
-        } else { # default set of ASIF stats:
-
-          asif_stats[level_current,
-                     c("sens", "spec",
-                       "acc", "bacc", "wacc",
-                       "dprime",
-                       # my_goal,        # my.goal (name)
-                       "cost")] <- c(#
-                         asif_results$sens, asif_results$spec,
-                         asif_results$acc, asif_results$bacc, asif_results$wacc,
-                         asif_results$dprime,
-                         # asif_results[[my.goal]],  # my.goal (value)
-                         asif_results$cost
-                       )
-
-        } # if (my.goal).
-        # Note: Horizontal/by-row measures (ppv, npv) are currently NOT recorded in asif_stats.
-
-        # print(asif_stats)    # 4debugging
-
-        # NASTY and UGLY code end. ------
+        } # HACKY code end.
 
 
-        # NICER code start: ------
+        # CLEANER code start: ------
 
-        # # Define the set of ASIF stats: ----
+        # # Define the set of ASIF stats [asif_stats_name_v]: ----
         # if (!is.null(my_goal)){ # include my.goal (name and value):
         #
-        #   asif_stats_v <- c("sens", "spec",
-        #                     "acc", "bacc", "wacc",
-        #                     "dprime",
-        #                     my_goal,        # my.goal (name)
-        #                     "cost")
+        #   asif_stats_name_v <- c("sens", "spec",
+        #                          "acc", "bacc", "wacc",
+        #                          "dprime",
+        #                          my_goal,        # my.goal (name)
+        #                          "cost")
         #
         # } else { # default set of ASIF stats:
         #
-        #   asif_stats_v <- c("sens", "spec",
-        #                     "acc", "bacc", "wacc",
-        #                     "dprime",
-        #                     # my_goal,        # my.goal (name)
-        #                     "cost")
+        #   asif_stats_name_v <- c("sens", "spec",
+        #                          "acc", "bacc", "wacc",
+        #                          "dprime",
+        #                          # my_goal,      # my.goal (name)
+        #                          "cost")
         #
         # } # if (my.goal).
         # # Note: Horizontal/by-row measures (ppv, npv) are currently NOT recorded in asif_stats.
-        #
-        #
-        # # Update row and columns of asif_results: ----
-        #
-        # asif_stats[level_current, asif_stats_v] <- asif_results[level_current, asif_stats_v]
-        #
-        # print(asif_stats)    # 4debugging
 
-        # NICER code end. ------
+
+        # Update row and columns of asif_stats (df) with elements of asif_results (vector): ----
+        # # (Assuming asif_stats_name_v (defined above, outside of loop):
+
+        asif_stats[level_current, asif_stats_name_v] <- asif_results[asif_stats_name_v]
+
+        # print(asif_stats)  # 4debugging
+
+        # CLEANER code end. ------
+
+
+        # # Verify that HACKY and CLEANER codes yield same result:
+        # asif_stats_m2 <- asif_stats  # 4checking
+        #
+        # if (all.equal(asif_stats_m1, asif_stats_m2)){
+        #   # print("Ok: Both asif_stats methods yield the same result, qed.")
+        # } else {
+        #   print("Caveat: Both asif_stats methods yield DIFFERENT results.")
+        # }
 
 
         # Stop growing tree, if ASIF classification is perfect: ----
@@ -428,7 +485,12 @@ fftrees_grow_fan <- function(x,
         } else if (x$params$goal.chase == my_goal){
 
           # ToDo: What if goal.chase == my_goal?
-          message(paste0("No known limit for stopping FFT-growth when goal.chase value = '", x$params$goal.chase, "'."))
+
+          if (!x$params$quiet) {
+            msg <- paste0("\u2014 A limit for growing FFTs with goal.chase = '", x$params$goal.chase, "' is unknown.\n")
+            cat(u_f_hig(msg))
+          }
+
 
         } else { # note an unknown/invalid goal.chase value:
 
@@ -519,30 +581,32 @@ fftrees_grow_fan <- function(x,
         level_stats_i$exit[level_current]      <- exit_current
 
 
-        # Define the set of level stats [level_stats_v]: ----
-        if (!is.null(my_goal)){ # include my.goal (name and value):
-
-          level_stats_v <- c("hi", "fa", "mi", "cr",
-                             "sens", "spec",
-                             "dprime",
-                             "bacc", "acc", "wacc",
-                             my_goal,        # my.goal (name)
-                             "cost_dec", "cost")
-
-        } else { # default set of level stats:
-
-          level_stats_v <- c("hi", "fa", "mi", "cr",
-                             "sens", "spec",
-                             "dprime",
-                             "bacc", "acc", "wacc",
-                             # my_goal,        # my.goal (name)
-                             "cost_dec", "cost")
-
-        } # if (my.goal).
-        # Note: Horizontal/by-row measures (ppv, npv) are currently NOT recorded in level_stats_i.
+        # # Define the set of level stats names [level_stats_name_v]: ----
+        # if (!is.null(my_goal)){ # include my.goal (name and value):
+        #
+        #   level_stats_name_v <- c("hi", "fa", "mi", "cr",
+        #                           "sens", "spec",
+        #                           "dprime",
+        #                           "bacc", "acc", "wacc",
+        #                           my_goal,        # my.goal (name)
+        #                           "cost_dec", "cost")
+        #
+        # } else { # default set of level stats:
+        #
+        #   level_stats_name_v <- c("hi", "fa", "mi", "cr",
+        #                           "sens", "spec",
+        #                           "dprime",
+        #                           "bacc", "acc", "wacc",
+        #                           # my_goal,        # my.goal (name)
+        #                           "cost_dec", "cost")
+        #
+        # } # if (my.goal).
+        # # Note: Horizontal/by-row measures (ppv, npv) are currently NOT recorded in level_stats_i.
 
         # Select level stats (variables):
-        level_stats_i[level_current, level_stats_v] <- results_cum[ , level_stats_v]
+        # # (Assuming level_stats_name_v (defined above, outside of loop):
+
+        level_stats_i[level_current, level_stats_name_v] <- results_cum[ , level_stats_name_v]
 
       } # Step 4.
 
@@ -637,12 +701,12 @@ fftrees_grow_fan <- function(x,
         level_stats_i$exit[last_level_nr] <- .5
 
 
-        # Note: Why not use same stats as in level_stats_v above? (Here: "dprime" and "cost" missing): +++ here now +++
+        # Note: Why not use same stats as in level_stats_name_v above? (Here: "dprime" and "cost" missing): +++ here now +++
         # level_stats_i[last_level_nr, c("hi", "fa", "mi", "cr",
         #                                "sens", "spec", "bacc", "acc", "wacc", "cost_dec")] <- last_classtable[, c("hi", "fa", "mi", "cr", "sens", "spec", "bacc", "acc", "wacc", "cost_dec")]
 
-        # NEW (using same level_stats_v as above) on 2022-09-23:
-        level_stats_i[last_level_nr, level_stats_v] <- last_classtable[ , level_stats_v]
+        # NEW (using same level_stats_name_v as above) on 2022-09-23:
+        level_stats_i[last_level_nr, level_stats_name_v] <- last_classtable[ , level_stats_name_v]
 
       } # if (last_exit_direction != .5).
 

--- a/R/fftrees_ranktrees.R
+++ b/R/fftrees_ranktrees.R
@@ -77,7 +77,7 @@ fftrees_ranktrees <- function(x,
   x$trees$decisions$train <- x$trees$decisions$train[tree_rank_df$tree]
   names(x$trees$decisions$train) <- paste0("tree_", 1:nrow(tree_rank_df))
 
-  # Best training tree:
+  # Get and set value of best training tree:
   x$trees$best$train <- select_best_tree(x, data = "train", goal = x$params$goal)
 
   } # if (data == "train").

--- a/R/fftrees_threshold_factor_grid.R
+++ b/R/fftrees_threshold_factor_grid.R
@@ -224,6 +224,7 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
                             "n" = NA,  "hi" = NA, "fa" = NA, "mi" = NA, "cr" = NA,
                             "sens" = NA, "spec" = NA,  "ppv"  = NA, "npv"  = NA,
                             "acc"  = NA, "bacc" = NA, "wacc" = NA,
+                            # my.goal = NA,  # (+)
                             "dprime" = NA,
                             "cost_dec" = NA, "cost" = NA)
 

--- a/R/helper.R
+++ b/R/helper.R
@@ -507,13 +507,18 @@ fact_clean <- function(data.train,
 #' @param goal character. A goal to maximize or minimize when selecting a tree from an existing \code{x}
 #' (for which values exist in \code{x$trees$stats}).
 #'
+#' @param my.goal.max logical. Default direction for user-defined \code{my.goal}: Should \code{my.goal} be maximized?
+#' Default: \code{my.goal.max = TRUE}.
+#'
 #' @return An integer denoting the \code{tree} that maximizes/minimizes \code{goal} in \code{data}.
 #'
 #' @seealso
 #' \code{\link{FFTrees}} for creating FFTs from and applying them to data.
 
-select_best_tree <- function(x, data, goal,
-                             my.goal.max = TRUE  # default for my.goal: maximize (ToDo: currently not set anywhere)
+select_best_tree <- function(x,
+                             data,
+                             goal,
+                             my.goal.max = TRUE  # Default direction for my.goal: maximize (ToDo: currently not set anywhere)
                              ){
 
   # Verify inputs: ------

--- a/R/helper.R
+++ b/R/helper.R
@@ -2,11 +2,9 @@
 # Miscellaneous auxiliary/utility functions.
 # ------------------------------------------
 
-
 # (1) Validating or verifying stuff: ------
 
-
-# valid_train_test_data: ------
+# verify_train_test_data: ------
 
 # Goal: Ensure that train and test data are sufficiently similar (e.g., contain the same variables)
 #       and provide feedback on any existing differences.
@@ -19,7 +17,7 @@
 #
 # Output: Boolean.
 
-valid_train_test_data <- function(train_data, test_data){
+verify_train_test_data <- function(train_data, test_data){
 
   # Initialize: ----
 
@@ -69,7 +67,7 @@ valid_train_test_data <- function(train_data, test_data){
 
   return(valid)
 
-} # valid_train_test_data().
+} # verify_train_test_data().
 
 # # Check:
 # (df1 <- data.frame(matrix( 1:9,  nrow = 3)))
@@ -78,13 +76,13 @@ valid_train_test_data <- function(train_data, test_data){
 # (df0 <- df1[-(1:3), ])
 #
 # # FALSE cases:
-# valid_train_test_data(df0, df1)
-# valid_train_test_data(df1, df0)
-# valid_train_test_data(df1, df3)
-# valid_train_test_data(df3, df1)
+# verify_train_test_data(df0, df1)
+# verify_train_test_data(df1, df0)
+# verify_train_test_data(df1, df3)
+# verify_train_test_data(df3, df1)
 # # TRUE cases:
-# valid_train_test_data(df1, df2)
-# valid_train_test_data(df1, df2[ , 3:1])
+# verify_train_test_data(df1, df2)
+# verify_train_test_data(df1, df2[ , 3:1])
 
 
 
@@ -135,12 +133,12 @@ verify_all_cues_in_data <- function(cues, data){
 
 
 
-# verify_tree: ------
+# verify_tree_arg: ------
 
-# Verify a "tree" argument [to be used in print(x) and plot(x)].
-# Returns a tree number (as numeric) or "best.train"/"best.test" (as character).
+# Verify AND return a "tree" ARGUMENT from an FFtrees object x, given a data type [to be used in print(x) and plot(x)].
+# Returns either a tree number (as numeric) or "best.train"/"best.test" (as character).
 
-verify_tree <- function(x, data, tree){
+verify_tree_arg <- function(x, data, tree){
 
   # Verify inputs: ----
 
@@ -158,18 +156,21 @@ verify_tree <- function(x, data, tree){
   }
 
   if (tree == "best.test" & is.null(x$tree$stats$test)) {
+
     warning("You asked for the 'best.test' tree, but there are no 'test' data. Used the best tree for 'train' data instead...")
 
     tree <- "best.train"
   }
 
   if (is.numeric(tree) & (tree %in% 1:x$trees$n) == FALSE) {
+
     stop(paste0("You asked for a tree that does not exist. This object has ", x$trees$n, " trees."))
   }
 
   if (inherits(data, "character")) {
 
     if (data == "test" & is.null(x$trees$stats$test)) {
+
       stop("You asked for 'test' data, but there are no 'test' data. Consider using data = 'train' instead...")
     }
 
@@ -204,9 +205,9 @@ verify_tree <- function(x, data, tree){
 
   # Output: ----
 
-  return(tree) # (character or numeric)
+  return(tree) # (as character OR numeric)
 
-} # verify_tree().
+} # verify_tree_arg().
 
 
 

--- a/R/helper.R
+++ b/R/helper.R
@@ -512,7 +512,9 @@ fact_clean <- function(data.train,
 #' @seealso
 #' \code{\link{FFTrees}} for creating FFTs from and applying them to data.
 
-select_best_tree <- function(x, data, goal){
+select_best_tree <- function(x, data, goal,
+                             my.goal.max = TRUE  # default for my.goal: maximize (ToDo: currently not set anywhere)
+                             ){
 
   # Verify inputs: ------
 
@@ -534,7 +536,7 @@ select_best_tree <- function(x, data, goal){
 
   # # (a) narrow goal range:
   #
-  # valid_tree_select_goal_narrow <- c("acc", "bacc", "wacc", "dprime", "cost")  # ToDo: Is "dprime" being computed?
+  # valid_tree_select_goal_narrow <- c("acc", "bacc", "wacc", "dprime", "cost")
   # testthat::expect_true(goal %in% valid_tree_select_goal_narrow)
 
   # (b) wide goal range:
@@ -543,13 +545,39 @@ select_best_tree <- function(x, data, goal){
   max_goals <- c("hi", "cr",
                  "sens", "spec",
                  "ppv", "npv",
-                 "acc", "bacc", "wacc", "dprime",
+                 "acc", "bacc", "wacc",
+                 "dprime",
                  "pci")
 
   # Goals to minimize (less is better):
   min_goals <- c("mi", "fa",
                  "cost", "cost_dec", "cost_cue",
                  "mcu")
+
+  # Current goal is user-defined my.goal:
+  if (!is.null(x$params$my.goal) & (goal == x$params$my.goal)){
+
+    if (my.goal.max) { # add my.goal to max_goals:
+
+      max_goals <- c(max_goals, x$params$my.goal)
+
+      if (!x$params$quiet) {
+        msg <- paste0("\u2014 Selecting an FFT to maximize your goal = '", x$params$my.goal, "'\n")
+        cat(u_f_hig(msg))
+      }
+
+    } else { # add my.goal to min_goals:
+
+      min_goals <- c(min_goals, x$params$my.goal)
+
+      if (!x$params$quiet) {
+        msg <- paste0("\u2014 Selecting an FFT to minimize your goal = '", x$params$my.goal, "'\n")
+        cat(u_f_hig(msg))
+      }
+
+    }
+
+  }
 
   valid_tree_select_goal <- c(max_goals, min_goals)
   testthat::expect_true(goal %in% valid_tree_select_goal)

--- a/R/plotFFTrees_function.R
+++ b/R/plotFFTrees_function.R
@@ -477,7 +477,7 @@ plot.FFTrees <- function(x = NULL,
 
     # Verify tree input: ----
 
-    tree <- verify_tree(x = x, data = data, tree = tree)  # use helper (for plotting AND printing)
+    tree <- verify_tree_arg(x = x, data = data, tree = tree)  # use helper (for plotting AND printing)
 
 
     # Get "best" tree: ----

--- a/R/printFFTrees_function.R
+++ b/R/printFFTrees_function.R
@@ -94,7 +94,7 @@ print.FFTrees <- function(x = NULL,
 
   # Verify tree input: ----
 
-  tree <- verify_tree(x = x, data = data, tree = tree)  # use helper (for plotting AND printing)
+  tree <- verify_tree_arg(x = x, data = data, tree = tree)  # use helper (for plotting AND printing)
 
 
   # Get "best" tree: ----

--- a/README.Rmd
+++ b/README.Rmd
@@ -38,13 +38,10 @@ url_JDM_pdf   <- "https://journal.sjdm.org/17/17217/jdm17217.pdf"
 [![R-CMD-check](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml)
 <!-- Devel badges end. -->
 
-
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color=blue)](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- Release badges end. -->
-
-
 
 <!-- ALL status badges start: --> 
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,11 +39,11 @@ url_JDM_pdf   <- "https://journal.sjdm.org/17/17217/jdm17217.pdf"
 <!-- Devel badges end. -->
 
 
-
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color=blue)](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- Release badges end. -->
+
 
 
 <!-- ALL status badges start: --> 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.8.0.9009 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.8.0.9010 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -328,6 +328,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-01-20.\]
+\[File `README.Rmd` last updated on 2023-01-21.\]
 
 <!-- eof. -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.8.0.9008 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.8.0.9009 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 

--- a/man/select_best_tree.Rd
+++ b/man/select_best_tree.Rd
@@ -4,7 +4,7 @@
 \alias{select_best_tree}
 \title{Select the best tree (from current set of FFTs)}
 \usage{
-select_best_tree(x, data, goal)
+select_best_tree(x, data, goal, my.goal.max = TRUE)
 }
 \arguments{
 \item{x}{An \code{FFTrees} object.}
@@ -13,6 +13,9 @@ select_best_tree(x, data, goal)
 
 \item{goal}{character. A goal to maximize or minimize when selecting a tree from an existing \code{x}
 (for which values exist in \code{x$trees$stats}).}
+
+\item{my.goal.max}{logical. Default direction for user-defined \code{my.goal}: Should \code{my.goal} be maximized?
+Default: \code{my.goal.max = TRUE}.}
 }
 \value{
 An integer denoting the \code{tree} that maximizes/minimizes \code{goal} in \code{data}.


### PR DESCRIPTION
This PR enables **optimization** for a user-defined `my.goal` (as defined by `my.goal.fun`) on both cue level (`goal.threshold`) and tree level (`goal.chase` and `goal`).  However, this functionality is still **explorative** (i.e., set in `fftrees_create()`, rather than enabled for main `FFTrees()` function).

Some additional code cleanup and maintenance (to improve consistency and performance).

