### PR TITLE
Tree trimming functions: Adding `add_nodes()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
 Version: 1.9.0.9005
-Date: 2023-02-17
+Date: 2023-02-18
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
 Version: 1.9.0.9005
-Date: 2023-02-18
+Date: 2023-02-19
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.9.0.9004
-Date: 2023-02-16
+Version: 1.9.0.9005
+Date: 2023-02-17
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -846,6 +846,7 @@ flip_exits <- function(fft, nodes = NA){
 
   n_cues <- nrow(fft)
 
+
   # Special case 1:
   if (any(nodes %in% 1:n_cues == FALSE)){ # some nodes are missing:
 
@@ -865,18 +866,20 @@ flip_exits <- function(fft, nodes = NA){
 
     nodes <- setdiff(nodes, missing_nodes)
 
-  }
+  } # if sc 1.
+
 
   # Special case 2:
   if (n_cues %in% nodes){ # aiming to flip the final/exit node:
 
-    msg <- paste0("flip_exits: Exits of a final node (", n_cues, ") cannot be flipped")
+    msg <- paste0("flip_exits: Cannot flip exits of the final node: ", n_cues)
 
     message(msg)
 
     nodes <- nodes[nodes != n_cues]
 
-  }
+  } # if sc 2.
+
 
   # Main: ----
 
@@ -884,7 +887,7 @@ flip_exits <- function(fft, nodes = NA){
 
   # For current nodes:
 
-  # ERROR: Cue direction is ALWAYS for criterion = TRUE/signal/1 (on right) => Must not be flipped when exit changes!
+  # Note ERROR: Cue direction is ALWAYS for criterion = TRUE/signal/1 (on right) => Must not be flipped when exit changes!
   # # 1. flip cue direction:
   # fft_mod$direction[nodes] <- directions_df$negation[match(fft_mod$direction[nodes], table = directions_df$direction)]
 
@@ -902,8 +905,8 @@ flip_exits <- function(fft, nodes = NA){
 } # flip_exits().
 
 # # Check:
-# (ffts_df <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
-# (fft <- read_fft_df(ffts_df, tree = 2))  # 1 FFT (as df, from above)
+# (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
+# (fft <- read_fft_df(ffts, tree = 2))  # 1 FFT (as df, from above)
 #
 # flip_exits(fft)
 # flip_exits(fft, nodes = c(1))
@@ -919,6 +922,7 @@ flip_exits <- function(fft, nodes = NA){
 #
 # # Flipping all and back:
 # all.equal(fft, flip_exits(flip_exits(fft, nodes = 3:1), nodes = 1:3))
+
 
 
 # reorder_nodes: ------

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -961,7 +961,7 @@ reorder_nodes <- function(fft, order = NA){
 
     return(fft)
 
-  }
+  } # if no change.
 
 
   # Main: ----
@@ -972,9 +972,10 @@ reorder_nodes <- function(fft, order = NA){
   # IF the exit cue has been changed:
   exit_cue_pos <- which(order == n_cues)
 
+  # Special case 1:
   if (exit_cue_pos != n_cues){
 
-    message(paste0("reorder_nodes: Previous exit node moved to node position ", exit_cue_pos))
+    message(paste0("reorder_nodes: Former exit node now is node ", exit_cue_pos))
 
     # ?: Which exit direction should be used for previous exit cue?
 
@@ -995,7 +996,7 @@ reorder_nodes <- function(fft, order = NA){
     # Option 3:
     # Goal: Provide BOTH the noise (0: left) and the signal (1: right) alternative for a previous exit node.
 
-  } # if (exit_cue_pos).
+  } # if sc 1.
 
 
   # Output: ----
@@ -1010,13 +1011,12 @@ reorder_nodes <- function(fft, order = NA){
 
 } # reorder_nodes().
 
-
 # # Check:
 # (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
 # (fft  <- read_fft_df(ffts, tree = 5))
 #
 # plot(x, tree = 5)
-# x$trees$definitions[5, ]
+# ffts[5, ]
 # x$trees$inwords[5]
 #
 # reorder_nodes(fft)  # unchanged

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -1043,18 +1043,26 @@ reorder_nodes <- function(fft, order = NA){
 # 2. A specific set of cues, their order, but variable exit structures:  The FFTs in 1 FFTrees object.
 # 3. A specific set of cues, but variable cue orders and exit structures.
 
+# ToDo:
+# 1. get all node subsets (with all possible subsets of nodes)
+#    = all_combinations() for each possible length (1:n_nodes).
+#
+# 2. Combine
+#    1. all node subsets,
+#    2. all_node_orders(), and
+#    3. all_exit_structures()
+#    to get all possible variants of a given FFT.
+
 
 # all_node_orders: ------
 
-
-# Goal: Apply reorder_nodes(fft) to all possible permutations of cues.
+# Goal: Apply reorder_nodes(fft) to get all possible permutations of cues for a fft.
 #
 # Input:
 #   fft: 1 FFT (as df, 1 row per cue)
 #
 # Output:
 #   Definitions of FFT in all possible cue orders (predicting 1/Signal/TRUE for all changed cues, as reorder_nodes())
-
 
 all_node_orders <- function(fft){
 
@@ -1088,11 +1096,10 @@ all_node_orders <- function(fft){
 
 } # all_node_orders().
 
-
-# Check:
-# ffts_df <- get_fft_df(x)  # x$trees$definitions / definitions (as df)
-# fft  <- read_fft_df(ffts_df, tree = 1)  # 1 FFT (as df, from above)
-
+# # Check:
+# (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
+# (fft  <- read_fft_df(ffts, tree = 1))  # 1 FFT (as df, from above)
+#
 # (dfs_1 <- all_node_orders(fft = read_fft_df(ffts_df, tree = 1)))
 # (dfs_2 <- all_node_orders(fft = read_fft_df(ffts_df, tree = 2)))
 
@@ -1157,14 +1164,12 @@ all_exit_structures <- function(fft){
 
 } # all_exit_structures().
 
-
 # # Check:
-# ffts_df <- get_fft_df(x)  # x$trees$definitions / definitions (as df)
-# fft  <- read_fft_df(ffts_df, tree = 1)  # 1 FFT (as df, from above)
+# (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
+# (fft  <- read_fft_df(ffts, tree = 1))  # 1 FFT (as df, from above)
 #
 # (dfs_3 <- all_exit_structures(fft = fft))
 # (dfs_4 <- all_exit_structures(fft = read_fft_df(ffts_df, tree = 2)))
-
 
 
 # ToDo: ------
@@ -1173,6 +1178,6 @@ all_exit_structures <- function(fft){
 #   (1) FFT definitions (df, 1 row per tree) OR
 #   (2) single FFTs (as df, 1 row per node).
 # - Return the result in the same format as the input.
-# - When entering a set of FFT definitions, return modified set?
+# - When applying fn to a set of FFT definitions, return the modified set?
 
 # eof.

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -300,6 +300,10 @@ add_nodes <- function(fft,
   # Verify inputs:
   testthat::expect_true(verify_fft_as_df(fft))
 
+  if (!all(is.na(direction))){
+    testthat::expect_true(verify_dir_sym(direction))
+  }
+
   if (all(is.na(nodes))) { # catch case 0:
 
     message("add_nodes: FFT remains unchanged")  # 4debugging
@@ -426,6 +430,8 @@ add_nodes <- function(fft,
   # # Repair row names:
   # row.names(fft_new) <- 1:nrow(fft_new)
 
+  # ToDo: Verify fft_new?
+
   return(fft_new)
 
 } # add_nodes().
@@ -540,6 +546,8 @@ drop_nodes <- function(fft, nodes = NA){
 
   # Repair row names:
   row.names(fft_mod) <- 1:nrow(fft_mod)
+
+  # ToDo: Verify fft_mod?
 
   return(fft_mod)
 
@@ -671,17 +679,13 @@ edit_nodes <- function(fft,
 
       cur_dir <- direction[i]
 
-      # Get 6 direction symbols:
-      direction_symbols <- directions_df$direction[1:6]
-
-      if (cur_dir %in% direction_symbols){ # verify: valid direction symbol
+      if (verify_dir_sym(cur_dir)){ # verify direction symbol:
 
         fft_mod$direction[node_i] <- cur_dir  # set value
 
       } else {
 
-        msg_dir <- paste0("edit_nodes: The direction symbol of node ", node_i, " must be in ", paste0(direction_symbols, collapse = ", "))
-        stop(msg_dir)
+        stop(paste0("edit_nodes: Unknown direction symbol: ", cur_dir))
 
       }
 
@@ -746,6 +750,8 @@ edit_nodes <- function(fft,
   # # Repair row names:
   # row.names(fft_mod) <- 1:nrow(fft_mod)
 
+  # ToDo: Verify fft_mod?
+
   return(fft_mod)
 
 } # edit_nodes().
@@ -764,7 +770,8 @@ edit_nodes <- function(fft,
 # edit_nodes(fft, nodes = c(1, 1, 1), cue = c("A", "B", "C"))  # repeated change of 1 node: works
 #
 # edit_nodes(fft, nodes = c(1, 2, 3), direction = c("!=", "<=", ">="))  # works, for valid direction symbols
-# edit_nodes(fft, nodes = c(1, 1, 1), direction = c("=", "<", ">"))  # repeated change of 1 node: works
+# edit_nodes(fft, nodes = c(1, 1, 1), direction = c("=", "<<", ">>"))  # repeated change of 1 node: works
+# edit_nodes(fft, nodes = c(1, 2, 3), direction = c("!=", "<<", ">>"))  # NOTE: INVALID direction symbol are IGNORED.
 #
 # edit_nodes(fft, nodes = 1:3, cue = c("A", "B", "C"), threshold = c("X", "Y", "xyz"))  # works, but NO validation with data
 #

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -442,29 +442,29 @@ add_nodes <- function(fft,
 #
 # add_nodes(fft)
 # add_nodes(fft, nodes = 1,
-#           class = "class_1", cue = "cue_1", direction = "dir_1", threshold = "thr_1", exit = "ext_1")
+#           class = "class_1", cue = "cue_1", direction = ">=", threshold = "thr_1", exit = "ext_1")
 # add_nodes(fft, nodes = 2,
-#           class = "class_2", cue = "cue_2", direction = "dir_2", threshold = "thr_2", exit = "ext_2")
+#           class = "class_2", cue = "cue_2", direction = "<=", threshold = "thr_2", exit = "ext_2")
 # add_nodes(fft, nodes = 4,
-#           class = "class_4", cue = "cue_4", direction = "dir_4", threshold = "thr_4", exit = "ext_4")
+#           class = "class_4", cue = "cue_4", direction = "!=", threshold = "thr_4", exit = "ext_4")
 #
 # my_nodes <- c(1, 2, 4, 6, 8:10, 50, 100)
 #
 # add_nodes(fft, nodes = my_nodes,
 #           class = paste0("class_", my_nodes),
 #           cue = paste0("cue_", my_nodes),
-#           direction = paste0("dir_", my_nodes),
+#           direction = sample(c("!=", ">=", "<="), length(my_nodes), replace = TRUE),
 #           threshold = paste0("thr_", my_nodes),
 #           exit = paste0("ext_", my_nodes)
 #           )
 #
 # my_nodes <- c(2, 4, 2, 4)
-# my_value <- 1:4
+# my_value <- 11:14
 #
 # add_nodes(fft, nodes = my_nodes,
 #           class = paste0("class_", my_value),
 #           cue = paste0("cue_", my_value),
-#           direction = paste0("dir_", my_value),
+#           direction = sample(c("!=", ">=", "<="), length(my_nodes), replace = TRUE),
 #           threshold = paste0("thr_", my_value),
 #           exit = paste0("ext_", my_value)
 # )
@@ -770,11 +770,12 @@ edit_nodes <- function(fft,
 # edit_nodes(fft, nodes = c(1, 1, 1), cue = c("A", "B", "C"))  # repeated change of 1 node: works
 #
 # edit_nodes(fft, nodes = c(1, 2, 3), direction = c("!=", "<=", ">="))  # works, for valid direction symbols
-# edit_nodes(fft, nodes = c(1, 1, 1), direction = c("=", "<<", ">>"))  # repeated change of 1 node: works
-# edit_nodes(fft, nodes = c(1, 2, 3), direction = c("!=", "<<", ">>"))  # NOTE: INVALID direction symbol are IGNORED.
+# edit_nodes(fft, nodes = c(1, 1, 1), direction = c("=", "<=", ">="))  # repeated change of 1 node: works (use LAST)
+# edit_nodes(fft, nodes = c(1, 2, 3), direction = c("!=", "<<", ">"))  # NOTE: INVALID direction symbol FAILS.
 #
 # edit_nodes(fft, nodes = 1:3, cue = c("A", "B", "C"), threshold = c("X", "Y", "xyz"))  # works, but NO validation with data
 #
+# ToDo: +++ here now +++ NO LONGER WORKS:
 # edit_nodes(fft, nodes = c(1, 1, 1), exit = c(1, 0, 1))  # repeated change of 1 node works
 # edit_nodes(fft, nodes = c(1, 2, 2), exit = c(0, 0, 1))
 # edit_nodes(fft, nodes = c(1, 2, 3), exit = c("FALse", " Signal ", 3/6))

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -791,27 +791,28 @@ edit_nodes <- function(fft,
 } # edit_nodes().
 
 # # Check:
-# (ffts_df <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
-# (fft <- read_fft_df(ffts_df, tree = 1))  # 1 FFT (as df, from above)
+# (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
+# (fft <- read_fft_df(ffts, tree = 1))  # 1 FFT (as df, from above)
 #
 # edit_nodes(fft)
 # edit_nodes(fft, nodes = c(1, 1), cue = "ABC", exit = c(1, 0))  # error: args differ in length
 #
 # edit_nodes(fft, nodes = 1:3, class = c("c", "n", "c"))  # works, for valid class values
-# edit_nodes(fft, nodes = 1:3, class = c("c", "n", "n"))  # works, but NO validation with data
+# edit_nodes(fft, nodes = 1:3, class = c("N", "C", "N"))  # works, but NO validation with data
 #
 # edit_nodes(fft, nodes = 1:3, cue = c("A", "B", "C"))  # works, but NO validation with data
 # edit_nodes(fft, nodes = c(1, 1, 1), cue = c("A", "B", "C"))  # repeated change of 1 node: works
 #
 # edit_nodes(fft, nodes = c(1, 2, 3), direction = c("!=", "<=", ">="))  # works, for valid direction symbols
-# edit_nodes(fft, nodes = c(1, 1, 1), direction = c("=", "<=", ">="))  # repeated change of 1 node: works (use LAST)
+# edit_nodes(fft, nodes = c(1, 1, 1), direction = c("=", "<=", ">="))  # repeated change of 1 node: works (using LAST)
 # edit_nodes(fft, nodes = c(1, 2, 3), direction = c("!=", "<<", ">"))  # NOTE: INVALID direction symbol FAILS.
 #
 # edit_nodes(fft, nodes = 1:3, cue = c("A", "B", "C"), threshold = c("X", "Y", "xyz"))  # works, but NO validation with data
 #
-# edit_nodes(fft, nodes = c(1, 1, 1), exit = c(0, 0, 1))  # repeated change of 1 node works
-# edit_nodes(fft, nodes = c(1, 2, 2), exit = c(0, 0, 1))
-# edit_nodes(fft, nodes = c(1, 2, 3), exit = c("FALse", " Signal ", 3/6))
+# edit_nodes(fft, nodes = c(1, 1, 1), exit = c(0, 0, 1))  # repeated change of 1 node works (using LAST)
+# edit_nodes(fft, nodes = c(1, 2, 2), exit = c(0, 0, 1))  # works (using LAST)
+# edit_nodes(fft, nodes = c(1, 2, 3), exit = c("FALse", " Signal ", 3/6)) # interpreting exit_type
+# edit_nodes(fft, nodes = c(1, 2, 3), exit = c(0, 0, 1))  # Error: Final exit must be 0.5
 
 
 

--- a/R/util_verify.R
+++ b/R/util_verify.R
@@ -4,6 +4,46 @@
 
 # Functions for validating or verifying stuff: ------
 
+
+# verify_dir_sym: ------
+
+# Goal: Verify a vector x of direction symbols
+#       (given global constant directions_df)
+
+verify_dir_sym <- function(x){
+
+  valid <- FALSE
+
+  # Get first 6 direction symbols:
+  dir_sym <- directions_df$direction[1:6]  # from global constant.
+
+  if (all(x %in% dir_sym)){ # verify: valid direction symbol
+
+    valid <- TRUE  # set value
+
+  } else {
+
+    missing_sym <- setdiff(x, dir_sym)
+    msg <- paste0("verify_dir_sym: Some symbols (", paste0(missing_sym, collapse = ", "),
+                  ") are NOT in (", paste0(dir_sym, collapse = ", "), ")")
+    message(msg)
+
+  }
+
+
+  # Output: ----
+
+  return(valid)
+
+} # verify_dir_sym().
+
+# # Check:
+# verify_dir_sym(c("=", "!=", ">", ">=", "<", "<=", "=")) # is TRUE
+# verify_dir_sym(c("==")) # is FALSE
+# verify_dir_sym(c("=<", "+", "=>")) # are FALSE
+
+
+
 # verify_exit_type: ------
 
 # Goal: Ensure that a vector x contains valid exit types

--- a/R/util_verify.R
+++ b/R/util_verify.R
@@ -383,7 +383,12 @@ verify_fft_as_df <- function(fft_df){
 
   if (all(req_tree_vars %in% provided_vars)){
 
-    # ToDo: Verify variables further (e.g., verify their contents).
+    # Verify variables further (e.g., verify their contents):
+    # ToDo: verify class (requires data)
+    # ToDo: verify cue (requires data)
+    testthat::expect_true(verify_dir_sym(fft_df$direction))
+    # ToDo: verify threshold
+    testthat::expect_true(verify_exit_type(fft_df$exit))
 
     return(TRUE)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,10 +39,12 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 [![R-CMD-check](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml)
 <!-- Devel badges end. -->
 
+
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color='00a9e0')](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- Release badges end. -->
+
 
 
 <!-- ALL badges start: --> 

--- a/README.Rmd
+++ b/README.Rmd
@@ -160,7 +160,7 @@ set.seed(246)  # for reproducible randomness
 
 ```{r example-heart-create, collapse = FALSE, results = "hide"}
 # Create an FFTrees object from the heartdisease data: 
