### PR TITLE
Expand the range of interpretable `my.tree` definitions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.8.0.9013
-Date: 2023-01-25
+Version: 1.8.0.9014
+Date: 2023-01-26
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.8.0.9012
-Date: 2023-01-22
+Version: 1.8.0.9013
+Date: 2023-01-25
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.8
 
-## 1.8.0.9013
+## 1.8.0.9014
 
 This is the current development version of **FFTrees**, available at <https://github.com/ndphillips/FFTrees>. 
 
@@ -18,7 +18,7 @@ Changes since last release:
 
 ### Major changes 
 
-- Prepared for modular tree translation and editing functions (`util_gfft.R`). 
+- Increased vocabulary for interpreting verbal FFT descriptions (using `my.tree`).
 - Enabled user-defined `my.goal` on cue and tree levels (as defined by `my.goal.fun`). 
 - Enabled optimizing `dprime` on cue and tree levels (by using `"dprime"` as `goal.threshold`, `goal.chase`, or `goal` values). 
 - Added decision outcome and cue costs to `asif_results` (in `fftrees_grow_fan()`). 
@@ -28,12 +28,12 @@ Changes since last release:
 
 ### Minor changes 
 
-- Prepared for global tree notation separator (`fft_node_sep`). 
 - Included `dprime` values in cue level statistics (`x$cues$thresholds` and `x$cues$stats`). 
 - Included `dprime` values in competition statistics (`x$competition$train` and `x$competition$test`). 
 - Improved `summary()`: Include current goal and cost values (if `"cost"` used in goals).
 - Improved user feedback on combinations of goal and cost values.
-
+- Prepared for modular tree translation and editing functions (`util_gfft.R`). 
+- Prepared for global tree notation separator (`fft_node_sep`). 
 
 <!-- Details: --> 
 
@@ -408,6 +408,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2023-01-25.]
+[File `NEWS.md` last updated on 2023-01-26.]
 
 <!-- eof. -->

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,14 @@
 
 # FFTrees 1.8
 
-## 1.8.0.9012
+## 1.8.0.9013
 
 This is the current development version of **FFTrees**, available at <https://github.com/ndphillips/FFTrees>. 
 
 **FFTrees** version 1.9.0 is to be released [on CRAN](https://CRAN.R-project.org/package=FFTrees) [in 2023-02]. 
-This version improves consistency (by abstraction), robustness (by more global object verification), and transparency (by more explicit user feedback), but also fixes some bugs.
+This version adds functionality (e.g., optimizing for new goals), 
+improves consistency and robustness (by increasing abstraction, e.g., using more global constants and object verification), 
+increases transparency (by providing more explicit user feedback), and fixes some bugs. 
 
 <!-- Log of changes: --> 
 
@@ -40,8 +42,9 @@ Changes since last release:
 - Added verification functions (for checking integrity of objects or validity of inputs).
 - Re-arranged arguments of key functions (`FFTrees()` and `fftrees_create()`) by functionality. 
 - Re-arranged and cleaned code (in main and helper functions).
+- Re-defined local constants as global constants (in `util_gfft.R`). 
 - Revised status badges in `README`. 
-- Fixed bugs and revised vignettes.
+- Fixed bugs and revised vignettes. 
 
 
 <!-- Development version: --> 
@@ -67,9 +70,7 @@ Changes since last release:
 ### Major changes
 
 - Enabled manually defining FFTs with `tree.definitions` or using FFTs of `object` in `FFTrees()`. 
-
 - Enabled setting `goal = 'dprime'` to select FFTs in `FFTrees()`. 
-
 - Added and improved user feedback (when `quiet = FALSE`). 
 
 
@@ -81,6 +82,8 @@ Changes since last release:
     - Show `n.per.icon` legend when `what = 'icontree'`. 
     - Bug fix: Removed clipping of titles and labels.
     - Tweaked spacing parameters.
+
+<!-- Blank line. --> 
 
 - Trimmed white space from elements in tree definitions (in `fftrees_apply.R`). 
 
@@ -405,6 +408,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2023-01-22.]
+[File `NEWS.md` last updated on 2023-01-25.]
 
 <!-- eof. -->

