### PR TITLE
Completing overhaul of FFT translation functions (plus many minor changes)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.8.0.9011
+Version: 1.8.0.9012
 Date: 2023-01-22
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,12 @@
 
 # FFTrees 1.8
 
-## 1.8.0.9011
+## 1.8.0.9012
 
 This is the current development version of **FFTrees**, available at <https://github.com/ndphillips/FFTrees>. 
 
 **FFTrees** version 1.9.0 is to be released [on CRAN](https://CRAN.R-project.org/package=FFTrees) [in 2023-02]. 
-This version adds functionality, improves user feedback and robustness, and fixes minor bugs.
+This version improves consistency (by abstraction), robustness (by more global object verification), and transparency (by more explicit user feedback), but also fixes some bugs.
 
 <!-- Log of changes: --> 
 
@@ -16,6 +16,7 @@ Changes since last release:
 
 ### Major changes 
 
+- Prepared for modular tree translation and editing functions (`util_gfft.R`). 
 - Enabled user-defined `my.goal` on cue and tree levels (as defined by `my.goal.fun`). 
 - Enabled optimizing `dprime` on cue and tree levels (by using `"dprime"` as `goal.threshold`, `goal.chase`, or `goal` values). 
 - Added decision outcome and cue costs to `asif_results` (in `fftrees_grow_fan()`). 
@@ -25,9 +26,10 @@ Changes since last release:
 
 ### Minor changes 
 
+- Prepared for global tree notation separator (`fft_node_sep`). 
 - Included `dprime` values in cue level statistics (`x$cues$thresholds` and `x$cues$stats`). 
 - Included `dprime` values in competition statistics (`x$competition$train` and `x$competition$test`). 
-- Improved `summar()`: Include current goal and cost values (if `"cost"` used in goals).
+- Improved `summary()`: Include current goal and cost values (if `"cost"` used in goals).
 - Improved user feedback on combinations of goal and cost values.
 
 
@@ -403,6 +405,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2023-01-21.]
+[File `NEWS.md` last updated on 2023-01-22.]
 
 <!-- eof. -->

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -164,6 +164,8 @@ fftrees_apply <- function(x,
     tree_i_id <- tree_defs$tree[tree_i]
     # print(paste0("\u2014 Current tree_i = ", tree_i, " corresponds to tree_i_id = ", tree_i_id)) # 4debugging
 
+    # print(tree_defs)  # 4debugging
+
     # Read FFT definition (with 1 row per tree) into df (with 1 row per node):
     cur_fft_df <- read_fft_df(ffts = tree_defs, tree = tree_i_id)
     # print(cur_fft_df)  # 4debugging

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -746,20 +746,21 @@ fftrees_grow_fan <- function(x,
 
       # OLD code start: ----
 
-      # Store OLD tree definition ("_o") using level_stats_i (each FFT as 1 line of df):
-      tree_definitions_o$tree[tree_i]       <- tree_i  # counter & ID
-      tree_definitions_o$nodes[tree_i]      <- length(level_stats_i$cue)
-      tree_definitions_o$classes[tree_i]    <- paste(substr(level_stats_i$class, 1, 1), collapse = fft_node_sep)
-      tree_definitions_o$cues[tree_i]       <- paste(level_stats_i$cue,                 collapse = fft_node_sep)
-      tree_definitions_o$directions[tree_i] <- paste(level_stats_i$direction,           collapse = fft_node_sep)
-      tree_definitions_o$thresholds[tree_i] <- paste(level_stats_i$threshold,           collapse = fft_node_sep)
-      tree_definitions_o$exits[tree_i]      <- paste(level_stats_i$exit,                collapse = fft_node_sep)
-
-      # print(tree_definitions_o)  # 4debugging
+      # # Store OLD tree definition ("_o") using level_stats_i (each FFT as 1 line of df):
+      # tree_definitions_o$tree[tree_i]       <- tree_i  # counter & ID
+      # tree_definitions_o$nodes[tree_i]      <- length(level_stats_i$cue)
+      # tree_definitions_o$classes[tree_i]    <- paste(substr(level_stats_i$class, 1, 1), collapse = fft_node_sep)
+      # tree_definitions_o$cues[tree_i]       <- paste(level_stats_i$cue,                 collapse = fft_node_sep)
+      # tree_definitions_o$directions[tree_i] <- paste(level_stats_i$direction,           collapse = fft_node_sep)
+      # tree_definitions_o$thresholds[tree_i] <- paste(level_stats_i$threshold,           collapse = fft_node_sep)
+      # tree_definitions_o$exits[tree_i]      <- paste(level_stats_i$exit,                collapse = fft_node_sep)
+      #
+      # # print(tree_definitions_o)  # 4debugging
 
       # OLD code end. ----
 
       # +++ here now +++
+
 
       # NEW code start: ----
 
@@ -775,8 +776,8 @@ fftrees_grow_fan <- function(x,
 
     } # loop (over trees).
 
-    # Check: Verify equality of OLD and NEW code results:
-    if (!all.equal(tree_definitions, tree_definitions_o)) { stop("OLD vs. NEW: tree_definitions diff") }
+    # # Check: Verify equality of OLD and NEW code results:
+    # if (!all.equal(tree_definitions, tree_definitions_o)) { stop("OLD vs. NEW: tree_definitions diff") }
 
 
     # Remove duplicate trees (rows):

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -744,6 +744,18 @@ fftrees_grow_fan <- function(x,
       level_stats_i <- level_stats_ls[[tree_i]]
       # print(level_stats_i)  # 4debugging
 
+      # NEW code start: ----
+
+      # Select variables of cur_tree_df from level_stats_i:
+      req_tree_vars <- c("class", "cue", "direction", "threshold", "exit")  # [all singular]
+      cur_tree_df <- level_stats_i[ , req_tree_vars]
+      # print(cur_tree_df)  # 4debugging
+
+      tree_definitions[tree_i, ] <- write_fft_df(fft = cur_tree_df, tree = tree_i)
+      # print(tree_definitions[tree_i, ])  # 4debugging
+
+      # NEW code end. ----
+
       # OLD code start: ----
 
       # # Store OLD tree definition ("_o") using level_stats_i (each FFT as 1 line of df):
@@ -760,19 +772,6 @@ fftrees_grow_fan <- function(x,
       # OLD code end. ----
 
       # +++ here now +++
-
-
-      # NEW code start: ----
-
-      # Select variables of cur_tree_df from level_stats_i:
-      req_tree_vars <- c("class", "cue", "direction", "threshold", "exit")  # [all singular]
-      cur_tree_df <- level_stats_i[ , req_tree_vars]
-      # print(cur_tree_df)  # 4debugging
-
-      tree_definitions[tree_i, ] <- write_fft_df(fft = cur_tree_df, tree = tree_i)
-      # print(tree_definitions[tree_i, ])  # 4debugging
-
-      # NEW code end. ----
 
     } # loop (over trees).
 

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -775,7 +775,6 @@ fftrees_grow_fan <- function(x,
 
     } # loop (over trees).
 
-
     # Check: Verify equality of OLD and NEW code results:
     if (!all.equal(tree_definitions, tree_definitions_o)) { stop("OLD vs. NEW: tree_definitions diff") }
 

--- a/R/fftrees_wordstofftrees.R
+++ b/R/fftrees_wordstofftrees.R
@@ -269,6 +269,21 @@ fftrees_wordstofftrees <- function(x,
 
   # Save result in x$trees$definitions (1 line, as df): ----
 
+  # NEW code start: ----
+
+  fft_df <- data.frame(class = classes_v,
+                       cue = cues_v,
+                       direction = directions_v,
+                       threshold = thresholds_v,
+                       exit = exits_v,
+                       #
+                       stringsAsFactors = FALSE
+  )
+
+  my_tree_def <- write_fft_df(fft = fft_df, tree = 1L)
+  # print(my_tree_def)  # 4debugging
+
+  # NEW code end. ----
 
 
   # OLD code start: ----
@@ -293,22 +308,6 @@ fftrees_wordstofftrees <- function(x,
   # OLD code end. ----
 
   # +++ here now +++:
-
-  # NEW code start: ----
-
-  fft_df <- data.frame(class = classes_v,
-                       cue = cues_v,
-                       direction = directions_v,
-                       threshold = thresholds_v,
-                       exit = exits_v,
-                       #
-                       stringsAsFactors = FALSE
-  )
-
-  my_tree_def <- write_fft_df(fft = fft_df, tree = 1L)
-  # print(my_tree_def)  # 4debugging
-
-  # NEW code end. ----
 
   # # Check: Verify equality of OLD and NEW code results:
   # if (!all.equal(my_tree_def, my_tree_def_o)) { stop("OLD vs. NEW: my_tree_def diff") }

--- a/R/fftrees_wordstofftrees.R
+++ b/R/fftrees_wordstofftrees.R
@@ -273,22 +273,22 @@ fftrees_wordstofftrees <- function(x,
 
   # OLD code start: ----
 
-  # fft_node_sep <- ";"  # (local constant)
-
-  my_tree_def_o <- data.frame(
-    # Add. variables:
-    tree       = 1L,
-    nodes      = nodes_n,
-    # Key variables of fft (all plural):
-    classes    = paste(classes_v,    collapse = fft_node_sep),
-    cues       = paste(cues_v,       collapse = fft_node_sep),
-    directions = paste(directions_v, collapse = fft_node_sep),
-    thresholds = paste(thresholds_v, collapse = fft_node_sep),
-    exits      = paste(exits_v,      collapse = fft_node_sep),
-    #
-    stringsAsFactors = FALSE
-  )
-  # print(my_tree_def_o)  # 4debugging
+  # # fft_node_sep <- ";"  # (local constant)
+  #
+  # my_tree_def_o <- data.frame(
+  #   # Add. variables:
+  #   tree       = 1L,
+  #   nodes      = nodes_n,
+  #   # Key variables of fft (all plural):
+  #   classes    = paste(classes_v,    collapse = fft_node_sep),
+  #   cues       = paste(cues_v,       collapse = fft_node_sep),
+  #   directions = paste(directions_v, collapse = fft_node_sep),
+  #   thresholds = paste(thresholds_v, collapse = fft_node_sep),
+  #   exits      = paste(exits_v,      collapse = fft_node_sep),
+  #   #
+  #   stringsAsFactors = FALSE
+  # )
+  # # print(my_tree_def_o)  # 4debugging
 
   # OLD code end. ----
 
@@ -310,8 +310,8 @@ fftrees_wordstofftrees <- function(x,
 
   # NEW code end. ----
 
-  # Check: Verify equality of OLD and NEW code results:
-  if (!all.equal(my_tree_def, my_tree_def_o)) { stop("OLD vs. NEW: my_tree_def diff") }
+  # # Check: Verify equality of OLD and NEW code results:
+  # if (!all.equal(my_tree_def, my_tree_def_o)) { stop("OLD vs. NEW: my_tree_def diff") }
 
 
   # Modify object x:

--- a/R/fftrees_wordstofftrees.R
+++ b/R/fftrees_wordstofftrees.R
@@ -310,7 +310,6 @@ fftrees_wordstofftrees <- function(x,
 
   # NEW code end. ----
 
-
   # Check: Verify equality of OLD and NEW code results:
   if (!all.equal(my_tree_def, my_tree_def_o)) { stop("OLD vs. NEW: my_tree_def diff") }
 

--- a/R/summaryFFTrees_function.R
+++ b/R/summaryFFTrees_function.R
@@ -93,7 +93,7 @@ summary.FFTrees <- function(object,
 
   # General information: Current algorithm, goals, numerical parameters, etc.:
 
-  params_txt <- paste0("algorithm = '", object$params$algorithm)
+  params_txt <- paste0("algorithm = '", object$params$algorithm, "'")
   params_num <- paste0("max.levels = ", object$params$max.levels)
 
   params_goal <- paste0("goal = '", object$params$goal,
@@ -114,8 +114,9 @@ summary.FFTrees <- function(object,
   # General user feedback (in all settings): ----
   cat("- Parameters: ",
       params_txt, ", ", # "              ",
-      params_num, "\n",   "              ",
-      params_goal, sep = "")
+      params_num, ",\n",   "              ",
+      params_goal, ".",
+      sep = "")
   cat("\n")
 
   # Specific user feedback (conditional on current settings): ----

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -65,12 +65,11 @@ read_fft_df <- function(ffts, tree = 1){
   # Main: ----
 
   # Extract elements of definition (as vectors):
-  classes    <- trimws(unlist(strsplit(cur_fft$classes,    fft_node_sep)))
-  cues       <- trimws(unlist(strsplit(cur_fft$cues,       fft_node_sep)))
-  directions <- trimws(unlist(strsplit(cur_fft$directions, fft_node_sep)))
-  thresholds <- trimws(unlist(strsplit(cur_fft$thresholds, fft_node_sep)))
-  exits      <- trimws(unlist(strsplit(cur_fft$exits,      fft_node_sep)))
-
+  classes    <- trimws(unlist(strsplit(cur_fft$classes,    split = fft_node_sep, fixed = TRUE)))
+  cues       <- trimws(unlist(strsplit(cur_fft$cues,       split = fft_node_sep, fixed = TRUE)))
+  directions <- trimws(unlist(strsplit(cur_fft$directions, split = fft_node_sep, fixed = TRUE)))
+  thresholds <- trimws(unlist(strsplit(cur_fft$thresholds, split = fft_node_sep, fixed = TRUE)))
+  exits      <- trimws(unlist(strsplit(cur_fft$exits,      split = fft_node_sep, fixed = TRUE)))
 
   # Verify that the vector lengths (of tree definition parts) correspond to n_nodes:
   v_lengths <- sapply(list(classes, cues, directions, thresholds, exits), FUN = length)
@@ -79,10 +78,11 @@ read_fft_df <- function(ffts, tree = 1){
 
     # Determine vectors with lengths differing from n_nodes:
     req_tvec_names <- c("classes", "cues", "directions", "thresholds", "exits")  # [mostly plural]
-    req_tvec_na_ix <- v_lengths != n_nodes
-    req_tvec_diffs <- paste(req_tvec_names[req_tvec_na_ix], collapse = ", ")
+    ixs_with_diffs <- v_lengths != n_nodes  # name indices
+    tvec_diffs_col <- paste(req_tvec_names[ixs_with_diffs], collapse = ", ")
+    vlen_diffs_col <- paste(v_lengths[ixs_with_diffs], collapse = ", ")
 
-    msg <- paste0("The lengths of some FFT definition parts differ from n_nodes = ", n_nodes, ": ", req_tvec_diffs)
+    msg <- paste0("The lengths of some FFT definition parts differ from n_nodes = ", n_nodes, ":\n  names of v = (", tvec_diffs_col, "), v_lengths = (", vlen_diffs_col, ").")
     stop(msg)
 
   }

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,6 +53,7 @@ url_JDM_pdf   <- "https://journal.sjdm.org/17/17217/jdm17217.pdf"
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color='b22222')](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- ALL status badges end. --> 
 
+
 <!-- Pkg goal: -->
 
 The R package **FFTrees** creates, visualizes and evaluates _fast-and-frugal decision trees_ (FFTs) for solving binary classification tasks following the methods described in Phillips, Neth, Woike & Gaissmaier (2017, as\ [html](`r url_JDM_html`) | [PDF](`r url_JDM_pdf`)). 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.8.0.9011 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.8.0.9012 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -328,6 +328,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-01-21.\]
+\[File `README.Rmd` last updated on 2023-01-23.\]
 
 <!-- eof. -->

--- a/tests/testthat/test-mytree.R
+++ b/tests/testthat/test-mytree.R
@@ -1,7 +1,8 @@
 context("test-mytree")
 
 
-test_that("Can build tree based off of auto-generated tree in words", {
+test_that("Can build tree based on best auto-generated tree in words (v1)", {
+
   x <- FFTrees(diagnosis ~ .,
     data = heartdisease,
     quiet = TRUE
@@ -20,16 +21,16 @@ test_that("Can build tree based off of auto-generated tree in words", {
 })
 
 
-test_that("Can build tree based off of custom tree in words (v1)", {
+test_that("Can build tree based on custom tree in words (v2)", {
 
-  best_tree_in_words <- "If thalach > 170, decide True.
+  my_tree_in_words <- "If thalach > 170, decide True.
    If slope = {flat}, decide False.
    If ca <= 0, decide False, otherwise, decide True."
 
   x <- FFTrees(diagnosis ~ .,
     data = heart.train,
     data.test = heart.test,
-    my.tree = best_tree_in_words
+    my.tree = my_tree_in_words
   )
 
   expect_s3_class(object = x, class = "FFTrees")
@@ -37,8 +38,13 @@ test_that("Can build tree based off of custom tree in words (v1)", {
   expect_identical(
     object = x$trees$definitions,
     expected = structure(list(
-      tree = 1L, nodes = 3L, classes = "n;c;n", cues = "thalach;slope;ca",
-      directions = ">;!=;>", thresholds = "170;flat;0", exits = "1;0;.5"
+      tree = 1L,
+      nodes = 3L,
+      classes = paste(c("n", "c", "n"),         collapse = fft_node_sep), # "n;c;n",
+      cues = paste(c("thalach", "slope", "ca"), collapse = fft_node_sep), # "thalach;slope;ca",
+      directions = paste(c(">", "!=", ">"),     collapse = fft_node_sep), # ">;!=;>",
+      thresholds = paste(c("170", "flat", "0"), collapse = fft_node_sep), # "170;flat;0",
+      exits = paste(c("1", "0", ".5"),          collapse = fft_node_sep)  # "1;0;.5"
     ),
     row.names = c(NA, -1L), class = c("tbl_df", "tbl", "data.frame")
     )
@@ -47,15 +53,16 @@ test_that("Can build tree based off of custom tree in words (v1)", {
 })
 
 
-test_that("Can build tree based off of custom tree in words (v2)", {
-  best_tree_in_words <- "If thal = {fd}, decide False.
+test_that("Can build tree based on custom tree in words (v3)", {
+
+  my_tree_2 <- "If thal = {fd}, decide False.
    If age > 40, decide False.
    If ca > 0, decide False, otherwise, decide True."
 
   x <- FFTrees(diagnosis ~ .,
     data = heart.train,
     data.test = heart.test,
-    my.tree = best_tree_in_words
+    my.tree = my_tree_2
   )
 
   expect_s3_class(object = x, class = "FFTrees")
@@ -63,8 +70,13 @@ test_that("Can build tree based off of custom tree in words (v2)", {
   expect_identical(
     object = x$trees$definitions,
     expected = structure(list(
-      tree = 1L, nodes = 3L, classes = "c;n;n", cues = "thal;age;ca",
-      directions = "!=;<=;<=", thresholds = "fd;40;0", exits = "0;0;.5"
+      tree = 1L,
+      nodes = 3L,
+      classes = paste(c("c", "n", "n"),       collapse = fft_node_sep), # "c;n;n",
+      cues = paste(c("thal", "age", "ca"),    collapse = fft_node_sep), # "thal;age;ca",
+      directions = paste(c("!=", "<=", "<="), collapse = fft_node_sep), # "!=;<=;<=",
+      thresholds = paste(c("fd", "40", "0"),  collapse = fft_node_sep), # "fd;40;0",
+      exits = paste(c("0", "0", ".5"),        collapse = fft_node_sep)  # "0;0;.5"
     ),
     row.names = c(NA, -1L), class = c("tbl_df", "tbl", "data.frame")
     )
@@ -73,7 +85,7 @@ test_that("Can build tree based off of custom tree in words (v2)", {
 })
 
 
-test_that("A custom tree in my.tree is built successfully (v3)", {
+test_that("A custom tree in my.tree is built successfully (v4)", {
 
   # Create my.fft (from a verbal FFT description,
   # with the final node predicting the True (1:right) criterion value first:
@@ -92,8 +104,13 @@ test_that("A custom tree in my.tree is built successfully (v3)", {
   expect_identical(
     object = my.fft$trees$definitions,
     expected = structure(list(
-      tree = 1L, nodes = 3L, classes = "n;n;c", cues = "sex;age;thal",
-      directions = "=;>=;!=", thresholds = "1;45;fd,normal", exits = "1;0;.5"
+      tree = 1L,
+      nodes = 3L,
+      classes = paste(c("n", "n", "c"),             collapse = fft_node_sep), # "n;n;c",
+      cues = paste(c("sex", "age", "thal"),         collapse = fft_node_sep), # "sex;age;thal",
+      directions = paste(c("=", ">=", "!="),        collapse = fft_node_sep), # "=;>=;!=",
+      thresholds = paste(c("1", "45", "fd,normal"), collapse = fft_node_sep), # "1;45;fd,normal",
+      exits = paste(c("1", "0", ".5"),              collapse = fft_node_sep)  # "1;0;.5"
     ), class = c(
       "tbl_df",
       "tbl", "data.frame"


### PR DESCRIPTION
This PR improves the package's **consistency**, **modularity**, and **robustness**, by completing the overhaul of tree translation functions and code snippets of the last 2 PRs.  Details include:

- using complementary `read_fft_df()` and `write_fft_df()` functions (and corresponding verification functions)
- using a global tree node separator `fft_node_sep` (also in tests)
- providing more consistent and explicit user feedback
- providing more informative `summary()` (e.g., on params)

**Please note**:  Due to the wide range of changes and despite careful checks, the OLD code snippets are currently only commented out (in case something should break).  If all goes well, they will be removed in future cleanups...