### PR TITLE
Add `quiet` option to hide/show feedback messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.9.0.9007
-Date: 2023-02-21
+Version: 1.9.0.9008
+Date: 2023-02-22
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -307,7 +307,8 @@ add_fft_df <- function(fft, ffts_df = NULL){
 add_nodes <- function(fft,
                       nodes = NA,  # as vector (1 integer or multiple nodes)
                       class = NA, cue = NA, direction = NA, threshold = NA, exit = NA,  # variables of fft nodes (as df rows)
-                      my.node = NA){
+                      my.node = NA,
+                      quiet = FALSE){
 
   # Prepare: ----
 
@@ -320,7 +321,10 @@ add_nodes <- function(fft,
 
   if (all(is.na(nodes))) { # catch case 0:
 
-    message("add_nodes: fft remains unchanged")  # 4debugging
+    # Provide user feedback:
+    if (!quiet){
+      cat(u_f_msg(paste0("add_nodes: fft remains unchanged\n")))
+    }
 
     return(fft)
 
@@ -335,6 +339,8 @@ add_nodes <- function(fft,
   len_set_args <- sapply(X = key_args, FUN = length)[non_NA_args]
 
   if (length(unique(len_set_args)) > 1){
+
+    # Error message:
     stop("edit_nodes: All modifier args (e.g., nodes, ..., exit) must have the same length.")
   }
 
@@ -361,7 +367,11 @@ add_nodes <- function(fft,
     # Remove duplicated nodes:
     nodes <- nodes[last_node_ix]
 
-    message(paste0("add_nodes: Removing duplicated nodes. Remaining nodes: ", paste0(nodes, collapse = ", ")))
+    # Provide user feedback:
+    if (!quiet){
+      msg_1 <- paste0("add_nodes: Removing duplicated nodes. Remaining nodes: ", paste0(nodes, collapse = ", "))
+      cat(u_f_msg(paste0(msg_1, "\n")))
+    }
 
     # Adjust other inputs accordingly:
     class <- class[last_node_ix]
@@ -386,8 +396,11 @@ add_nodes <- function(fft,
     ix_decr <- (nodes > n_total)
     nodes[ix_decr] <- (n_total - sum(ix_decr) + 1):n_total
 
-    msg_2 <- paste0("add_nodes: Adjusted values of nodes to ", paste(nodes, collapse = ", "))
-    message(msg_2)
+    # Provide user feedback:
+    if (!quiet){
+      msg_2 <- paste0("add_nodes: Adjusted values of nodes to ", paste(nodes, collapse = ", "))
+      cat(u_f_msg(paste0(msg_2, "\n")))
+    }
 
   } # if sc 2.
 
@@ -433,14 +446,21 @@ add_nodes <- function(fft,
                                   exit = exit)
 
   # Special case 3: Remove duplicate exit nodes
-  if (max(nodes) > max(ix_old)){ # new exit node:
+  if (max(nodes) > max(ix_old)){ # A new exit node:
 
     ix_old_exit <- max(ix_old)
 
-    fft_mod$exit[ix_old_exit] <- exit_types[2]
+    fft_mod$exit[ix_old_exit] <- exit_types[2]  # set to 1/TRUE/Signal
 
-    msg <- paste0("add_nodes: Set former exit node (now node ", ix_old_exit, ") to ", exit_types[2])
-    message(msg)
+    # Provide user feedback:
+    if (!quiet){
+
+      old_exit_cue <- fft_mod$cue[ix_old_exit]
+
+      msg_3 <- paste0("add_nodes: Set exit type of former final node ", n_cues, ": ", old_exit_cue, " (now node ", ix_old_exit, ") to ", exit_types[2])
+      cat(u_f_msg(paste0(msg_3, "\n")))
+    }
+
 
   } # if sc 3.
 
@@ -456,6 +476,7 @@ add_nodes <- function(fft,
   return(fft_mod)
 
 } # add_nodes().
+
 
 # # Check:
 # (ffts_df <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
@@ -492,7 +513,6 @@ add_nodes <- function(fft,
 #           threshold = paste0("thr_", my_value),
 #           exit = c(sample(exit_types[1:2], size = length(my_nodes) - 1, replace = TRUE), 0.5)
 # )
-
 
 
 
@@ -591,7 +611,7 @@ drop_nodes <- function(fft, nodes = NA, quiet = FALSE){
       new_exit_cue <- fft_mod$cue[new_exit_node]
       old_node_pos <- which(fft$cue == new_exit_cue)
 
-      msg_4 <- paste0("drop_nodes: New final node ", new_exit_node, ": cue = ", new_exit_cue, " (was node ", old_node_pos, " of fft)")
+      msg_4 <- paste0("drop_nodes: New final node ", new_exit_node, ": ", new_exit_cue, " (was node ", old_node_pos, " of fft)")
       cat(u_f_msg(paste0(msg_4, "\n")))
     }
 

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -579,16 +579,19 @@ drop_nodes <- function(fft, nodes = NA, quiet = FALSE){
   fft_mod <- fft[new_nodes, ]  # main step
 
   # Special case 4:
-  if (n_cues %in% nodes){ # Previous exit cue was dropped/new exit node:
+  if (n_cues %in% new_nodes == FALSE){ # Previous exit cue was dropped/new exit node:
 
-    new_exit_node <- nrow(fft_mod)  # NOT length(new_nodes)
-    old_exit_node <- n_cues
+    new_exit_node <- nrow(fft_mod) # = length(new_nodes)
 
     fft_mod$exit[new_exit_node] <- exit_types[3]  # set new exit node
 
     # Provide user feedback:
     if (!quiet){
-      msg_4 <- paste0("drop_nodes: New final node: ", new_exit_node, " (was node ", old_exit_node, " of fft)")
+
+      new_exit_cue <- fft_mod$cue[new_exit_node]
+      old_node_pos <- which(fft$cue == new_exit_cue)
+
+      msg_4 <- paste0("drop_nodes: New final node ", new_exit_node, ": cue = ", new_exit_cue, " (was node ", old_node_pos, " of fft)")
       cat(u_f_msg(paste0(msg_4, "\n")))
     }
 
@@ -609,22 +612,27 @@ drop_nodes <- function(fft, nodes = NA, quiet = FALSE){
 
 # # Check:
 # (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
-# (fft <- read_fft_df(ffts, tree = 1))  # 1 FFT (as df, from above)
+# (fft <- read_fft_df(ffts, tree = 2))  # 1 FFT (as df, from above)
 #
 # drop_nodes(fft)
 # drop_nodes(fft, nodes = c(1))
 # drop_nodes(fft, nodes = c(3))
 # drop_nodes(fft, nodes = c(3, 1))
+# drop_nodes(fft, nodes = c(3, 1, 2))  # works: NO new final node
 #
-# drop_nodes(fft, nodes = c(1, 1, 1))  # duplicated nodes are only dropped once.
+# drop_nodes(fft, nodes = c(1, 1, 2, 2))  # duplicated nodes are only dropped once.
 #
 # # Dropping final node / new final node:
+# drop_nodes(fft, nodes = 2)    # works: NO new final node
+# drop_nodes(fft, nodes = 1:3)
 # drop_nodes(fft, nodes = 4)    # works: new final node
+# drop_nodes(fft, nodes = 3:4)  # works: new final node
 # drop_nodes(fft, nodes = 2:6)  # works (1 node left: new exit)
 #
 # # Dropping everything:
 # drop_nodes(fft, nodes = 1:6)  # note + error: nothing left
 # drop_nodes(fft, nodes = 1:4)  # error: nothing left
+
 
 
 # select_nodes: ------

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -506,7 +506,7 @@ add_nodes <- function(fft,
 #
 # Output: Modified version of fft (as df, with fewer nodes).
 
-drop_nodes <- function(fft, nodes = NA){
+drop_nodes <- function(fft, nodes = NA, quiet = FALSE){
 
   # Prepare: ----
 
@@ -515,7 +515,10 @@ drop_nodes <- function(fft, nodes = NA){
 
   if (all(is.na(nodes))) { # catch case 0:
 
-    message("drop_nodes: fft remains unchanged")  # 4debugging
+    # Provide user feedback:
+    if (!quiet){
+      cat(u_f_msg(paste0("drop_nodes: fft remains unchanged\n")))
+    }
 
     return(fft)
 
@@ -529,24 +532,30 @@ drop_nodes <- function(fft, nodes = NA){
   # Special case 1:
   if (any(nodes %in% 1:n_cues == FALSE)){ # notify that nodes are missing:
 
-    missing_nodes <- setdiff(nodes, 1:n_cues)
+    # Provide user feedback:
+    if (!quiet){
 
-    msg_1 <- paste0("drop_nodes: Some nodes do not occur in FFT and will be ignored: ",
-                    paste(missing_nodes, collapse = ", "))
+      missing_nodes <- setdiff(nodes, 1:n_cues)
 
-    message(msg_1)
+      msg_1 <- paste0("drop_nodes: Some nodes do not occur in FFT and will be ignored: ",
+                      paste(missing_nodes, collapse = ", "))
+      cat(u_f_msg(paste0(msg_1, "\n")))
+    }
 
   } # if sc 1.
 
   # Special case 2:
   if (any(duplicated(nodes))){
 
-    duplicated_nodes <- unique(nodes[duplicated(nodes)])
+    # Provide user feedback:
+    if (!quiet){
 
-    msg_2 <- paste0("drop_nodes: Duplicated nodes are dropped only once: ",
-                    paste(duplicated_nodes, collapse = ", "))
+      duplicated_nodes <- unique(nodes[duplicated(nodes)])
 
-    message(msg_2)
+      msg_2 <- paste0("drop_nodes: Duplicated nodes are dropped only once: ",
+                      paste(duplicated_nodes, collapse = ", "))
+      cat(u_f_msg(paste0(msg_2, "\n")))
+    }
 
   } # if sc 2.
 
@@ -555,10 +564,12 @@ drop_nodes <- function(fft, nodes = NA){
 
   # Determine new nodes:
   new_nodes <- setdiff(1:n_cues, nodes)
+  # print(new_nodes)  # 4debugging
 
   # Special case 3:
   if (length(new_nodes) == 0){ # nothing left:
 
+    # Error message:
     msg_3 <- paste0("drop_nodes: Nothing left of fft")
     stop(msg_3)
 
@@ -570,13 +581,16 @@ drop_nodes <- function(fft, nodes = NA){
   # Special case 4:
   if (n_cues %in% nodes){ # Previous exit cue was dropped/new exit node:
 
-    new_exit_node <- max(new_nodes)  # NOT length(new_nodes)
+    new_exit_node <- nrow(fft_mod)  # NOT length(new_nodes)
     old_exit_node <- n_cues
 
     fft_mod$exit[new_exit_node] <- exit_types[3]  # set new exit node
 
-    msg_4 <- paste0("drop_nodes: New final node: ", new_exit_node, " (was node ", old_exit_node, " of fft)")
-    message(msg_4)
+    # Provide user feedback:
+    if (!quiet){
+      msg_4 <- paste0("drop_nodes: New final node: ", new_exit_node, " (was node ", old_exit_node, " of fft)")
+      cat(u_f_msg(paste0(msg_4, "\n")))
+    }
 
   } # if sc 4.
 
@@ -595,7 +609,7 @@ drop_nodes <- function(fft, nodes = NA){
 
 # # Check:
 # (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
-# (fft <- read_fft_df(ffts, tree = 2))  # 1 FFT (as df, from above)
+# (fft <- read_fft_df(ffts, tree = 1))  # 1 FFT (as df, from above)
 #
 # drop_nodes(fft)
 # drop_nodes(fft, nodes = c(1))
@@ -624,7 +638,7 @@ drop_nodes <- function(fft, nodes = NA){
 #
 # Output: Modified version of fft (as df, with fewer nodes).
 
-select_nodes <- function(fft, nodes = NA){
+select_nodes <- function(fft, nodes = NA, quiet = FALSE){
 
   # Prepare: ----
 
@@ -633,6 +647,7 @@ select_nodes <- function(fft, nodes = NA){
 
   if (all(is.na(nodes))) { # catch case 0:
 
+    # Error message:
     stop("select_nodes: Nothing left of fft")
 
     # return(NA)
@@ -651,12 +666,15 @@ select_nodes <- function(fft, nodes = NA){
 
     missing_nodes <- setdiff(nodes, 1:n_cues)
 
-    msg_1 <- paste0("select_nodes: Some nodes do not occur in FFT and will be ignored: ",
-                    paste(missing_nodes, collapse = ", "))
-
-    message(msg_1)
-
     nodes <- setdiff(nodes, missing_nodes)  # remove missing nodes
+
+    # Provide user feedback:
+    if (!quiet){
+
+      msg <- paste0("select_nodes: Some nodes do not occur in FFT and will be ignored: ",
+                    paste(missing_nodes, collapse = ", "))
+      cat(u_f_msg(paste0(msg, "\n")))
+    }
 
   } # if sc 1.
 
@@ -664,14 +682,17 @@ select_nodes <- function(fft, nodes = NA){
   # Special case 2:
   if (any(duplicated(nodes))){
 
-    duplicated_nodes <- unique(nodes[duplicated(nodes)])
-
-    msg_2 <- paste0("select_nodes: Duplicated nodes are selected only once: ",
-                    paste(duplicated_nodes, collapse = ", "))
-
-    message(msg_2)
-
     nodes <- unique(nodes)  # remove duplicated nodes
+
+    # Provide user feedback:
+    if (!quiet){
+
+      duplicated_nodes <- unique(nodes[duplicated(nodes)])
+
+      msg <- paste0("select_nodes: Duplicated nodes are selected only once: ",
+                    paste(duplicated_nodes, collapse = ", "))
+      cat(u_f_msg(paste0(msg, "\n")))
+    }
 
   } # if sc 2.
 
@@ -679,7 +700,10 @@ select_nodes <- function(fft, nodes = NA){
   # Special case 3 (AFTER removing any missing or duplicated nodes):
   if (length(nodes) == n_cues) {
 
-    message("select_nodes: fft remains unchanged")  # 4debugging
+    # Provide user feedback:
+    if (!quiet){
+      cat(u_f_msg(paste0("select_nodes: fft remains unchanged\n")))
+    }
 
     return(fft)
 
@@ -690,14 +714,6 @@ select_nodes <- function(fft, nodes = NA){
 
   # Determine nodes to drop (complement):
   drop_nodes <- setdiff(1:n_cues, nodes)
-
-  # # Special case 3:
-  # if (length(drop_nodes) == n_cues){ # nothing left:
-  #
-  #   msg_3 <- paste0("select_nodes: Nothing left of fft")
-  #   stop(msg_3)
-  #
-  # } # if sc 3.
 
   # Filter rows of fft:
   fft_mod <- fft[nodes, ]  # main step
@@ -710,8 +726,13 @@ select_nodes <- function(fft, nodes = NA){
 
     fft_mod$exit[new_exit_node] <- exit_types[3]  # set new exit node
 
-    msg_4 <- paste0("select_nodes: New final node: ", new_exit_node, " (was node ", old_exit_node, " of fft)")
-    message(msg_4)
+    # Provide user feedback:
+    if (!quiet){
+
+      msg <- paste0("select_nodes: New final node: ", new_exit_node, " (was node ", old_exit_node, " of fft)")
+      cat(u_f_msg(paste0(msg, "\n")))
+
+    }
 
   } # if sc 4.
 
@@ -776,7 +797,8 @@ select_nodes <- function(fft, nodes = NA){
 edit_nodes <- function(fft,
                        nodes = NA,  # as vector (1 or multiple nodes)
                        class = NA, cue = NA, direction = NA, threshold = NA, exit = NA,  # variables of fft nodes (as df rows)
-                       my.node = NA){
+                       my.node = NA,
+                       quiet = FALSE){
 
   # Prepare: ----
 
@@ -785,7 +807,10 @@ edit_nodes <- function(fft,
 
   if (all(is.na(nodes))) { # catch case 0:
 
-    message("edit_nodes: fft remains unchanged")  # 4debugging
+    # Provide user feedback:
+    if (!quiet){
+      cat(u_f_msg(paste0("edit_nodes: fft remains unchanged\n")))
+    }
 
     return(fft)
 
@@ -810,10 +835,14 @@ edit_nodes <- function(fft,
 
     missing_nodes <- setdiff(nodes, 1:n_cues)
 
-    msg <- paste0("edit_nodes: Some nodes do not occur in FFT and will be ignored: ",
-                  paste(missing_nodes, collapse = ", "))
+    # Provide user feedback:
+    if (!quiet){
 
-    message(msg)
+      msg <- paste0("edit_nodes: Some nodes do not occur in FFT and will be ignored: ",
+                    paste(missing_nodes, collapse = ", "))
+      cat(u_f_msg(paste0(msg, "\n")))
+
+    }
 
     # Remove missing nodes:
     nodes <- setdiff(nodes, missing_nodes)
@@ -841,6 +870,7 @@ edit_nodes <- function(fft,
 
       } else {
 
+        # Error message:
         msg_class <- paste0("edit_nodes: The class of node ", node_i, " must be in ", paste0(cue_classes, collapse = ", "))
         stop(msg_class)
 
@@ -870,6 +900,7 @@ edit_nodes <- function(fft,
 
       } else {
 
+        # Error message:
         stop(paste0("edit_nodes: Unknown direction symbol: ", cur_dir))
 
       }
@@ -900,6 +931,7 @@ edit_nodes <- function(fft,
 
         } else {
 
+          # Error message:
           msg_exit <- paste0("edit_nodes: The exit of non-final node ", node_i, " must be in ", paste0(exit_types[1:2], collapse = ", "))
           stop(msg_exit)
 
@@ -913,6 +945,7 @@ edit_nodes <- function(fft,
 
         } else {
 
+          # Error message:
           msg_final <- paste0("edit_nodes: The exit of final node ", node_i, " must be ", exit_types[3])
           stop(msg_final)
 
@@ -920,6 +953,7 @@ edit_nodes <- function(fft,
 
       } else { # Error:
 
+        # Error message:
         stop("edit_nodes: Current node_i exceeds n_cues of fft")
 
       }
@@ -977,7 +1011,7 @@ edit_nodes <- function(fft,
 #
 # Output: Modified version of fft (as df, with flipped cue directions/exits)
 
-flip_exits <- function(fft, nodes = NA){
+flip_exits <- function(fft, nodes = NA, quiet = FALSE){
 
   # Prepare: ----
 
@@ -986,7 +1020,10 @@ flip_exits <- function(fft, nodes = NA){
 
   if (all(is.na(nodes))) { # catch case 0:
 
-    message("flip_exits: fft remains unchanged")  # 4debugging
+    # Provide user feedback:
+    if (!quiet){
+      cat(u_f_msg(paste0("flip_exits: fft remains unchanged\n")))
+    }
 
     return(fft)
 
@@ -1010,10 +1047,15 @@ flip_exits <- function(fft, nodes = NA){
     # stop(err_msg)  # Error
 
     # B. Continue, but ignore the missing nodes:
-    msg <- paste0("flip_exits: Some nodes do not occur in FFT and will be ignored: ",
-                  paste(missing_nodes, collapse = ", "))
 
-    message(msg)
+    # Provide user feedback:
+    if (!quiet){
+
+      msg <- paste0("flip_exits: Some nodes do not occur in FFT and will be ignored: ",
+                    paste(missing_nodes, collapse = ", "))
+      cat(u_f_msg(paste0(msg, "\n")))
+
+    }
 
     nodes <- setdiff(nodes, missing_nodes)
 
@@ -1023,9 +1065,13 @@ flip_exits <- function(fft, nodes = NA){
   # Special case 2:
   if (n_cues %in% nodes){ # aiming to flip the final/exit node:
 
-    msg <- paste0("flip_exits: Cannot flip exits of the final node: ", n_cues)
+    # Provide user feedback:
+    if (!quiet){
 
-    message(msg)
+      msg <- paste0("flip_exits: Cannot flip exits of the final node: ", n_cues)
+      cat(u_f_msg(paste0(msg, "\n")))
+
+    }
 
     nodes <- nodes[nodes != n_cues]
 
@@ -1087,7 +1133,7 @@ flip_exits <- function(fft, nodes = NA){
 # Output:
 # fft_mod: modified FFT (in multi-line format, as df)
 
-reorder_nodes <- function(fft, order = NA){
+reorder_nodes <- function(fft, order = NA, quiet = FALSE){
 
   # Prepare: ----
 
@@ -1108,7 +1154,10 @@ reorder_nodes <- function(fft, order = NA){
 
   if (all(order == 1:n_cues)) { # catch case:
 
-    message("reorder_nodes: fft remains unchanged")  # 4debugging
+    # Provide user feedback:
+    if (!quiet){
+      cat(u_f_msg(paste0("reorder_nodes: fft remains unchanged\n")))
+    }
 
     return(fft)
 
@@ -1126,7 +1175,10 @@ reorder_nodes <- function(fft, order = NA){
   # Special case 1:
   if (exit_cue_pos != n_cues){
 
-    message(paste0("reorder_nodes: Former exit node now is node ", exit_cue_pos))
+    # Provide user feedback:
+    if (!quiet){
+      cat(u_f_msg(paste0("reorder_nodes: Former exit node now is node ", exit_cue_pos, "\n")))
+    }
 
     # ?: Which exit direction should be used for previous exit cue?
 
@@ -1179,7 +1231,6 @@ reorder_nodes <- function(fft, order = NA){
 
 
 
-
 # (C) Macros / Combinations of tree editing functions: --------
 
 # Conundrums:
@@ -1204,6 +1255,7 @@ reorder_nodes <- function(fft, order = NA){
 #    2. all_node_orders(),  and
 #    3. all_exit_structures()
 #    to get ALL possible variants of a given FFT.
+
 
 
 # all_node_orders: ------
@@ -1231,7 +1283,10 @@ all_node_orders <- function(fft, quiet = FALSE){
   # Special case 1:
   if (n_cues == 1){
 
-    message(paste0("all_orders: fft contains only 1 node"))
+    # Provide user feedback:
+    if (!quiet){
+      cat(u_f_msg(paste0("all_orders: fft contains only 1 node\n")))
+    }
 
     # Write fft definition:
     cur_fft_df <- write_fft_df(fft = fft, tree = 1)
@@ -1248,7 +1303,7 @@ all_node_orders <- function(fft, quiet = FALSE){
 
   for (i in 1:nrow(all_orders)){
 
-    cur_fft <- reorder_nodes(fft = fft, order = all_orders[i, ])
+    cur_fft <- reorder_nodes(fft = fft, order = all_orders[i, ], quiet = quiet)
 
     cur_fft_df <- write_fft_df(fft = cur_fft, tree = as.integer(i))
 
@@ -1318,7 +1373,7 @@ all_exit_structures <- function(fft, quiet = FALSE){
 
       for (j in 1:nrow(comb_i)){ # loop 2: combinations
 
-        cur_fft <- flip_exits(fft = fft, nodes = comb_i[j, ])
+        cur_fft <- flip_exits(fft = fft, nodes = comb_i[j, ], quiet = quiet)
 
         cnt <- cnt + 1  # increment
 
@@ -1386,7 +1441,7 @@ all_node_subsets <- function(fft, quiet = FALSE){
     cur_nodes <- node_subsets_l[[i]]
     # print(cur_nodes)  # 4debugging
 
-    fft_sub <- select_nodes(fft = fft, nodes = cur_nodes)
+    fft_sub <- select_nodes(fft = fft, nodes = cur_nodes, quiet = quiet)
     # print(fft_sub)  # 4debugging
 
     fft_df <- write_fft_df(fft = fft_sub, tree = cnt)
@@ -1512,7 +1567,7 @@ all_fft_variants <- function(fft, quiet = FALSE){
 # nrow(all_3)
 # verify_ffts_df(all_3)
 #
-# (all_4 <- all_fft_variants(fft = read_fft_df(ffts, tree = 2), quiet = TRUE))
+# (all_4 <- all_fft_variants(fft = read_fft_df(ffts, tree = 2), quiet = FALSE))
 # nrow(all_4)
 # verify_ffts_df(all_4)
 

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -28,6 +28,13 @@
 # 1 FFT collection function:
 # - add_fft_df: Adds definitions (as df) of individual FFTs (as df) to (a set of existing) definitions.
 
+# # Create example data/object x:
+# hd <- FFTrees(formula = diagnosis ~ .,
+#               data = heart.train,
+#               data.test = heart.test)
+# x <- hd  # copy object (with 7 FFTs)
+
+
 
 # read_fft_df: ------
 
@@ -110,11 +117,6 @@ read_fft_df <- function(ffts_df, tree = 1){
 } # read_fft_df().
 
 # # Check:
-# hd <- FFTrees(formula = diagnosis ~ .,
-#               data = heart.train,
-#               data.test = heart.test)
-# x <- hd  # copy object (with 7 FFTs)
-#
 # # FFT definitions:
 # (ffts <- get_fft_df(x))  # using the helper function
 #
@@ -1214,7 +1216,7 @@ reorder_nodes <- function(fft, order = NA){
 # Output:
 #   A set of FFT definitions in all possible cue orders (predicting 1/Signal/TRUE for all changed cues, as reorder_nodes())
 
-all_node_orders <- function(fft){
+all_node_orders <- function(fft, quiet = FALSE){
 
   # Prepare: ----
 
@@ -1255,6 +1257,12 @@ all_node_orders <- function(fft){
   } # for i.
 
 
+  # Provide user feedback:
+  if (!quiet){
+    cat(u_f_msg(paste0("\u2014 Generated ", nrow(out), " node orders.\n")))
+  }
+
+
   # Output: ----
 
   return(out)  # ffts_df (definitions of ffts)
@@ -1279,7 +1287,7 @@ all_node_orders <- function(fft){
 # Input: fft: 1 FFT (as df, 1 row per cue).
 # Output: A set of FFT definitions (ffts_df).
 
-all_exit_structures <- function(fft){
+all_exit_structures <- function(fft, quiet = FALSE){
 
   # Prepare: ----
 
@@ -1325,6 +1333,12 @@ all_exit_structures <- function(fft){
   } # if (n_cues > 1).
 
 
+  # Provide user feedback:
+  if (!quiet){
+    cat(u_f_msg(paste0("\u2014 Generated ", nrow(out), " exit structures.\n")))
+  }
+
+
   # Output: ----
 
   return(out)  # ffts_df (definitions of ffts)
@@ -1347,7 +1361,7 @@ all_exit_structures <- function(fft){
 # Input: fft: 1 FFT (as df, 1 row per cue).
 # Output: A set of FFT definitions (ffts_df).
 
-all_node_subsets <- function(fft){
+all_node_subsets <- function(fft, quiet = FALSE){
 
   # Prepare: ----
 
@@ -1385,6 +1399,12 @@ all_node_subsets <- function(fft){
   } # for i.
 
 
+  # Provide user feedback:
+  if (!quiet){
+    cat(u_f_msg(paste0("\u2014 Generated ", nrow(out), " node subsets.\n")))
+  }
+
+
   # Output: ----
 
   return(out)  # ffts_df (definitions of ffts)
@@ -1413,7 +1433,7 @@ all_node_subsets <- function(fft){
 # Output: A set of FFT definitions (ffts_df).
 
 
-all_fft_variants <- function(fft){
+all_fft_variants <- function(fft, quiet = FALSE){
 
   # Prepare: ------
 
@@ -1431,11 +1451,8 @@ all_fft_variants <- function(fft){
 
   # 1. Get all_node_subsets(): ----
 
-  set_1 <- all_node_subsets(fft = fft)
+  set_1 <- all_node_subsets(fft = fft, quiet = quiet)
   # print(set_1)  # 4debugging
-
-  # Provide user feedback:
-  cat(u_f_msg(paste0("\u2014 Generated ", nrow(set_1), " node subsets.\n")))
 
 
   # 2. Get all node orders (for each fft definition): ----
@@ -1448,14 +1465,11 @@ all_fft_variants <- function(fft){
     # print(cur_fft)  # 4debugging
 
     # Get all_node_orders() for cur_fft:
-    cur_node_orders <- all_node_orders(fft = cur_fft)
+    cur_node_orders <- all_node_orders(fft = cur_fft, quiet = quiet)
 
     set_2 <- add_fft_df(fft = cur_node_orders, ffts_df = set_2)
 
   } # for i.
-
-  # Provide user feedback:
-  cat(u_f_msg(paste0("\u2014 Generated ", nrow(set_2), " node orders.\n")))
 
 
   # 3. Get all exit structures (for each fft definition): ----
@@ -1468,14 +1482,17 @@ all_fft_variants <- function(fft){
     # print(cur_fft)  # 4debugging
 
     # Get all_() for cur_fft:
-    cur_exit_structures <- all_exit_structures(fft = cur_fft)
+    cur_exit_structures <- all_exit_structures(fft = cur_fft, quiet = quiet)
 
     set_3 <- add_fft_df(fft = cur_exit_structures, ffts_df = set_3)
 
   } # for i.
 
+
   # Provide user feedback:
-  cat(u_f_msg(paste0("\u2014 Generated ", nrow(set_3), " exit structures.\n")))
+  if (!quiet){
+    cat(u_f_msg(paste0("\u2014 Generated ", nrow(set_3), " variants.\n")))
+  }
 
 
   # Output: ------
@@ -1495,7 +1512,7 @@ all_fft_variants <- function(fft){
 # nrow(all_3)
 # verify_ffts_df(all_3)
 #
-# (all_4 <- all_fft_variants(fft = read_fft_df(ffts, tree = 2)))
+# (all_4 <- all_fft_variants(fft = read_fft_df(ffts, tree = 2), quiet = TRUE))
 # nrow(all_4)
 # verify_ffts_df(all_4)
 

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -28,6 +28,8 @@
 # 1 FFT collection function:
 # - add_fft_df: Adds definitions (as df) of individual FFTs (as df) to (a set of existing) definitions.
 
+
+
 # # Create example data/object x:
 # hd <- FFTrees(formula = diagnosis ~ .,
 #               data = heart.train,
@@ -37,6 +39,7 @@
 
 
 # read_fft_df: ------
+
 
 # Goal: Extract 1 FFT (as df) from multi-line FFT definitions (as df).
 #
@@ -63,6 +66,7 @@ read_fft_df <- function(ffts_df, tree = 1){
   testthat::expect_true(length(tree) == 1)
 
   if (!(tree %in% ffts_df$tree)){
+    # Error message:
     stop(paste0("No FFT #", tree, " found in ffts_df"))
   }
 
@@ -97,6 +101,7 @@ read_fft_df <- function(ffts_df, tree = 1){
     tvec_diffs_col <- paste(req_tvec_names[ixs_with_diffs], collapse = ", ")
     vlen_diffs_col <- paste(v_lengths[ixs_with_diffs], collapse = ", ")
 
+    # Error message:
     msg <- paste0("The lengths of some FFT definition parts differ from n_nodes = ", n_nodes, ":\n  names of v = (", tvec_diffs_col, "), v_lengths = (", vlen_diffs_col, ").")
     stop(msg)
 
@@ -110,11 +115,13 @@ read_fft_df <- function(ffts_df, tree = 1){
                     exit = exits,
                     stringsAsFactors = FALSE)
 
+
   # Output: ----
 
   return(fft) # (df with 1 row per node)
 
 } # read_fft_df().
+
 
 # # Check:
 # # FFT definitions:
@@ -129,6 +136,7 @@ read_fft_df <- function(ffts_df, tree = 1){
 
 # write_fft_df: ------
 
+
 # Goal: Turn 1 FFT (as df) into a line of multi-line FFT definitions (as df).
 # Inputs:
 # - fft: A definition of 1 FFT (as df, with 1 row per node,
@@ -139,6 +147,7 @@ read_fft_df <- function(ffts_df, tree = 1){
 # Note: Code is currently used at the end of
 # - fftrees_grow_fan()         +++ here now +++
 # - fftrees_wordstofftrees()   +++ here now +++
+
 
 write_fft_df <- function(fft, tree = -99L){
 
@@ -172,6 +181,7 @@ write_fft_df <- function(fft, tree = -99L){
     stringsAsFactors = FALSE
   )
 
+
   # Output: ----
 
   # Convert df to tibble:
@@ -180,6 +190,7 @@ write_fft_df <- function(fft, tree = -99L){
   return(fft_in_1_line)
 
 } # write_fft_df().
+
 
 # # Check:
 # (ffts <- get_fft_df(x))  # using the helper function
@@ -213,9 +224,11 @@ write_fft_df <- function(fft, tree = -99L){
 
 # add_fft_df: ------
 
+
 # Goal: Add an FFT definition (Case 1) or 1 FFT as df (Case 2) to an existing set of FFT definitions.
 #
 # Output: Verified tree definitions of x$trees$definitions (as 1 df); else NA.
+
 
 add_fft_df <- function(fft, ffts_df = NULL){
 
@@ -243,17 +256,20 @@ add_fft_df <- function(fft, ffts_df = NULL){
 
     cur_fft <- write_fft_df(fft = fft, tree = 1)
 
+    # ToDo: Use quiet arg & cat(u_f_msg()) here?
     message("Wrote 1 FFT (from df) to a 1-line definition.")
 
     add_fft_df(fft = cur_fft, ffts_df = ffts_df)  # re-call (with modified 1st argument)
 
   } else {
 
+    # Error message:
     stop("fft must be a valid FFT definition (as df) or a valid FFT (as df)")
 
   }
 
 } # add_fft_df().
+
 
 # # Check:
 # (ffts_df <- get_fft_df(x))
@@ -280,6 +296,7 @@ add_fft_df <- function(fft, ffts_df = NULL){
 
 
 # add_nodes: ------
+
 
 # Goal: Add some node(s) (or cues) to a given FFT.
 #
@@ -518,6 +535,7 @@ add_nodes <- function(fft,
 
 # drop_nodes: ------
 
+
 # Goal: Delete/drop some nodes (or cues) of a given FFT.
 #
 # Inputs:
@@ -525,6 +543,7 @@ add_nodes <- function(fft,
 #   nodes = vector of nodes to drop (as integer in 1:nrow(fft))
 #
 # Output: Modified version of fft (as df, with fewer nodes).
+
 
 drop_nodes <- function(fft, nodes = NA, quiet = FALSE){
 
@@ -630,6 +649,7 @@ drop_nodes <- function(fft, nodes = NA, quiet = FALSE){
 
 } # drop_nodes().
 
+
 # # Check:
 # (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
 # (fft <- read_fft_df(ffts, tree = 2))  # 1 FFT (as df, from above)
@@ -657,6 +677,7 @@ drop_nodes <- function(fft, nodes = NA, quiet = FALSE){
 
 # select_nodes: ------
 
+
 # Goal: Select some nodes (or cues) of a given FFT.
 #       Note: select_nodes() is the complement of drop_nodes().
 #
@@ -665,6 +686,7 @@ drop_nodes <- function(fft, nodes = NA, quiet = FALSE){
 #   nodes = vector of nodes to select (as integer in 1:nrow(fft))
 #
 # Output: Modified version of fft (as df, with fewer nodes).
+
 
 select_nodes <- function(fft, nodes = NA, quiet = FALSE){
 
@@ -777,6 +799,7 @@ select_nodes <- function(fft, nodes = NA, quiet = FALSE){
 
 } # select_nodes().
 
+
 # # Check:
 # (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
 # (fft <- read_fft_df(ffts, tree = 2))  # 1 FFT (as df, from above)
@@ -805,6 +828,7 @@ select_nodes <- function(fft, nodes = NA, quiet = FALSE){
 
 # edit_nodes: ------
 
+
 # Goal: Change (some parameters of) existing nodes.
 #
 # Inputs:
@@ -821,6 +845,7 @@ select_nodes <- function(fft, nodes = NA, quiet = FALSE){
 #
 # Note: As edit_nodes() is ignorant of data, the values of class, cue, and threshold
 #       are currently NOT validated for a specific set of data.
+
 
 edit_nodes <- function(fft,
                        nodes = NA,  # as vector (1 or multiple nodes)
@@ -1003,6 +1028,7 @@ edit_nodes <- function(fft,
 
 } # edit_nodes().
 
+
 # # Check:
 # (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
 # (fft <- read_fft_df(ffts, tree = 1))  # 1 FFT (as df, from above)
@@ -1031,6 +1057,7 @@ edit_nodes <- function(fft,
 
 # flip_exits: ------
 
+
 # Goal: Flip the exits (i.e., cue direction and exit type) of some FFT's (non-final) nodes.
 #
 # Inputs:
@@ -1038,6 +1065,7 @@ edit_nodes <- function(fft,
 #   nodes = vector of nodes to swap (as integer in 1:nrow(fft))
 #
 # Output: Modified version of fft (as df, with flipped cue directions/exits)
+
 
 flip_exits <- function(fft, nodes = NA, quiet = FALSE){
 
@@ -1129,6 +1157,7 @@ flip_exits <- function(fft, nodes = NA, quiet = FALSE){
 
 } # flip_exits().
 
+
 # # Check:
 # (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
 # (fft <- read_fft_df(ffts, tree = 2))  # 1 FFT (as df, from above)
@@ -1152,6 +1181,7 @@ flip_exits <- function(fft, nodes = NA, quiet = FALSE){
 
 # reorder_nodes: ------
 
+
 # Goal: Re-order the nodes of an existing FFT.
 #
 # Inputs:
@@ -1160,6 +1190,7 @@ flip_exits <- function(fft, nodes = NA, quiet = FALSE){
 #
 # Output:
 # fft_mod: modified FFT (in multi-line format, as df)
+
 
 reorder_nodes <- function(fft, order = NA, quiet = FALSE){
 
@@ -1242,6 +1273,7 @@ reorder_nodes <- function(fft, order = NA, quiet = FALSE){
 
 } # reorder_nodes().
 
+
 # # Check:
 # (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
 # (fft  <- read_fft_df(ffts, tree = 5))
@@ -1288,6 +1320,7 @@ reorder_nodes <- function(fft, order = NA, quiet = FALSE){
 
 # all_node_orders: ------
 
+
 # Goal: Apply reorder_nodes(fft) to get all possible permutations of cues for a fft.
 #
 # Input:
@@ -1295,6 +1328,7 @@ reorder_nodes <- function(fft, order = NA, quiet = FALSE){
 #
 # Output:
 #   A set of FFT definitions in all possible cue orders (predicting 1/Signal/TRUE for all changed cues, as reorder_nodes())
+
 
 all_node_orders <- function(fft, quiet = FALSE){
 
@@ -1352,6 +1386,7 @@ all_node_orders <- function(fft, quiet = FALSE){
 
 } # all_node_orders().
 
+
 # # Check:
 # (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
 # (fft  <- read_fft_df(ffts, tree = 1))  # 1 FFT (as df, from above)
@@ -1363,12 +1398,14 @@ all_node_orders <- function(fft, quiet = FALSE){
 
 # all_exit_structures: ------
 
+
 # Goal: Get all 2^(n-1) possible exit structures for an FFT with n cues.
 #
 # Method: Use flip_exits() on nodes = `all_combinations()` for all length values of 1:(n_cues - 1).
 #
 # Input: fft: 1 FFT (as df, 1 row per cue).
 # Output: A set of FFT definitions (ffts_df).
+
 
 all_exit_structures <- function(fft, quiet = FALSE){
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,10 +39,12 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 [![R-CMD-check](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml)
 <!-- Devel badges end. -->
 
+
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color='00a9e0')](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- Release badges end. -->
+
 
 <!-- ALL badges start: --> 
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
@@ -51,6 +53,7 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 <!-- [![Downloads/month](https://cranlogs.r-pkg.org/badges/FFTrees?color=brightgreen)](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color='b22222')](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- ALL badges end. --> 
+
 
 
 <!-- Pkg goal: -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.9.0.9007 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.9.0.9008 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -333,6 +333,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-02-21.\]
+\[File `README.Rmd` last updated on 2023-02-22.\]
 
 <!-- eof. -->


### PR DESCRIPTION
This PR adds a `quiet` argument to various tree trimming functions to hide/show feedback messages (plus some minor bug fixes).