### PR TITLE
Keeping goal and cost parameters of existing`FFTrees` object and fix a bug in `flip_exit()`

### DIFF
--- a/R/FFTrees.R
+++ b/R/FFTrees.R
@@ -247,11 +247,32 @@ FFTrees <- function(formula = NULL,
     testthat::expect_s3_class(object, class = "FFTrees")
 
     # Fill in some missing defaults by current object values:
-    if (is.null(formula)){ formula <- object$formula }
+
+    # Main formula and data parameters (to keep/preserve):
+    if (is.null(formula)) { formula <- object$formula }
     if (is.null(data)) { data <- object$data$train }
     if (is.null(data.test) & (!is.null(object$data$test))) { data.test <- object$data$test }
 
-    # Other candidates: goal and threshold parameters.
+    # goal parameters:
+    if (is.null(goal)) { goal <- object$params$goal }
+    if (is.null(goal.chase)) { goal.chase <- object$params$goal.chase }
+    if (is.null(goal.threshold)) { goal.threshold <- object$params$goal.threshold }
+
+    # cost parameters:
+    if (is.null(cost.outcomes)) { cost.outcomes <- object$params$cost.outcomes }
+    if (is.null(cost.cues)) { cost.cues <- object$params$cost.cues }
+
+    # Other candidates (of parameters to keep/preserve):
+    # numthresh, stopping, ...
+    if (is.null(algorithm)) { algorithm <- object$params$algorithm }
+    if (is.null(max.levels)) { max.levels <- object$params$max.levels }
+
+    # Provide user feedback: ----
+
+    if (!quiet) {
+      msg <- paste0("Using the FFTrees object provided (and some of its key parameters).\n")
+      cat(u_f_hig(msg))
+    }
 
   }
 

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -397,19 +397,14 @@ fftrees_create <- function(formula = NULL,
     cost.outcomes <- list(hi = 0, fa = 1, mi = 1, cr = 0)  # default values (analogous to accuracy: r = -1)
 
     if (!quiet) {
-      cat(u_f_msg("\u2014 Setting 'cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0)'\n"))
+      cat(u_f_msg("\u2014 Using the default list of 'cost.outcomes = list(hi = 0, fa = 1, mi = 1, cr = 0)'\n"))
     }
   }
 
   testthat::expect_true(!is.null(cost.outcomes), info = "cost.outcomes is NULL")
-
-  testthat::expect_type(cost.outcomes, type = "list"
-                        # info = "cost.outcomes must be a list in the form list(hi = a, mi = x, fa = x, cr = x)"
-  )
-
+  testthat::expect_type(cost.outcomes, type = "list")
   testthat::expect_true(all(names(cost.outcomes) %in% c("hi", "fa", "mi", "cr")),
-                        info = "cost.outcomes must be a list in the form list(hi = a, fa = b, mi = c, cr = d)"
-  )
+                        info = "cost.outcomes must be a list in the form list(hi = a, fa = b, mi = c, cr = d)")
 
 
   # cost.cues: ----