-heart_fft <- FFTrees(formula = diagnosis ~., 
+heart_fft <- FFTrees(formula = diagnosis ~.,
                      data = heart.train,
                      data.test = heart.test, 
                      decision.labels = c("Healthy", "Disease"))

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,13 +39,10 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 [![R-CMD-check](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml)
 <!-- Devel badges end. -->
 
-
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color='00a9e0')](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- Release badges end. -->
-
-
 
 <!-- ALL badges start: --> 
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
@@ -54,7 +51,6 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 <!-- [![Downloads/month](https://cranlogs.r-pkg.org/badges/FFTrees?color=brightgreen)](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color='b22222')](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- ALL badges end. --> 
-
 
 
 <!-- Pkg goal: -->

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ We use the main `FFTrees()` function to create FFTs for the
 
 ``` r
 # Create an FFTrees object from the heartdisease data: 
-heart_fft <- FFTrees(formula = diagnosis ~., 
+heart_fft <- FFTrees(formula = diagnosis ~.,
                      data = heart.train,
                      data.test = heart.test, 
                      decision.labels = c("Healthy", "Disease"))
@@ -333,6 +333,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-02-18.\]
+\[File `README.Rmd` last updated on 2023-02-19.\]
 
 <!-- eof. -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.9.0.9004 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.9.0.9005 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -333,6 +333,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-02-15.\]
+\[File `README.Rmd` last updated on 2023-02-18.\]
 
 <!-- eof. -->


### PR DESCRIPTION
This PR adds a new tree editing / trimming function `add_nodes()` and improves robustness by adding argument verification functions (e.g., for verifying the integrity of direction symbols and exit structures, as well as using both to verify fft definitions).