### PR TITLE
Adding `all_subsets()`, `all_node_subsets()` and improve verification functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.9.0.9005
-Date: 2023-02-19
+Version: 1.9.0.9006
+Date: 2023-02-20
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/R/util_abc.R
+++ b/R/util_abc.R
@@ -629,9 +629,9 @@ all_combinations <- function(x, length){
 # all_subsets: List all combinations of all sub-lengths 0 < n < length(x) of a set x: ------
 
 # Goal: Get all subsets of x (i.e., all possible combinations of all possible lengths 0 < n < length(x)).
-#       Note: Both extremes (an empty set NULL, and the full set x) are NOT included/returned here.
+#       Note: The extreme NULL (an empty set) is NOT, but the full set (all of x) can be included/returned.
 
-all_subsets <- function(x){
+all_subsets <- function(x, include_x = TRUE){
 
   # Prepare: ----
 
@@ -644,7 +644,18 @@ all_subsets <- function(x){
 
   # Main: ----
 
-  for (i in 1:(length(x) - 1)){
+  if (include_x){
+
+    max_size <- length(x)  # a. include maximum subset with ALL length(x) elements
+
+  } else {
+
+    max_size <- (length(x) - 1)  # b. exclude maximum subset with ALL length(x) elements
+
+  }
+
+  # Loop through set sizes:
+  for (i in 1:max_size){
 
     l_i <- utils::combn(x = x, m = i, simplify = FALSE)
 
@@ -661,6 +672,7 @@ all_subsets <- function(x){
 
 # # Check:
 # all_subsets(1:4)
+# all_subsets(1:4, include_x = FALSE)  # excluding 1:4 set
 # all_subsets(LETTERS[1:3])
 # all_subsets(NA)
 # all_subsets("X")

--- a/R/util_abc.R
+++ b/R/util_abc.R
@@ -579,7 +579,6 @@ all_permutations <- function(x) {
 all_combinations <- function(x, length){
 
   # Prepare: ----
-  out <- NA  # initialize
 
   # Verify inputs:
   if (all(is.na(x)) || is.na(length)){
@@ -591,18 +590,24 @@ all_combinations <- function(x, length){
     length <- length(x)
   }
 
-  # Main: Use utils::combn to obtain matrix: ----
-  m <- utils::combn(x = x, m = length)
+  out <- NA  # initialize
 
-  if (is.vector(m)){
 
-    out <- m  # return as is
+  # Main: ----
 
-  } else if (is.matrix(m)){
+  # Use utils::combn to obtain a matrix:
+  mx <- utils::combn(x = x, m = length)
 
-    out <- t(m)  # transpose m into matrix of rows
+  if (is.vector(mx)){
+
+    out <- mx  # return as is
+
+  } else if (is.matrix(mx)){
+
+    out <- t(mx)  # transpose m into matrix of rows
 
   }
+
 
   # Output: ----
 
@@ -645,6 +650,6 @@ if (getRversion() >= "2.15.1") utils::globalVariables(c(".", "tree", "tree_new",
 
 # ToDo: ------
 
-# - etc.
+# - Get all_subsets() based on all_combinations().
 
 # eof.

--- a/R/util_abc.R
+++ b/R/util_abc.R
@@ -405,8 +405,8 @@ get_exit_type <- function(x, verify = TRUE){
 
   if (verify){
 
-  # Verify that extypes describe an FFT:
-  verify_exit_type(extypes) # verify (without consequences)
+    # Verify that extypes describe an FFT:
+    verify_exit_type(extypes) # verify (without consequences)
 
   }
 
@@ -623,6 +623,34 @@ all_combinations <- function(x, length){
 # all_combinations(x = 1:3, length = 88)
 # all_combinations(x = 1:3, length = NA)
 # all_combinations(x = NA, length = 1)
+
+
+
+# all_subsets: List all combinations of length 0 < n < length(x) of a set x: ------
+
+all_subsets <- function(x){
+
+  if (length(x) < 2){
+    return(x)
+  }
+
+  l_out <- vector("list", 0)
+
+  for (i in 1:length(x)){
+
+    l_i <- utils::combn(x = x, m = i, simplify = FALSE)
+
+    l_out <- c(l_out, l_i)
+
+  } # for i.
+
+  return(l_out)
+
+} # all_subsets().
+
+# # Check:
+# all_subsets(1:3)
+# all_subsets(LETTERS[1:3])
 
 
 

--- a/R/util_abc.R
+++ b/R/util_abc.R
@@ -567,7 +567,7 @@ all_permutations <- function(x) {
 # all_permutations(c("A", "B", "b", "a"))
 
 
-# all_combinations: List all combinations of length n of a set x: ------
+# all_combinations: List all combinations of a length n of a set x: ------
 
 # # (a) Using utils::combn:
 # m <- utils::combn(x = 1:4, m = 2)
@@ -626,17 +626,25 @@ all_combinations <- function(x, length){
 
 
 
-# all_subsets: List all combinations of length 0 < n < length(x) of a set x: ------
+# all_subsets: List all combinations of all sub-lengths 0 < n < length(x) of a set x: ------
+
+# Goal: Get all subsets of x (i.e., all possible combinations of all possible lengths 0 < n < length(x)).
+#       Note: Both extremes (an empty set NULL, and the full set x) are NOT included/returned here.
 
 all_subsets <- function(x){
+
+  # Prepare: ----
 
   if (length(x) < 2){
     return(x)
   }
 
-  l_out <- vector("list", 0)
+  l_out <- vector("list", 0)  # initialize
 
-  for (i in 1:length(x)){
+
+  # Main: ----
+
+  for (i in 1:(length(x) - 1)){
 
     l_i <- utils::combn(x = x, m = i, simplify = FALSE)
 
@@ -644,13 +652,18 @@ all_subsets <- function(x){
 
   } # for i.
 
-  return(l_out)
+
+  # Output: ----
+
+  return(l_out) # as list
 
 } # all_subsets().
 
 # # Check:
-# all_subsets(1:3)
+# all_subsets(1:4)
 # all_subsets(LETTERS[1:3])
+# all_subsets(NA)
+# all_subsets("X")
 
 
 

--- a/R/util_const.R
+++ b/R/util_const.R
@@ -13,11 +13,13 @@
 algorithm_options <- c("ifan", "dfan")  # (global constant)
 
 
+
 # - goal_options: ----
 
 # A set of default goals (for FFT selection):
 
 goal_options <- c("acc", "bacc", "wacc",  "dprime",  "cost")  # (global constant)
+
 
 
 # - cost_outcomes_default: ----
@@ -28,6 +30,7 @@ goal_options <- c("acc", "bacc", "wacc",  "dprime",  "cost")  # (global constant
 cost_outcomes_default <- list(hi = 0, fa = 1, mi = 1, cr = 0)  # (global constant)
 
 
+
 # - cost_cues_default: ----
 
 # Cue cost = graded mcu / "graded frugality":
@@ -36,17 +39,21 @@ cost_outcomes_default <- list(hi = 0, fa = 1, mi = 1, cr = 0)  # (global constan
 cost_cues_default <- 0  # (global constant)
 
 
+
+# - cue_classes: ----
+
+cue_classes <- c( #  (global constant)
+  "c",  # categorical: character, factor, logical
+  "n")  # numeric: integer, double
+
+
+
 # - fft_node_sep: ----
 
 # A node separation marker in tree definitions (symbol):
 
 fft_node_sep <- ";"  # (global constant)
 
-
-# - cue_classes: ----
-
-cue_classes <- c("c",  # categorical: character, factor, logical
-                 "n")  # numeric: integer, double
 
 
 # - directions_df: ----
@@ -91,12 +98,11 @@ negations_v <- c("not", "is not")  # (global constant)
 # - exit_types: ----
 
 # Exit types (as numeric):
-# 1. exit_types[1]: 0   representing FALSE, left, noise
-# 2. exit_types[2]: 1   representing TRUE, right, signal
+# 1. exit_types[1]: 0   representing FALSE, left, noise N
+# 2. exit_types[2]: 1   representing TRUE, right, signal S
 # 3. exit_types[3]: 0.5 representing 2/4, both, final
 
 exit_types <- c(0, 1, 0.5)  # (global constant)
-
 
 
 

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -18,6 +18,7 @@
 # into a more modular format of individual FFTs (as df with 1 row per node), and back.
 # Reason: The latter can be manipulated more easily by tree editing/manipulation/trimming functions (B).
 
+
 # Details:
 #
 # 2 FFT translation functions:
@@ -310,7 +311,7 @@ add_nodes <- function(fft,
 
   if (all(is.na(nodes))) { # catch case 0:
 
-    message("add_nodes: FFT remains unchanged")  # 4debugging
+    message("add_nodes: fft remains unchanged")  # 4debugging
 
     return(fft)
 
@@ -505,7 +506,7 @@ drop_nodes <- function(fft, nodes = NA){
 
   if (all(is.na(nodes))) { # catch case 0:
 
-    message("drop_nodes: FFT remains unchanged")  # 4debugging
+    message("drop_nodes: fft remains unchanged")  # 4debugging
 
     return(fft)
 
@@ -669,7 +670,7 @@ select_nodes <- function(fft, nodes = NA){
   # Special case 3 (AFTER removing any missing or duplicated nodes):
   if (length(nodes) == n_cues) {
 
-    message("select_nodes: FFT remains unchanged")  # 4debugging
+    message("select_nodes: fft remains unchanged")  # 4debugging
 
     return(fft)
 
@@ -775,7 +776,7 @@ edit_nodes <- function(fft,
 
   if (all(is.na(nodes))) { # catch case 0:
 
-    message("edit_nodes: FFT remains unchanged")  # 4debugging
+    message("edit_nodes: fft remains unchanged")  # 4debugging
 
     return(fft)
 
@@ -976,7 +977,7 @@ flip_exits <- function(fft, nodes = NA){
 
   if (all(is.na(nodes))) { # catch case 0:
 
-    message("flip_exits: FFT remains unchanged")  # 4debugging
+    message("flip_exits: fft remains unchanged")  # 4debugging
 
     return(fft)
 
@@ -1098,7 +1099,7 @@ reorder_nodes <- function(fft, order = NA){
 
   if (all(order == 1:n_cues)) { # catch case:
 
-    message("reorder_nodes: FFT remains unchanged")  # 4debugging
+    message("reorder_nodes: fft remains unchanged")  # 4debugging
 
     return(fft)
 

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -262,6 +262,7 @@ add_fft_df <- function(fft, ffts_df = NULL){
 
 
 
+
 # (B) Editing tree descriptions: --------
 
 # Goal: Functions for editing, manipulating, and trimming individual FFTs (in df format).
@@ -1167,6 +1168,7 @@ reorder_nodes <- function(fft, order = NA){
 # reorder_nodes(fft, order = c(2, 1, 3))  # exit cue unchanged
 # reorder_nodes(fft, order = c(1, 3, 2))  # exit cue changed
 # reorder_nodes(fft, order = c(3, 1, 2))  # exit cue changed
+
 
 
 

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -1183,17 +1183,17 @@ reorder_nodes <- function(fft, order = NA){
 # Possible differences/similarities within a "family of FFTs" (from narrow to wide):
 # 1. A specific set of cues, their order, and exit structure:  1 FFT from FFTrees object.
 # 2. A specific set of cues, their order, but variable exit structures:  The FFTs in 1 FFTrees object.
-# 3. A specific set of cues, but variable cue orders and exit structures.
+# +. A specific set of cues, but variable cue orders AND exit structures.
+#
+# 3. get all node subsets (with all possible subsets of nodes)
+#    = all_combinations() for each possible length (excluding extremes of 0 and n_nodes, i.e., 1:(n_nodes - 1)).
 
 # ToDo:
-# 1. get all node subsets (with all possible subsets of nodes)
-#    = all_combinations() for each possible length (1:n_nodes).
-#
-# 2. Combine
-#    1. all node subsets,
-#    2. all_node_orders(), and
+# Combine 3 macro-functions:
+#    1. all_node_subsets(), and
+#    2. all_node_orders(),  and
 #    3. all_exit_structures()
-#    to get all possible variants of a given FFT.
+#    to get ALL possible variants of a given FFT.
 
 
 # all_node_orders: ------
@@ -1312,6 +1312,64 @@ all_exit_structures <- function(fft){
 #
 # (dfs_3 <- all_exit_structures(fft = fft))
 # (dfs_4 <- all_exit_structures(fft = read_fft_df(ffts_df, tree = 2)))
+
+
+# all_node_subsets(): ------
+
+# Goal: Get all subtrees of an FFT.
+
+all_node_subsets <- function(fft){
+
+  # Prepare: ----
+
+  # Verify inputs:
+  testthat::expect_true(verify_fft_as_df(fft))
+
+  # Initialize:
+  out <- NULL
+  cnt <- 1
+
+  n_cues <- nrow(fft)
+
+
+  # Main: ----
+
+  # Get subsets of nodes (as list):
+  node_subsets_l <- all_subsets(1:n_cues)
+
+  # Loop through list elements:
+  for (i in 1:length(node_subsets_l)){
+
+    cur_nodes <- node_subsets_l[[i]]
+    # print(cur_nodes)  # 4debugging
+
+    fft_sub <- select_nodes(fft, nodes = cur_nodes)
+    # print(fft_sub)  # 4debugging
+
+    fft_df <- write_fft_df(fft = fft_sub, tree = cnt)
+    # print(fft_df)  # 4debugging
+
+    cnt <- cnt + 1 # increment
+
+    out <- add_fft_df(fft = fft_df, ffts_df = out)
+
+  } # for i.
+
+
+  # Output: ----
+
+  return(out)
+
+} # all_node_subsets().
+
+# Check:
+# (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
+# (fft  <- read_fft_df(ffts, tree = 1))  # 1 FFT (as df, from above)
+#
+# (ast_3 <- all_node_subsets(fft = fft))
+# (ast_4 <- all_node_subsets(fft = read_fft_df(ffts, tree = 2)))
+
+
 
 
 # ToDo: ------

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -1335,7 +1335,7 @@ all_node_subsets <- function(fft){
   # Main: ----
 
   # Get subsets of nodes (as list):
-  node_subsets_l <- all_subsets(1:n_cues)
+  node_subsets_l <- all_subsets(x = 1:n_cues, include_x = TRUE)  # include the full set of all nodes
 
   # Loop through list elements:
   for (i in 1:length(node_subsets_l)){
@@ -1343,7 +1343,7 @@ all_node_subsets <- function(fft){
     cur_nodes <- node_subsets_l[[i]]
     # print(cur_nodes)  # 4debugging
 
-    fft_sub <- select_nodes(fft, nodes = cur_nodes)
+    fft_sub <- select_nodes(fft = fft, nodes = cur_nodes)
     # print(fft_sub)  # 4debugging
 
     fft_df <- write_fft_df(fft = fft_sub, tree = cnt)
@@ -1371,12 +1371,18 @@ all_node_subsets <- function(fft){
 
 
 
-
 # ToDo: ------
 
+# - Combine 3 macro-functions:
+#    1. all_node_subsets(), and
+#    2. all_node_orders(),  and
+#    3. all_exit_structures()
+#    to get ALL possible variants of a given FFT.
+#
 # - Make some functions (e.g., tree editing functions) work alternative inputs of either
 #   (1) FFT definitions (df, 1 row per tree) OR
 #   (2) single FFTs (as df, 1 row per node).
+#
 # - Return the result in the same format as the input.
 # - When applying fn to a set of FFT definitions, return the modified set?
 

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -111,17 +111,17 @@ read_fft_df <- function(ffts_df, tree = 1){
 
 # # Check:
 # hd <- FFTrees(formula = diagnosis ~ .,
-#                 data = heart.train,
-#                 data.test = heart.test)
+#               data = heart.train,
+#               data.test = heart.test)
 # x <- hd  # copy object (with 7 FFTs)
 #
 # # FFT definitions:
-# ffts_df <- get_fft_df(x)  # using the helper function
-# ffts_df
+# (ffts <- get_fft_df(x))  # using the helper function
 #
-# read_fft_df(ffts_df, 2)
-# read_fft_df(ffts_df, 2:3)  # yields error
-# read_fft_df(ffts_df, 8)    # yields error
+# read_fft_df(ffts, 1)    # works
+# read_fft_df(ffts, 7)    # works
+# read_fft_df(ffts, 2:3)  # yields an error
+# read_fft_df(ffts, 8)    # yields an error
 
 
 
@@ -180,22 +180,28 @@ write_fft_df <- function(fft, tree = -99L){
 } # write_fft_df().
 
 # # Check:
-# fft_df <- read_fft_df(ffts_df, 3)  # from above
-# fft_df
+# (ffts <- get_fft_df(x))  # using the helper function
+# (fft <- read_fft_df(ffts, 2))  # from above
 #
-# write_fft_df(fft_df, tree = 123)
+# write_fft_df(fft, tree = 123)
+
 
 
 # # Verify that read_fft_df() and write_fft_df() are complementary functions:
+
+# Show that:
+# 1. converting a line of ffts_df by read_fft_df() into df of 1 FFT and
+# 2. re-converting df back into 1 row per tree by write_fft_df()
+# yields original line:
+
+# for (id in 1:nrow(ffts)){
 #
-# # Show that:
-# # 1. converting a line of ffts_df by read_fft_df() into df of 1 FFT and
-# # 2. re-converting df back into 1 row per tree by write_fft_df()
-# # yields original line:
+#   def_org <- as.data.frame(ffts[id, ])
+#   def_new <- write_fft_df(read_fft_df(ffts, id), id)
+#   # print(def_org)  # 4debugging
+#   # print(def_new)  # 4debugging
 #
-# for (id in 1:nrow(ffts_df)){
-#
-#   check <- all.equal(ffts_df[id, ], write_fft_df(read_fft_df(ffts_df, id), id))
+#   check <- all.equal(def_org, def_new)
 #
 #   print(paste0("\u2014 tree id = ", id, ": ", check))
 #
@@ -1244,8 +1250,8 @@ all_node_orders <- function(fft){
 # (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
 # (fft  <- read_fft_df(ffts, tree = 1))  # 1 FFT (as df, from above)
 #
-# (dfs_1 <- all_node_orders(fft = read_fft_df(ffts_df, tree = 1)))
-# (dfs_2 <- all_node_orders(fft = read_fft_df(ffts_df, tree = 2)))
+# (dfs_1 <- all_node_orders(fft = read_fft_df(ffts, tree = 1)))
+# (dfs_2 <- all_node_orders(fft = read_fft_df(ffts, tree = 2)))
 
 
 
@@ -1313,7 +1319,7 @@ all_exit_structures <- function(fft){
 # (fft  <- read_fft_df(ffts, tree = 1))  # 1 FFT (as df, from above)
 #
 # (dfs_3 <- all_exit_structures(fft = fft))
-# (dfs_4 <- all_exit_structures(fft = read_fft_df(ffts_df, tree = 2)))
+# (dfs_4 <- all_exit_structures(fft = read_fft_df(ffts, tree = 2)))
 
 
 # all_node_subsets(): ------

--- a/R/util_verify.R
+++ b/R/util_verify.R
@@ -317,7 +317,6 @@ verify_tree_arg <- function(x, data, tree){
 # Inputs: ffts_df FFT definitions (1-line per FFT, as df, usually from x$trees$definitions or get_fft_df(x)).
 # Output: Boolean.
 
-
 verify_fft_definition <- function(ffts_df){
 
   # verify ffts_df:
@@ -338,15 +337,54 @@ verify_fft_definition <- function(ffts_df){
 
   if (all(req_tdef_vars %in% provided_vars)){
 
-    # ToDo: Verify variables further (e.g., verify their contents).
+    # Verify variables further (e.g., verify their contents):
+
+    # ToDo: verify classes (requires data)
+    # ToDo: verify cues (requires data)
+
+    # Verify directions:
+
+    # (a) as list elements:
+    lapply(ffts_df$directions, FUN = function(x){
+
+      directions <- trimws(unlist(strsplit(x, split = fft_node_sep, fixed = TRUE)))
+      # print(directions)  # 4debugging
+      testthat::expect_true(verify_dir_sym(directions))
+
+    })
+
+    # (b) as 1 long vector:
+    # directions <- trimws(unlist(strsplit(ffts_df$directions, split = fft_node_sep, fixed = TRUE)))
+    # print(directions)  # 4debugging
+    # testthat::expect_true(verify_dir_sym(directions))
+
+    # ToDo: verify thresholds
+
+    # Verify exits:
+
+    # (a) as list elements:
+    lapply(ffts_df$exits, FUN = function(x){
+
+      exits <- trimws(unlist(strsplit(x, split = fft_node_sep, fixed = TRUE)))
+      # print(exits)  # 4debugging
+      testthat::expect_true(verify_exit_type(exits))
+
+    })
+
+
+    # Output 1:
 
     return(TRUE)
+
 
   } else {
 
     missing_vars <- setdiff(req_tdef_vars, provided_vars)
 
     message("Input 'ffts_df' is not a valid (set of) FFT definition(s).\nMissing variables: ", paste(missing_vars, collapse = ", "))
+
+
+    # Output 2:
 
     return(FALSE)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,10 +39,12 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 [![R-CMD-check](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml)
 <!-- Devel badges end. -->
 
+
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color='00a9e0')](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- Release badges end. -->
+
 
 <!-- ALL badges start: --> 
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.9.0.9005 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.9.0.9006 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -333,6 +333,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-02-19.\]
+\[File `README.Rmd` last updated on 2023-02-20.\]
 
 <!-- eof. -->


### PR DESCRIPTION
This PR adds various utility functions (for verifying FFT variables and creating all subsets) to 

- create `all_node_subsets()` and 
- make `verify_fft_definition()` and `verify_fft_as_df()` stricter. 