@@ -417,13 +412,13 @@ fftrees_create <- function(formula = NULL,
   if (!is.null(cost.cues) & (!"cost" %in% cur_goals)) {
 
     if (!quiet) {
-      msg <- paste0("Specified 'cost.cues', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.\n")
+      msg <- paste0("Specified a list of 'cost.cues', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.\n")
       cat(u_f_hig(msg))
     }
   }
 
   if ((!quiet) & (!is.null(cost.cues))) {
-    cat(u_f_msg("\u2014 Setting list of 'cost.cues'\n"))
+    cat(u_f_msg("\u2014 Using a list of 'cost.cues'\n"))
   }
 
   # Append cost.cues (for all cues in data):
@@ -463,7 +458,8 @@ fftrees_create <- function(formula = NULL,
   testthat::expect_type(repeat.cues, type = "logical")
 
 
-  # 2. Data quality checks: ------
+
+  # 2. Verify criterion and data: ------
 
   # Criterion is in data: ----
 

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -372,7 +372,7 @@ reorder_nodes <- function(fft, order = NA){
 
 
 
-# flip_exits: ------
+# flip_exit: ------
 
 
 # Goal: Flip the exits (i.e., cue direction and exit type) of some FFT's (non-final) nodes.
@@ -382,12 +382,20 @@ reorder_nodes <- function(fft, order = NA){
 # Output: Modified version of fft (as df, with flipped cue directions/exits)
 
 
-flip_exits <- function(fft, nodes){
+flip_exit <- function(fft, nodes = NA){
 
   # Prepare: ----
 
   # Verify inputs:
   testthat::expect_true(verify_fft_as_df(fft))
+
+  if (all(is.na(nodes))) { # catch case:
+
+    message("flip_exit: fft remains unchanged")  # 4debugging
+
+    return(fft)
+
+  }
 
   nodes <- as.integer(nodes)
   testthat::expect_true(is.integer(nodes), info = "nodes must be an integer vector")
@@ -407,10 +415,11 @@ flip_exits <- function(fft, nodes){
 
   # Main: ----
 
-  # For all nodes:
+  # For current nodes:
 
-  # 1. flip cue direction:
-  fft$direction[nodes] <- directions_df$negation[match(fft$direction[nodes], table = directions_df$direction)]
+  # ERROR: Cue direction is ALWAYS for criterion = TRUE/signal/1 (on right) => Must not be flipped when exit changes!
+  # # 1. flip cue direction:
+  # fft$direction[nodes] <- directions_df$negation[match(fft$direction[nodes], table = directions_df$direction)]
 
   # 2. swap exit:
   fft$exit[nodes] <- ifelse(fft$exit[nodes] == 1, 0, 1)
@@ -420,19 +429,20 @@ flip_exits <- function(fft, nodes){
 
   return(fft)
 
-} # flip_exits().
+} # flip_exit().
 
 # # Check:
 # ffts_df <- get_fft_definitions(x)  # x$trees$definitions / definitions (as df)
 # (fft <- read_fft_df(ffts_df, tree = 2))  # 1 FFT (as df, from above)
 #
-# flip_exits(fft, nodes = c(1))
-# flip_exits(fft, nodes = c(3))
-# flip_exits(fft, nodes = c(3, 1))
+# flip_exit(fft)
+# flip_exit(fft, nodes = c(1))
+# flip_exit(fft, nodes = c(3))
+# flip_exit(fft, nodes = c(3, 1))
 #
 # # Note:
-# flip_exits(fft, nodes = 4)
-# flip_exits(fft, nodes = 1:4)
+# flip_exit(fft, nodes = 4)
+# flip_exit(fft, nodes = 1:4)
 
 
 
@@ -510,7 +520,7 @@ all_node_orders <- function(fft){
 
 
 # Goal: Get all 2^(n-1) possible exit structures for an FFT with n cues.
-# Method: Use flip_exits() on nodes = `all_combinations()` for all length values of 1:(n_cues - 1).
+# Method: Use flip_exit() on nodes = `all_combinations()` for all length values of 1:(n_cues - 1).
 # Input: fft: 1 FFT (as df, 1 row per cue)
 
 
@@ -544,7 +554,7 @@ all_exit_structures <- function(fft){
 
       for (j in 1:nrow(comb_i)){
 
-        cur_fft <- flip_exits(fft = fft, nodes = comb_i[j, ])
+        cur_fft <- flip_exit(fft = fft, nodes = comb_i[j, ])
 
         cnt <- cnt + 1
 


### PR DESCRIPTION
This PR 

1. prevents that goal and cost parameters are re-set when providing an existing `FFTrees` object to `FFTrees()` and 

2. fixes a bug:  Cue directions must not be flipped when applying `flip_exit()`, as FFT definitions — by convention — always predict TRUE/signal/1 (to the right).