### PR TITLE
Add `all_fft_variants()` function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.9.0.9006
-Date: 2023-02-20
+Version: 1.9.0.9007
+Date: 2023-02-21
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.9
 
-## 1.9.0.9004
+## 1.9.0.9007
 
 This is the current development version of **FFTrees**, available at <https://github.com/ndphillips/FFTrees>.
 
@@ -15,7 +15,7 @@ Changes since last release:
 
 ### Major changes 
 
-- Added utility functions (and corresponding verifications):
+- Added utility functions (and corresponding verification functions):
     - `get_best_tree()` retrieves the ID of the best tree in an `FFTrees` object (given `goal`)
     - `get_exit_type()` converts a vector of exit descriptions into FFT exits (given `exit_types`)
     - `get_fft_df()` retrieves the tree definitions of an `FFTrees` object
@@ -447,6 +447,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2023-02-16.]
+[File `NEWS.md` last updated on 2023-02-21.]
 
 <!-- eof. -->

--- a/R/FFTrees.R
+++ b/R/FFTrees.R
@@ -310,7 +310,7 @@ FFTrees <- function(formula = NULL,
 
     # ToDo: Verify integrity of tree definitions:
     # 1. tree.definitions contains valid tree definitions (in appropriate format):
-    testthat::expect_true(verify_fft_definition(tree.definitions))
+    testthat::expect_true(verify_ffts_df(tree.definitions))
 
     # 2. tree.definitions fit to provided data (see verify_all_cues_in_data() in helper.R)
 

--- a/R/util_abc.R
+++ b/R/util_abc.R
@@ -475,7 +475,7 @@ get_fft_df <- function(x){
   x_tree_df <- x$trees$definitions  # definitions (as df/tibble)
 
   # verify:
-  if (verify_fft_definition(x_tree_df)){
+  if (verify_ffts_df(x_tree_df)){
 
     return(x_tree_df)
 

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -1430,8 +1430,12 @@ all_fft_variants <- function(fft){
   # Main: ------
 
   # 1. Get all_node_subsets(): ----
+
   set_1 <- all_node_subsets(fft = fft)
   # print(set_1)  # 4debugging
+
+  # Provide user feedback:
+  cat(u_f_msg(paste0("\u2014 Generated ", nrow(set_1), " node subsets.\n")))
 
 
   # 2. Get all node orders (for each fft definition): ----
@@ -1450,6 +1454,9 @@ all_fft_variants <- function(fft){
 
   } # for i.
 
+  # Provide user feedback:
+  cat(u_f_msg(paste0("\u2014 Generated ", nrow(set_2), " node orders.\n")))
+
 
   # 3. Get all exit structures (for each fft definition): ----
 
@@ -1467,6 +1474,9 @@ all_fft_variants <- function(fft){
 
   } # for i.
 
+  # Provide user feedback:
+  cat(u_f_msg(paste0("\u2014 Generated ", nrow(set_3), " exit structures.\n")))
+
 
   # Output: ------
 
@@ -1481,7 +1491,7 @@ all_fft_variants <- function(fft){
 # (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
 # (fft  <- read_fft_df(ffts, tree = 1))  # 1 FFT (as df, from above)
 #
-# (all_3 <- all_fft_variants(fft = fft))
+# (all_3 <- all_fft_variants(fft = read_fft_df(ffts, tree = 1)))
 # nrow(all_3)
 # verify_ffts_df(all_3)
 #

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -35,7 +35,7 @@
 #
 # Inputs:
 # ffts_df: A set of FFT definitions (as df, usually from an FFTrees object,
-#       with suitable variable names to pass verify_fft_definition()).
+#       with suitable variable names to pass verify_ffts_df()).
 # tree: A tree ID (corresponding to tree in ffts_df).
 #
 # Output: A definition of 1 FFT with 1 row per node (as df).
@@ -50,7 +50,7 @@ read_fft_df <- function(ffts_df, tree = 1){
   # Prepare: ----
 
   # Verify inputs:
-  testthat::expect_true(verify_fft_definition(ffts_df)) # verify structure and content
+  testthat::expect_true(verify_ffts_df(ffts_df)) # verify structure and content
 
   testthat::expect_true(is.numeric(tree))
   testthat::expect_true(length(tree) == 1)
@@ -217,7 +217,7 @@ write_fft_df <- function(fft, tree = -99L){
 
 add_fft_df <- function(fft, ffts_df = NULL){
 
-  if (verify_fft_definition(fft)){   # Case 1: fft is a (set of) FFT-definitions (in 1 row per tree, as df) ----
+  if (verify_ffts_df(fft)){   # Case 1: fft is a (set of) FFT-definitions (in 1 row per tree, as df) ----
 
     if (is.null(ffts_df)){ # no addend:
 
@@ -225,7 +225,7 @@ add_fft_df <- function(fft, ffts_df = NULL){
 
     } else { # add to existing FFT definitions of ffts_df:
 
-      if (verify_fft_definition(ffts_df)){
+      if (verify_ffts_df(ffts_df)){
 
         out_ffts_df <- rbind(ffts_df, fft)  # add to existing definitions
 
@@ -1370,7 +1370,7 @@ all_node_subsets <- function(fft){
 
 } # all_node_subsets().
 
-# Check:
+# # Check:
 # (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
 # (fft  <- read_fft_df(ffts, tree = 1))  # 1 FFT (as df, from above)
 #

--- a/R/util_verify.R
+++ b/R/util_verify.R
@@ -311,13 +311,13 @@ verify_tree_arg <- function(x, data, tree){
 
 
 
-# verify_fft_definition: ------
+# verify_ffts_df: ------
 
 # Goal: Verify a set of existing tree definitions (defs as df, from an FFTrees object).
 # Inputs: ffts_df FFT definitions (1-line per FFT, as df, usually from x$trees$definitions or get_fft_df(x)).
 # Output: Boolean.
 
-verify_fft_definition <- function(ffts_df){
+verify_ffts_df <- function(ffts_df){
 
   # verify ffts_df:
   testthat::expect_true(is.data.frame(ffts_df), info = "Input 'ffts_df' are not a data.frame")
@@ -390,7 +390,7 @@ verify_fft_definition <- function(ffts_df){
 
   }
 
-} # verify_fft_definition().
+} # verify_ffts_df().
 
 
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,12 +39,10 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 [![R-CMD-check](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml)
 <!-- Devel badges end. -->
 
-
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color='00a9e0')](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- Release badges end. -->
-
 
 <!-- ALL badges start: --> 
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.9.0.9006 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.9.0.9007 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -333,6 +333,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-02-20.\]
+\[File `README.Rmd` last updated on 2023-02-21.\]
 
 <!-- eof. -->


### PR DESCRIPTION
This PR adds and revises an `all_fft_variants()` function (returning FFT definitions for all node subsets, all node orders, and all exit structures of a given FFT).