--- a/R/fftrees_wordstofftrees.R
+++ b/R/fftrees_wordstofftrees.R
@@ -43,12 +43,14 @@ fftrees_wordstofftrees <- function(x,
 
   # Parameters / options: ------
 
-  directions_df <- data.frame(
-    direction   = c( "=",  ">", ">=", "<",  "<=", "!=", "equal", "equals", "equal to", "greater", "less"),
-    negation    = c("!=", "<=", "<",  ">=", ">",   "=",  "!=",    "!=",     "!=",       "<=",      ">=" ),
-    direction_f = c( "=",  ">", ">=", "<",  "<=", "!=",   "=",     "=",      "=",       ">",       "<"  ),
-    stringsAsFactors = FALSE
-  ) # (local constant)
+  # # Direction markers (symbols/words):
+  # directions_df <- data.frame(
+  #   direction   = c( "=",  ">", ">=", "<",  "<=", "!=", "equal", "equals", "equal to", "greater", "less"),
+  #   negation    = c("!=", "<=", "<",  ">=", ">",   "=",  "!=",    "!=",     "!=",       "<=",      ">=" ),
+  #   direction_f = c( "=",  ">", ">=", "<",  "<=", "!=",   "=",     "=",      "=",       ">",       "<"  ),
+  #   #
+  #   stringsAsFactors = FALSE
+  # ) # (local constant)
 
   # ToDo: Delete if not used anywhere: ----
   #
@@ -241,7 +243,9 @@ fftrees_wordstofftrees <- function(x,
     })
 
     # Look for negations in sentences:
-    negations_v <- c("not")  # (local constant)
+
+    # Define negation markers:
+    # negations_v <- c("not")  # (local constant)
 
     # Which sentences have negations?
     negations_log <- unlist(lapply(def[1:nodes_n], FUN = function(node_sentence) {

--- a/R/fftrees_wordstofftrees.R
+++ b/R/fftrees_wordstofftrees.R
@@ -96,7 +96,8 @@ fftrees_wordstofftrees <- function(x,
 
   # Split my.tree into def parts (dropping "otherwise" clause): ------
 
-  def <- unlist(strsplit(my.tree, split = "if", fixed = TRUE))
+  def <- unlist(strsplit(my.tree, split = "if ", fixed = TRUE))  # Note: Also removes trailing " " after "if"!
+  def <- paste0(" ", def)    # add leading " " again (to include in detecting cue name below)
   def <- def[2:length(def)]  # remove initial empty string
   # print(def)  # 4debugging
 
@@ -118,17 +119,17 @@ fftrees_wordstofftrees <- function(x,
     cues_v <- names(unlist(lapply(def[1:nodes_n], FUN = function(node_sentence) {
 
       # Can I find the name of a cue in this sentence?
-      cue.exists <- any(sapply(cue_names_l, FUN = function(cue.i) {
-        any(stringr::str_detect(node_sentence, paste0(" ", cue.i, " ")))
+      cue_exists <- any(sapply(cue_names_l, FUN = function(cue_i_name) {
+        any(stringr::str_detect(node_sentence, paste0(" ", cue_i_name, " ")))
       }))
 
-      if (!cue.exists) {
+      if (!cue_exists) {
         stop(paste("I could not find any valid cue names in the sentence: '", node_sentence, "'. Please rewrite", sep = ""))
       }
 
-      if (cue.exists) {
-        output <- which(sapply(cue_names_l, FUN = function(cue.i) {
-          stringr::str_detect(node_sentence, paste0(" ", cue.i, " "))
+      if (cue_exists) {
+        output <- which(sapply(cue_names_l, FUN = function(cue_i_name) {
+          stringr::str_detect(node_sentence, paste0(" ", cue_i_name, " "))
         }))
       }
 
@@ -141,6 +142,7 @@ fftrees_wordstofftrees <- function(x,
       which(cue_names_l == x)
     })]
   }
+
 
   # 2. classes_v: ----
   {
@@ -219,6 +221,7 @@ fftrees_wordstofftrees <- function(x,
 
     })
   }
+
 
   # 5. directions_v: ----
   {

--- a/R/fftrees_wordstofftrees.R
+++ b/R/fftrees_wordstofftrees.R
@@ -44,7 +44,7 @@ fftrees_wordstofftrees <- function(x,
   # Parameters / options: ------
 
   directions_df <- data.frame(
-    directions   = c("=",  ">",  ">=", "<",  "<=", "!=", "equal", "equals", "equal to", "greater", "less"),
+    directions   = c( "=",  ">", ">=", "<",  "<=", "!=", "equal", "equals", "equal to", "greater", "less"),
     negations    = c("!=", "<=", "<",  ">=", ">",   "=",  "!=",    "!=",     "!=",       "<=",      ">=" ),
     directions_f = c( "=",  ">", ">=", "<",  "<=", "!=",   "=",     "=",      "=",       ">",       "<"  ),
     stringsAsFactors = FALSE

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -10,9 +10,28 @@
 # B. Tree manipulation functions for editing individual FFTs.
 
 
-# (0) Constants: ------
+# (0) Define global constants: ------
+
+
+# - Node separation marker (symbol): ----
 
 fft_node_sep <- ";"  # (global constant)
+
+
+# - Direction markers (symbols/words): ----
+
+directions_df <- data.frame(
+  direction   = c( "=",  ">", ">=", "<",  "<=", "!=", "equal", "equals", "equal to", "greater", "less"),
+  negation    = c("!=", "<=", "<",  ">=", ">",   "=",  "!=",    "!=",     "!=",       "<=",      ">=" ),
+  direction_f = c( "=",  ">", ">=", "<",  "<=", "!=",   "=",     "=",      "=",       ">",       "<"  ),
+  #
+  stringsAsFactors = FALSE)  # (global constant)
+
+
+# - Negation markers: ----
+
+negations_v <- c("not")  # (global constant)
+
 
 
 # (A) Tree conversion/translation functions: ------

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -20,23 +20,35 @@ fft_node_sep <- ";"  # (global constant)
 
 # - Direction markers (symbols/words): ----
 
+direction_same <- c("equal", "identical", "same")
+direction_diff <- c("unequal", "different", "differs")
+
+direction_more <- c("more", "larger", "bigger", "greater", "above", "beyond", "exceed")
+direction_less <- c("less", "lower", "smaller", "fewer", "below")
+
 directions_df <- data.frame(
-  direction   = c( "=",  ">", ">=", "<",  "<=", "!=", "equal", "equals", "equal to",
-                   "greater", "larger",  "bigger", "more",
-                   "less",    "smaller", "fewer"),
-  direction_f = c( "=",  ">", ">=", "<",  "<=", "!=",   "=",     "=",      "=",
-                   ">",       ">",       ">",      ">",
-                   "<",       "<",       "<"),
-  negation    = c("!=", "<=", "<",  ">=", ">",   "=",  "!=",    "!=",     "!=",
-                  "<=",      "<=",      "<=",      "<=",
-                  ">=",      ">=",      ">="),
+  direction   = c("=",  ">", ">=", "<",  "<=", "!=",
+                  direction_same,
+                  direction_diff,
+                  direction_more,
+                  direction_less),
+  direction_f = c("=",  ">",  ">=", "<",  "<=", "!=",
+                  rep("=",  length(direction_same)),  # same
+                  rep("!=", length(direction_diff)),  # diff
+                  rep(">",  length(direction_more)),   # more
+                  rep("<",  length(direction_less))),  # less
+  negation    = c("!=", "<=", "<",  ">=", ">",  "=",
+                  rep("!=",  length(direction_same)),  # NOT same
+                  rep("=",   length(direction_diff)),   # NOT diff
+                  rep("<=",  length(direction_more)),   # NOT more
+                  rep(">=",  length(direction_less))),  # NOT less
   #
   stringsAsFactors = FALSE)  # (global constant)
 
 
 # - Negation markers: ----
 
-negations_v <- c("not")  # (global constant)
+negations_v <- c("not", "is not")  # (global constant)
 
 
 

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -21,9 +21,15 @@ fft_node_sep <- ";"  # (global constant)
 # - Direction markers (symbols/words): ----
 
 directions_df <- data.frame(
-  direction   = c( "=",  ">", ">=", "<",  "<=", "!=", "equal", "equals", "equal to", "greater", "less"),
-  negation    = c("!=", "<=", "<",  ">=", ">",   "=",  "!=",    "!=",     "!=",       "<=",      ">=" ),
-  direction_f = c( "=",  ">", ">=", "<",  "<=", "!=",   "=",     "=",      "=",       ">",       "<"  ),
+  direction   = c( "=",  ">", ">=", "<",  "<=", "!=", "equal", "equals", "equal to",
+                   "greater", "larger",  "bigger", "more",
+                   "less",    "smaller", "fewer"),
+  direction_f = c( "=",  ">", ">=", "<",  "<=", "!=",   "=",     "=",      "=",
+                   ">",       ">",       ">",      ">",
+                   "<",       "<",       "<"),
+  negation    = c("!=", "<=", "<",  ">=", ">",   "=",  "!=",    "!=",     "!=",
+                  "<=",      "<=",      "<=",      "<=",
+                  ">=",      ">=",      ">="),
   #
   stringsAsFactors = FALSE)  # (global constant)
 

--- a/R/util_verify.R
+++ b/R/util_verify.R
@@ -242,13 +242,15 @@ verify_fft_definitions <- function(fft_defs){
 
   if (all(req_tdef_vars %in% provided_vars)){
 
+    # ToDo: Verify variables further (e.g., verify their contents).
+
     return(TRUE)
 
   } else {
 
     missing_vars <- setdiff(req_tdef_vars, provided_vars)
 
-    message("Input fft_defs is missing the variables: ", paste(missing_vars, collapse = ", "))
+    message("Input fft_defs is not a valid FFT definition.\nMissing variables: ", paste(missing_vars, collapse = ", "))
 
     return(FALSE)
 
@@ -284,6 +286,8 @@ verify_fft_components <- function(fft_df){
   # Note: c("tree", "nodes") are only part of EXISTING tree definitions (i.e., not needed here).
 
   if (all(req_tree_vars %in% provided_vars)){
+
+    # ToDo: Verify variables further (e.g., verify their contents).
 
     return(TRUE)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -38,12 +38,10 @@ url_JDM_pdf   <- "https://journal.sjdm.org/17/17217/jdm17217.pdf"
 [![R-CMD-check](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml)
 <!-- Devel badges end. -->
 
-
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color=blue)](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- Release badges end. -->
-
 
 <!-- ALL status badges start: --> 
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.8.0.9012 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.8.0.9014 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -328,6 +328,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-01-23.\]
+\[File `README.Rmd` last updated on 2023-01-26.\]
 
 <!-- eof. -->

--- a/vignettes/FFTrees_mytree.Rmd
+++ b/vignettes/FFTrees_mytree.Rmd
@@ -195,7 +195,7 @@ fft_1 <- FFTrees(diagnosis ~.,
 
 # inspect:
 fft_1$trees$definitions
-plot(fft_1)
+plot(fft_1)  # Note flipped direction for cue 1: exit = 0.
 fft_1
 inwords(fft_1)
 

--- a/vignettes/FFTrees_mytree.Rmd
+++ b/vignettes/FFTrees_mytree.Rmd
@@ -68,7 +68,7 @@ Table: **Table 1**: Five cues and the binary criterion variable `diagnosis` for 
 
 Here's how we could verbally describe an FFT by using the first three cues in conditional sentences: 
 
-```{r fft-description}
+```{r my-tree-describe-fft-1}
 in_words <- "If sex = 1, predict True.
              If age < 45, predict False. 
              If thal = {fd, normal}, predict True. 
@@ -104,7 +104,7 @@ The text `Otherwise, predict EXIT` that we have included in the example above is
 Now, let's use our verbal description of an FFT (assigned to `in_words` above) as the `my.tree` argument of the `FFTrees()` function. 
 This creates a corresponding FFT and applies it to the `heartdisease` data:
 
-```{r create-my-tree, message = FALSE, results = 'hide'}
+```{r my-tree-create-1, message = FALSE, results = 'hide'}
 # Create FFTrees from a verbal FFT description (as my.tree): 
 my_fft <- FFTrees(diagnosis ~.,
                   data = heartdisease,
@@ -114,7 +114,7 @@ my_fft <- FFTrees(diagnosis ~.,
 
 Let's see how well our manually constructed FFT (`my_fft`) did:
 
-```{r plot-my-tree, fig.cap = "**Figure 1**: An FFT manually constructed using the `my.tree` argument of `FFTrees()`.", fig.show = 'hold'}
+```{r my-tree-plot-1, fig.cap = "**Figure 1**: An FFT manually constructed using the `my.tree` argument of `FFTrees()`.", fig.show = 'hold'}
 # Inspect FFTrees object:
 plot(my_fft)
 ```
@@ -123,6 +123,21 @@ plot(my_fft)
 
 When manually constructing a tree, the resulting `FFTrees` object only contains a single FFT. 
 Hence, the ROC plot (in the right bottom panel of **Figure\ 1**) cannot show a range of FFTs, but locates the constructed FFT in ROC space. 
+
+<!-- Note on tree definitions: -->
+
+The formal definition of our new FFT is available from the `FFTrees` object\ `my_fft`:
+
+```{r my-tree-def-1}
+# Get FFT definition(s):
+my_fft$trees$definitions
+```
+
+<!-- Note that noise exits (0) appear to have flipped directions: -->
+
+Note that the 2nd\ cue (`age`) in this FFT is predicting the _noise_ outcome (i.e., a non-final exit value of\ `0` or\ `FALSE`, shown to the left). 
+As the tree definitions always correspond to the _signal_ outcome (i.e., a non-final exit value of\ `1` or\ `TRUE`, shown to the right), 
+the direction of the 2nd node in **Figure\ 1** (if `age < 45`, predict\ `0`) is flipped relative to the tree definition (if `age >= 45`, predict\ `1`). Thus, the plot and the formal definition refer to the same\ FFT.
 
 <!-- Performance: -->
 
@@ -136,7 +151,7 @@ Consequently, its accuracy measures are only around baseline level.
 Let's see if we can come up with a better FFT. 
 The following example uses the cues\ `thal`, `cp`, and\ `ca` in the `my.tree` argument: 
 
-```{r verbal-spec-fft-1, message = FALSE, results = 'hide'}
+```{r my-tree-verbal-fft-2, message = FALSE, results = 'hide'}
 # Create 2nd FFTrees from an alternative FFT description (as my.tree): 
 my_fft_2 <- FFTrees(diagnosis ~.,
                     data = heartdisease, 
@@ -147,11 +162,17 @@ my_fft_2 <- FFTrees(diagnosis ~.,
                                Otherwise, predict False.")
 ```
 
-Again, let's view the best training tree to inspect its performance:
+Again, let's visualize the best training tree (to evaluate its performance) and briefly inspect its tree definition:
 
-```{r verbal-spec-fft-2, fig.cap = "**Figure 2**: Another FFT manually constructed using the `my.tree` argument of `FFTrees()`.", fig.show = 'hold'}
-# Inspect FFTrees object:
+```{r my-tree-plot-fft-2, fig.cap = "**Figure 2**: Another FFT manually constructed using the `my.tree` argument of `FFTrees()`.", fig.show = 'hold', collapse = TRUE}
+# Visualize FFT:
 plot(my_fft_2)
+
+# FFT definition:
+my_fft_2$trees$definitions
+# Note the flipped direction value for 2nd cue (exit = '0'):
+# 'if (cp  = a), predict 1' in the definition corresponds to 
+# 'if (cp != a), predict 0' in the plot.  
 ```
 
 This alternative FFT is nicely balancing sensitivity and specificity and performs much better overall. 
@@ -162,7 +183,7 @@ Nevertheless, it is still far from perfect ---\ so check out whether you can cre
 <!-- 1. In `fftrees_wordstofftrees()`, "Otherwise" part is being ignored. --> 
 <!-- 2. In `fftrees_ffttowords()`, the final sentence always predicts positive (True) instances first. --> 
 
-```{r checking-my-tree, echo = FALSE, eval = FALSE}
+```{r my-tree-checks-1, echo = FALSE, eval = FALSE}
 # 1. FFT with 2 cues (final cue is categorical): ------ 
 
 fft_1 <- FFTrees(diagnosis ~.,

--- a/vignettes/FFTrees_mytree.Rmd
+++ b/vignettes/FFTrees_mytree.Rmd
@@ -151,8 +151,8 @@ Consequently, its accuracy measures are only around baseline level.
 Let's see if we can come up with a better FFT. 
 The following example uses the cues\ `thal`, `cp`, and\ `ca` in the `my.tree` argument: 
 
-```{r my-tree-verbal-fft-2, message = FALSE, results = 'hide'}
-# Create 2nd FFTrees from an alternative FFT description (as my.tree): 
+```{r my-tree-fft-2-create, eval = FALSE, message = FALSE, results = 'hide'}
+# Create a 2nd FFT from an alternative FFT description (as my.tree): 
 my_fft_2 <- FFTrees(diagnosis ~.,
                     data = heartdisease, 
                     main = "My 2nd FFT", 
@@ -162,7 +162,29 @@ my_fft_2 <- FFTrees(diagnosis ~.,
                                Otherwise, predict False.")
 ```
 
-Again, let's visualize the best training tree (to evaluate its performance) and briefly inspect its tree definition:
+<!-- Show the flexibility in interpreting `my.tree`: -->
+
+As **FFTrees** aims to interpret the `my.tree` argument to the best of its abilities, there is some flexibility in entering a verbal description of an\ FFT. For instance, we also could have described our desired FFT in more flowery terms:
+
+```{r my-tree-fft-2-create-2, eval = TRUE, message = FALSE, results = 'hide'}
+# Create a 2nd FFT from an alternative FFT description (as my.tree): 
+my_fft_2 <- FFTrees(diagnosis ~.,
+                    data = heartdisease, 
+                    main = "My 2nd FFT", 
+                    my.tree = "If thal equals {rd,fd}, we shall say True.  
+                               If Cp differs from {a}, let's predict False.   
+                               If CA happens to exceed 1, we will insist on True.  
+                               Else, give up and go away.") 
+```
+
+However, as the vocabulary of **FFTrees** is limited, it is safer to enter cue directions in their symbolic form (i.e., using\ `=`, `<`, `<=`, `>`, `>=`, or\ `!=`).^[Unambiguous `my.tree` descriptions must avoid using "is" and "is not" without additional qualifications (like "equal", "different", "larger", "smaller", etc.).] 
+To verify that **FFTrees** interpreted our `my.tree` description, let's check whether the FFT of `inwords(my_fft_2)` yields a description that corresponds to our intended\ FFT:
+
+```{r my-tree-fft-2-inwords}
+inwords(my_fft_2)
+```
+
+As this seems what we wanted, let's visualize the best training tree (to evaluate its performance) and briefly inspect its tree definition:
 
 ```{r my-tree-plot-fft-2, fig.cap = "**Figure 2**: Another FFT manually constructed using the `my.tree` argument of `FFTrees()`.", fig.show = 'hold', collapse = TRUE}
 # Visualize FFT:
@@ -171,8 +193,8 @@ plot(my_fft_2)
 # FFT definition:
 my_fft_2$trees$definitions
 # Note the flipped direction value for 2nd cue (exit = '0'):
-# 'if (cp  = a), predict 1' in the definition corresponds to 
-# 'if (cp != a), predict 0' in the plot.  
+# 'if (cp  = a), predict 1' in the tree definition corresponds to 
+# 'if (cp != a), predict 0' in the my.tree description and plot.  
 ```
 
 This alternative FFT is nicely balancing sensitivity and specificity and performs much better overall. 


### PR DESCRIPTION
This PR mostly expands the range of possible `my.tree` definitions (by increasing the contents of the global constant `directions_df`).  

- See an example in vignette on "Manually specifying FFTs" (`FFTrees_mytree.Rmd`). 

