### PR TITLE
Improve tree editing functions and user feedback

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.9.0.9008
-Date: 2023-02-22
+Version: 1.9.0.9009
+Date: 2023-02-23
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.9.0.9009
-Date: 2023-02-23
+Version: 1.9.0.9010
+Date: 2023-02-24
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.9
 
-## 1.9.0.9007
+## 1.9.0.9010
 
 This is the current development version of **FFTrees**, available at <https://github.com/ndphillips/FFTrees>.
 
@@ -23,14 +23,14 @@ Changes since last release:
 
 <!-- Minor: --> 
 
-
 ### Minor changes 
 
 - Added detailed cost information when printing FFTs (with `print.FFTrees()`).  
 - Increased vocabulary for interpreting verbal FFT descriptions (using `my.tree`).
+- Improved user feedback (on different levels of detail). 
+
 
 <!-- Details: --> 
-
 
 ### Details 
 
@@ -447,6 +447,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2023-02-21.]
+[File `NEWS.md` last updated on 2023-02-24.]
 
 <!-- eof. -->

--- a/R/FFTrees.R
+++ b/R/FFTrees.R
@@ -212,7 +212,8 @@ FFTrees <- function(formula = NULL,
                     do.rf = TRUE,
                     do.svm = TRUE,
                     #
-                    quiet = FALSE,
+                    quiet = FALSE,       # ToDo: Deprecate, in favor of 3 more detailed Boolean parameters
+                    # ufeed = 2L,        # ToDo: user feedback level (from feed_types 0:3)
                     #
                     # Deprecated args:   Use instead:
                     comp = NULL,         # do.comp
@@ -224,6 +225,8 @@ FFTrees <- function(formula = NULL,
 ) {
 
   # Prepare: ------
+
+
 
   # A. Handle deprecated arguments and options: ------
 
@@ -264,6 +267,12 @@ FFTrees <- function(formula = NULL,
 
   # B. Verify inputs: ------
 
+
+  # Provide user feedback: ----
+
+  # if (!quiet.ini) { cli::cli_h2("Get FFTrees:") }
+
+
   # object: ----
 
   if (!is.null(object)) { # an FFTrees object is provided:
@@ -295,8 +304,13 @@ FFTrees <- function(formula = NULL,
     # Provide user feedback: ----
 
     if (!quiet) {
-      msg <- paste0("Using the FFTrees object provided (and some of its key parameters).\n")
-      cat(u_f_hig(msg))
+
+      msg <- paste0("Using the FFTrees object provided (and some of its key parameters).")
+
+      # cat(u_f_hig(msg, "\n"))
+
+      cli::cli_alert_info(msg)
+
     }
 
   }
@@ -352,9 +366,14 @@ FFTrees <- function(formula = NULL,
     # Provide user feedback: ----
 
     if (!quiet) {
-      msg <- paste0("Successfully split data into a ", scales::percent(train.p), " (N = ", scales::comma(nrow(data)), ") training and ",
-                    scales::percent(1 - train.p), " (N = ", scales::comma(nrow(data.test)), ") test set.\n")
-      cat(u_f_fin(msg))
+
+      msg <- paste0("Split data into a ", scales::percent(train.p), " (N = ", scales::comma(nrow(data)), ") training and ",
+                    scales::percent(1 - train.p), " (N = ", scales::comma(nrow(data.test)), ") test set.")
+
+      # cat(u_f_fin(msg), "\n")
+
+      cli::cli_alert_success(msg)
+
     }
 
   }
@@ -436,6 +455,11 @@ FFTrees <- function(formula = NULL,
   # 7. Fit competitive algorithms: ----
 
   x <- fftrees_fitcomp(x)
+
+
+  # Provide user feedback: ----
+
+  # if (!quiet.fin) { cli::cli_h2("Got FFTrees.") }
 
 
   # Output: ------

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -44,8 +44,12 @@ fftrees_apply <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    msg <- paste0("Aiming to apply FFTs to '", mydata, "' data:\n")
-    cat(u_f_ini(msg))
+
+    # msg <- paste0("Aiming to apply FFTs to '", mydata, "' data:\n")
+    # cat(u_f_ini(msg))
+
+    n_trees <- x$trees$n
+    cli::cli_alert("Applying {n_trees} FFT{?s} to '{mydata}' data:", class = "alert-start")
   }
 
 
@@ -445,8 +449,13 @@ fftrees_apply <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    msg <- paste0("Successfully applied FFTs to '", mydata, "' data.\n")
-    cat(u_f_fin(msg))
+
+    # msg <- paste0("Successfully applied FFTs to '", mydata, "' data.\n")
+    # cat(u_f_fin(msg))
+
+    n_trees <- x$trees$n
+    cli::cli_alert_success("Applied {n_trees} FFT{?s} to '{mydata}' data.")
+
   }
 
 

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -43,13 +43,13 @@ fftrees_apply <- function(x,
 
   # Provide user feedback: ----
 
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.ini) {
 
     # msg <- paste0("Aiming to apply FFTs to '", mydata, "' data:\n")
     # cat(u_f_ini(msg))
 
     n_trees <- x$trees$n
-    cli::cli_alert("Applying {n_trees} FFT{?s} to '{mydata}' data:", class = "alert-start")
+    cli::cli_alert("Apply {n_trees} FFT{?s} to '{mydata}' data:", class = "alert-start")
   }
 
 
@@ -448,7 +448,7 @@ fftrees_apply <- function(x,
 
   # Provide user feedback: ----
 
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.fin) {
 
     # msg <- paste0("Successfully applied FFTs to '", mydata, "' data.\n")
     # cat(u_f_fin(msg))

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -104,12 +104,17 @@ fftrees_create <- function(formula = NULL,
 
   # Provide user feedback: ----
 
-  if (!quiet) {
+  if (!quiet & !quiet.ini) {
 
     # msg <- "Aiming to create a new FFTrees object:\n"
     # cat(u_f_ini(msg))
 
-    cli::cli_alert("Creating a new FFTrees object:", class = "alert-start")
+    # basic:
+    cli::cli_alert("Create a new FFTrees object:", class = "alert-start")
+
+    # # more:
+    # cli::cli_h2(in_blue("Create FFT"))
+    # cli::cli_alert(in_darkgrey("Create a new FFTrees object:"), class = "alert-start")
 
   }
 
@@ -159,19 +164,22 @@ fftrees_create <- function(formula = NULL,
     if (!is.null(cost.outcomes) | !is.null(cost.cues)) { # use 'cost' goal per default:
 
       goal <- "cost"
-      if (!quiet) { cat(u_f_msg("\u2014 Setting 'goal = cost'\n")) }
+
+      if (!quiet & !quiet.set) { cat(u_f_msg("\u2014 Setting 'goal = cost'\n")) }
 
     } else { # use accuracy defaults (bacc/wacc):
 
       if (enable_wacc(sens.w)){ # use wacc:
 
         goal <- "wacc"
-        if (!quiet) { cat(u_f_msg("\u2014 Setting 'goal = wacc'\n")) }
+
+        if (!quiet & !quiet.set) { cat(u_f_msg("\u2014 Setting 'goal = wacc'\n")) }
 
       } else { # use bacc (as bacc == wacc):
 
         goal <- "bacc"
-        if (!quiet) { cat(u_f_msg("\u2014 Setting 'goal = bacc'\n")) }
+
+        if (!quiet & !quiet.set) { cat(u_f_msg("\u2014 Setting 'goal = bacc'\n")) }
 
       }
 
@@ -179,9 +187,12 @@ fftrees_create <- function(formula = NULL,
 
   } else { # feedback user setting:
 
-    if (!quiet) {
+    if (!quiet & !quiet.set) {
+
       msg <- paste0("\u2014 User set 'goal = ", goal, "'\n")
+
       cat(u_f_msg(msg))
+
     }
 
   } # if (is.null(goal)) else.
@@ -193,8 +204,15 @@ fftrees_create <- function(formula = NULL,
   if ((goal == "wacc") & (!enable_wacc(sens.w))){ # correct to "bacc":
 
     if (!quiet) {
-      cat(u_f_hig("\u2014 User set 'goal = wacc', but 'sens.w = 0.50': Setting 'goal = bacc'\n"))
+
+      wrn_msg <- "\u2014 User set 'goal = wacc', but 'sens.w = 0.50': Setting 'goal = bacc'"
+
+      # cat(u_f_hig(wrn_msg, "\n"))
+
+      cli::cli_alert_warning(wrn_msg)
+
     }
+
     goal <- "bacc"
 
   }
@@ -206,25 +224,25 @@ fftrees_create <- function(formula = NULL,
 
     goal.chase <- "cost"
 
-    if (!quiet) { cat(u_f_msg("\u2014 Setting 'goal.chase = cost'\n")) }
+    if (!quiet & !quiet.set) { cat(u_f_msg("\u2014 Setting 'goal.chase = cost'\n")) }
 
   } else if (is.null(goal.chase)) { # use accuracy defaults (bacc/wacc):
 
     if (enable_wacc(sens.w)){ # set to 'wacc':
 
       goal.chase <- "wacc"
-      if (!quiet) { cat(u_f_msg("\u2014 Setting 'goal.chase = wacc'\n")) }
+      if (!quiet & !quiet.set) { cat(u_f_msg("\u2014 Setting 'goal.chase = wacc'\n")) }
 
     } else { # set to 'bacc' (as bacc == wacc):
 
       goal.chase <- "bacc"
-      if (!quiet) { cat(u_f_msg("\u2014 Setting 'goal.chase = bacc'\n")) }
+      if (!quiet & !quiet.set) { cat(u_f_msg("\u2014 Setting 'goal.chase = bacc'\n")) }
 
     }
 
   } else { # feedback user setting:
 
-    if (!quiet) {
+    if (!quiet & !quiet.set) {
       msg <- paste0("\u2014 User set 'goal.chase = ", goal.chase, "'\n")
       cat(u_f_msg(msg))
     }
@@ -239,8 +257,15 @@ fftrees_create <- function(formula = NULL,
   if ((goal.chase == "wacc") & (!enable_wacc(sens.w))){ # correct to "bacc":
 
     if (!quiet) {
-      cat(u_f_hig("\u2014 User set 'goal.chase = wacc', but 'sens.w = 0.50': Setting 'goal.chase = bacc'\n"))
+
+      wrn_msg <- "\u2014 User set 'goal.chase = wacc', but 'sens.w = 0.50': Setting 'goal.chase = bacc'"
+
+      # cat(u_f_hig(wrn_msg, "\n"))
+
+      cli::cli_alert_warning(wrn_msg)
+
     }
+
     goal.chase <- "bacc"
 
   }
@@ -253,18 +278,18 @@ fftrees_create <- function(formula = NULL,
     if (enable_wacc(sens.w)){ # set to 'wacc':
 
       goal.threshold <- "wacc"
-      if (!quiet) { cat(u_f_msg("\u2014 Setting 'goal.threshold = wacc'\n")) }
+      if (!quiet & !quiet.set) { cat(u_f_msg("\u2014 Setting 'goal.threshold = wacc'\n")) }
 
     } else { # set to 'bacc' (as bacc == wacc):
 
       goal.threshold <- "bacc"
-      if (!quiet) { cat(u_f_msg("\u2014 Setting 'goal.threshold = bacc'\n")) }
+      if (!quiet & !quiet.set) { cat(u_f_msg("\u2014 Setting 'goal.threshold = bacc'\n")) }
 
     }
 
   } else { # feedback user setting:
 
-    if (!quiet) {
+    if (!quiet & !quiet.set) {
       msg <- paste0("\u2014 User set 'goal.threshold = ", goal.threshold, "'\n")
       cat(u_f_msg(msg))
     }
@@ -277,7 +302,7 @@ fftrees_create <- function(formula = NULL,
   # # Note: Default was set to goal.threshold = "bacc" (in FFTrees.R).
   #
   # # Use argument value from FFTrees(), but provide feedback:
-  # if (!quiet) {
+  # if (!quiet & !quiet.set) {
   #
   #   if (goal.threshold == "bacc"){ # report using bacc (i.e., the default):
   #
@@ -305,16 +330,31 @@ fftrees_create <- function(formula = NULL,
   if ((goal.threshold == "wacc") & (!enable_wacc(sens.w))){ # correct to "bacc":
 
     if (!quiet) {
-      cat(u_f_hig("\u2014 User set 'goal.threshold = wacc', but 'sens.w = 0.50': Setting 'goal.threshold = bacc'\n"))
+
+      wrn_msg <- "\u2014 User set 'goal.threshold = wacc', but 'sens.w = 0.50': Setting 'goal.threshold = bacc'"
+
+      # cat(u_f_hig(wrn_msg, "\n"))
+
+      cli::cli_alert_warning(wrn_msg)
+
     }
+
     goal.threshold <- "bacc"
+
   }
 
   if (goal.threshold == "cost") { # note that this only makes sense for outcome costs:
 
     if (!quiet) {
-      cat(u_f_hig("Optimizing cue thresholds for 'cost' only uses 'cost.outcomes', as 'cost.cues' are constant per cue.\n"))
+
+      wrn_msg <- "Optimizing cue thresholds for 'cost' only uses 'cost.outcomes', as 'cost.cues' are constant per cue."
+
+      # cat(u_f_hig(wrn_msg, "\n"))
+
+      cli::cli_alert_warning(wrn_msg)
+
     }
+
   }
 
 
@@ -360,8 +400,12 @@ fftrees_create <- function(formula = NULL,
   if ((enable_wacc(sens.w)) & (!"wacc" %in% cur_goals)) { # provide feedback:
 
     if (!quiet) {
-      msg <- paste0("You set 'sens.w = ", sens.w, "': Did you mean to set a goal to 'wacc'?\n")
-      cat(u_f_hig(msg))
+
+      wrn_msg <- paste0("You set 'sens.w = ", sens.w, "': Did you mean to set a goal to 'wacc'?")
+
+      # cat(u_f_hig(wrn_msg, "\n"))
+
+      cli::cli_alert_warning(wrn_msg)
     }
   }
 
@@ -397,13 +441,13 @@ fftrees_create <- function(formula = NULL,
 
     max.levels <- 4  # default
 
-    if (!quiet) {
+    if (!quiet & !quiet.set) {
       cat(u_f_msg("\u2014 Setting 'max.levels = 4'\n"))
     }
 
   } else { # user set max.levels:
 
-    if (!quiet) {
+    if (!quiet & !quiet.set) {
       msg <- paste0("\u2014 User set 'max.levels = ", max.levels, "'\n")
       cat(u_f_msg(msg))
     }
@@ -421,15 +465,21 @@ fftrees_create <- function(formula = NULL,
     if (!quiet) {
 
       cos <- paste(unlist(cost.outcomes), collapse = " ")
-      msg <- paste0("\u2014 User set 'cost.outcomes' = (", cos, ")\n")
-      cat(u_f_msg(msg))
+
+      if (!quiet.set){
+
+        msg <- paste0("\u2014 User set 'cost.outcomes' = (", cos, ")\n")
+        cat(u_f_msg(msg))
+
+      }
 
       if (!"cost" %in% cur_goals){
 
-        msg_2 <- paste0("Specified 'cost.outcomes', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.")
-        cat(u_f_hig(msg_2, "\n"))
+        wrn_msg <- paste0("Specified 'cost.outcomes', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.")
 
-        # cli::cli_alert_warning(msg_2)
+        # cat(u_f_hig(wrn_msg, "\n"))
+
+        cli::cli_alert_warning(wrn_msg)
 
       }
 
@@ -440,7 +490,7 @@ fftrees_create <- function(formula = NULL,
     # cost.outcomes <- list(hi = 0, fa = 1, mi = 1, cr = 0)  # default values (analogous to accuracy: r = -1)
     cost.outcomes <- cost_outcomes_default  # use global default
 
-    if (!quiet) {
+    if (!quiet & !quiet.set) {
 
       cos <- paste(unlist(cost.outcomes), collapse = " ")
       msg <- paste0("\u2014 Using default 'cost.outcomes' = (", cos, ")\n")
@@ -464,16 +514,21 @@ fftrees_create <- function(formula = NULL,
     if (!quiet) {
 
       ccs <- paste(unlist(cost.cues), collapse = " ")
-      msg <- paste0("\u2014 User set 'cost.cues' = (", ccs, ")")
-      cat(u_f_msg(msg, "\n"))
 
+      if (!quiet.set){
+
+        msg <- paste0("\u2014 User set 'cost.cues' = (", ccs, ")")
+        cat(u_f_msg(msg, "\n"))
+
+      }
 
       if (!"cost" %in% cur_goals){
 
-        msg_2 <- paste0("Specified 'cost.cues', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.")
-        cat(u_f_hig(msg_2, "\n"))
+        wrn_msg <- paste0("Specified 'cost.cues', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.")
 
-        # cli::cli_alert_warning(msg_2)
+        # cat(u_f_hig(wrn_msg, "\n"))
+
+        cli::cli_alert_warning(wrn_msg)
 
       }
 
@@ -481,9 +536,11 @@ fftrees_create <- function(formula = NULL,
 
   } else { # B: use default cost.cues:
 
-    if (!quiet) {
+    if (!quiet & !quiet.set) {
+
       msg <- paste0("\u2014 Using default 'cost.cues' = (", cost_cues_default, " per cue)\n")
       cat(u_f_msg(msg))
+
     }
 
   }
@@ -559,9 +616,12 @@ fftrees_create <- function(formula = NULL,
     # Convert criterion to logical:
     data[[criterion_name]] <- data[[criterion_name]] == decision.labels[2]
 
-    if (!quiet) {
+    if (!quiet & !quiet.set) {
+
       msg <- paste0("\u2014 Setting target to ", criterion_name, " == ", decision.labels[2], "\n")
+
       cat(u_f_msg(msg))
+
     }
 
   }
@@ -720,7 +780,7 @@ fftrees_create <- function(formula = NULL,
 
   # Provide user feedback: ----
 
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.fin) {
 
     # cat(u_f_fin("Successfully created a new FFTrees object.\n"))
 

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -425,8 +425,12 @@ fftrees_create <- function(formula = NULL,
       cat(u_f_msg(msg))
 
       if (!"cost" %in% cur_goals){
-        msg_2 <- paste0("Specified 'cost.outcomes', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.\n")
-        cat(u_f_hig(msg_2))
+
+        msg_2 <- paste0("Specified 'cost.outcomes', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.")
+        cat(u_f_hig(msg_2, "\n"))
+
+        # cli::cli_alert_warning(msg_2)
+
       }
 
     }
@@ -437,9 +441,11 @@ fftrees_create <- function(formula = NULL,
     cost.outcomes <- cost_outcomes_default  # use global default
 
     if (!quiet) {
+
       cos <- paste(unlist(cost.outcomes), collapse = " ")
       msg <- paste0("\u2014 Using default 'cost.outcomes' = (", cos, ")\n")
       cat(u_f_msg(msg))
+
     }
 
   }
@@ -458,12 +464,17 @@ fftrees_create <- function(formula = NULL,
     if (!quiet) {
 
       ccs <- paste(unlist(cost.cues), collapse = " ")
-      msg <- paste0("\u2014 User set 'cost.cues' = (", ccs, ")\n")
-      cat(u_f_msg(msg))
+      msg <- paste0("\u2014 User set 'cost.cues' = (", ccs, ")")
+      cat(u_f_msg(msg, "\n"))
+
 
       if (!"cost" %in% cur_goals){
-        msg_2 <- paste0("Specified 'cost.cues', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.\n")
-        cat(u_f_hig(msg_2))
+
+        msg_2 <- paste0("Specified 'cost.cues', but no goal = 'cost':\nFFT creation will ignore costs, but report cost statistics.")
+        cat(u_f_hig(msg_2, "\n"))
+
+        # cli::cli_alert_warning(msg_2)
+
       }
 
     }

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -105,8 +105,12 @@ fftrees_create <- function(formula = NULL,
   # Provide user feedback: ----
 
   if (!quiet) {
-    msg <- "Aiming to create a new FFTrees object:\n"
-    cat(u_f_ini(msg))
+
+    # msg <- "Aiming to create a new FFTrees object:\n"
+    # cat(u_f_ini(msg))
+
+    cli::cli_alert("Creating a new FFTrees object:", class = "alert-start")
+
   }
 
   # 1. Validation tests: ------
@@ -706,7 +710,11 @@ fftrees_create <- function(formula = NULL,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    cat(u_f_fin("Successfully created a new FFTrees object.\n"))
+
+    # cat(u_f_fin("Successfully created a new FFTrees object.\n"))
+
+    cli::cli_alert_success("Created a new FFTrees object.")
+
   }
 
 

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -68,12 +68,12 @@ fftrees_cuerank <- function(x = NULL,
   goal.threshold <- x$params$goal.threshold  # (assign ONCE here and then use below)
 
   # Provide user feedback:
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.ini) {
 
     # msg <- paste0("Aiming to rank ", cue_n, " cues (optimizing '", goal.threshold, "'):\n")
     # cat(u_f_ini(msg))
 
-    cli::cli_alert("Ranking {cue_n} cue{?s} (optimizing '{goal.threshold}'):",
+    cli::cli_alert("Rank {cue_n} cue{?s} (optimizing '{goal.threshold}'):",
                    class = "alert-start")
 
   }
@@ -361,7 +361,7 @@ fftrees_cuerank <- function(x = NULL,
 
 
   # Provide user feedback:
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.fin) {
 
     # msg <- paste0("Successfully ranked ", cue_n, " cues.\n")
     # cat(u_f_fin(msg))

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -69,8 +69,13 @@ fftrees_cuerank <- function(x = NULL,
 
   # Provide user feedback:
   if (!x$params$quiet) {
-    msg <- paste0("Aiming to rank ", cue_n, " cues (optimizing '", goal.threshold, "'):\n")
-    cat(u_f_ini(msg))
+
+    # msg <- paste0("Aiming to rank ", cue_n, " cues (optimizing '", goal.threshold, "'):\n")
+    # cat(u_f_ini(msg))
+
+    cli::cli_alert("Ranking {cue_n} cue{?s} (optimizing '{goal.threshold}'):",
+                   class = "alert-start")
+
   }
 
   # Define progress bar:
@@ -357,8 +362,12 @@ fftrees_cuerank <- function(x = NULL,
 
   # Provide user feedback:
   if (!x$params$quiet) {
-    msg <- paste0("Successfully ranked ", cue_n, " cues.\n")
-    cat(u_f_fin(msg))
+
+    # msg <- paste0("Successfully ranked ", cue_n, " cues.\n")
+    # cat(u_f_fin(msg))
+
+    cli::cli_alert_success("Ranked {cue_n} cue{?s} (optimizing '{goal.threshold}').")
+
   }
 
 

--- a/R/fftrees_define.R
+++ b/R/fftrees_define.R
@@ -78,8 +78,10 @@ fftrees_define <- function(x,
       # Provide user feedback: ----
 
       if (!x$params$quiet) {
+
         msg <- paste0("Sorted tree IDs in tree.definitions into 1:n_trees (tree = 1:", n_trees, ").\n")
         cat(u_f_hig(msg))
+
       }
 
       # print(tree.definitions)  # 4debugging
@@ -91,8 +93,12 @@ fftrees_define <- function(x,
     x$trees$n <- n_trees
 
     if (!x$params$quiet) {
-      msg <- paste0("Using ", x$trees$n, " FFTs from 'tree.definitions' as current trees.\n")
-      cat(u_f_hig(msg))
+
+      # msg <- paste0("Using ", x$trees$n, " FFTs from 'tree.definitions' as current trees:\n")
+      # cat(u_f_hig(msg))
+
+      cli::cli_alert_info("Using {x$trees$n} FFT{?s} from 'tree.definitions' as current tree{?s}.")
+
     }
 
 
@@ -106,8 +112,12 @@ fftrees_define <- function(x,
     x$trees$n <- as.integer(nrow(object$trees$definitions))
 
     if (!x$params$quiet) {
-      msg <- paste0("Using ", x$trees$n, " FFTs from 'object' as current trees.\n")
-      cat(u_f_hig(msg))
+
+      # msg <- paste0("Using ", x$trees$n, " FFTs from 'object' as current trees:\n")
+      # cat(u_f_hig(msg))
+
+      cli::cli_alert_info("Using {x$trees$n} FFT{?s} from 'object' as current tree{?s}.")
+
     }
 
 

--- a/R/fftrees_define.R
+++ b/R/fftrees_define.R
@@ -49,12 +49,12 @@ fftrees_define <- function(x,
 
   # Provide user feedback: ----
 
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.ini) {
 
     # msg <- paste0("Aiming to define FFTs:\n")
     # cat(u_f_ini(msg))
 
-    cli::cli_alert("Defining FFTs:", class = "alert-start")
+    cli::cli_alert("Define FFTs:", class = "alert-start")
   }
 
 
@@ -79,8 +79,11 @@ fftrees_define <- function(x,
 
       if (!x$params$quiet) {
 
-        msg <- paste0("Sorted tree IDs in tree.definitions into 1:n_trees (tree = 1:", n_trees, ").\n")
-        cat(u_f_hig(msg))
+        msg <- paste0("Sorted tree IDs in tree.definitions into 1:n_trees (tree = 1:", n_trees, ").")
+
+        # cat(u_f_hig(msg, "\n"))
+
+        cli::cli_alert_info(msg)
 
       }
 
@@ -139,7 +142,7 @@ fftrees_define <- function(x,
 
   # Provide user feedback: ----
 
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.fin) {
 
     n_trees <- x$trees$n
 

--- a/R/fftrees_define.R
+++ b/R/fftrees_define.R
@@ -50,8 +50,11 @@ fftrees_define <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    msg <- paste0("Aiming to define FFTs:\n")
-    cat(u_f_ini(msg))
+
+    # msg <- paste0("Aiming to define FFTs:\n")
+    # cat(u_f_ini(msg))
+
+    cli::cli_alert("Defining FFTs:", class = "alert-start")
   }
 
 
@@ -131,14 +134,17 @@ fftrees_define <- function(x,
     n_trees <- x$trees$n
 
     if (n_trees == 1){
-      msg <- paste0("Successfully defined ", n_trees, " FFT.\n")
+      msg <- paste0("Successfully defined ", n_trees, " FFT.")
     } else if (n_trees > 1){
-      msg <- paste0("Successfully defined ", n_trees, " FFTs.\n")
+      msg <- paste0("Successfully defined ", n_trees, " FFTs.")
     } else {
       msg <- "No FFTs were defined."
     }
 
-    cat(u_f_fin(msg))
+    # cat(u_f_fin(msg, "\n"))
+
+    cli::cli_alert_success("Defined {n_trees} FFT{?s}.")
+
   }
 
 

--- a/R/fftrees_ffttowords.R
+++ b/R/fftrees_ffttowords.R
@@ -70,8 +70,7 @@ fftrees_ffttowords <- function(x = NULL,
     # msg <- paste0("Aiming to express FFTs in words:\n")
     # cat(u_f_ini(msg))
 
-    n_trees <- x$trees$n
-    cli::cli_alert("Expressing {n_trees} FFT{?s} in words:", class = "alert-start")
+    cli::cli_alert("Expressing {x$trees$n} FFT{?s} in words:", class = "alert-start")
 
   }
 
@@ -306,8 +305,7 @@ fftrees_ffttowords <- function(x = NULL,
     # msg <- paste0("Successfully expressed FFTs in words.\n")
     # cat(u_f_fin(msg))
 
-    n_trees <- x$trees$n
-    cli::cli_alert_success("Expressed {n_trees} FFT{?s} in words.")
+    cli::cli_alert_success("Expressed {x$trees$n} FFT{?s} in words.")
 
   }
 

--- a/R/fftrees_ffttowords.R
+++ b/R/fftrees_ffttowords.R
@@ -65,12 +65,12 @@ fftrees_ffttowords <- function(x = NULL,
 
   # Provide user feedback: ----
 
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.ini) {
 
     # msg <- paste0("Aiming to express FFTs in words:\n")
     # cat(u_f_ini(msg))
 
-    cli::cli_alert("Expressing {x$trees$n} FFT{?s} in words:", class = "alert-start")
+    cli::cli_alert("Express {x$trees$n} FFT{?s} in words:", class = "alert-start")
 
   }
 
@@ -300,7 +300,7 @@ fftrees_ffttowords <- function(x = NULL,
 
   # Provide user feedback: ----
 
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.fin) {
 
     # msg <- paste0("Successfully expressed FFTs in words.\n")
     # cat(u_f_fin(msg))

--- a/R/fftrees_ffttowords.R
+++ b/R/fftrees_ffttowords.R
@@ -66,8 +66,13 @@ fftrees_ffttowords <- function(x = NULL,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    msg <- paste0("Aiming to express FFTs in words:\n")
-    cat(u_f_ini(msg))
+
+    # msg <- paste0("Aiming to express FFTs in words:\n")
+    # cat(u_f_ini(msg))
+
+    n_trees <- x$trees$n
+    cli::cli_alert("Expressing {n_trees} FFT{?s} in words:", class = "alert-start")
+
   }
 
 
@@ -297,8 +302,13 @@ fftrees_ffttowords <- function(x = NULL,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    msg <- paste0("Successfully expressed FFTs in words.\n")
-    cat(u_f_fin(msg))
+
+    # msg <- paste0("Successfully expressed FFTs in words.\n")
+    # cat(u_f_fin(msg))
+
+    n_trees <- x$trees$n
+    cli::cli_alert_success("Expressed {n_trees} FFT{?s} in words.")
+
   }
 
 

--- a/R/fftrees_fitcomp.R
+++ b/R/fftrees_fitcomp.R
@@ -61,12 +61,14 @@ fftrees_fitcomp <- function(x) {
   # Provide user feedback: ----
 
   if (do.lr | do.cart | do.rf | do.svm) {
-    if (!x$params$quiet) {
+    if (!x$params$quiet & !quiet.ini) {
 
       # msg <- "Aiming to fit comparative algorithms (disable by do.comp = FALSE):\n"
       # cat(u_f_ini(msg))
 
-      cli::cli_alert("Fitting comparative algorithms (disable by do.comp = FALSE):",
+      sum_alg <- sum(c(do.lr, do.cart, do.rf, do.svm))
+
+      cli::cli_alert("Fit {sum_alg} comparative algorithm{?s} (disable by {.code do.comp = FALSE}):",
                      class = "alert-start")
 
     }
@@ -213,11 +215,13 @@ fftrees_fitcomp <- function(x) {
   # Provide user feedback: ----
 
   if (do.lr | do.cart | do.rf | do.svm) {
-    if (!x$params$quiet) {
+
+    if (!x$params$quiet & !quiet.fin) {
 
       # cat(u_f_fin("Successfully fitted comparative algorithms.\n"))
 
-      cli::cli_alert_success("Fitted comparative algorithms.")
+      sum_alg <- sum(c(do.lr, do.cart, do.rf, do.svm))
+      cli::cli_alert_success("Fitted {sum_alg} comparative algorithm{?s}.")
 
     }
   }

--- a/R/fftrees_fitcomp.R
+++ b/R/fftrees_fitcomp.R
@@ -62,8 +62,13 @@ fftrees_fitcomp <- function(x) {
 
   if (do.lr | do.cart | do.rf | do.svm) {
     if (!x$params$quiet) {
-      msg <- "Aiming to fit comparative algorithms (disable by do.comp = FALSE):\n"
-      cat(u_f_ini(msg))
+
+      # msg <- "Aiming to fit comparative algorithms (disable by do.comp = FALSE):\n"
+      # cat(u_f_ini(msg))
+
+      cli::cli_alert("Fitting comparative algorithms (disable by do.comp = FALSE):",
+                     class = "alert-start")
+
     }
   }
 
@@ -209,7 +214,11 @@ fftrees_fitcomp <- function(x) {
 
   if (do.lr | do.cart | do.rf | do.svm) {
     if (!x$params$quiet) {
-      cat(u_f_fin("Successfully fitted comparative algorithms.\n"))
+
+      # cat(u_f_fin("Successfully fitted comparative algorithms.\n"))
+
+      cli::cli_alert_success("Fitted comparative algorithms.")
+
     }
   }
 

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -25,7 +25,7 @@ fftrees_grow_fan <- function(x,
   # Prepare: ------
 
   # Provide user feedback:
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.ini) {
 
     cur_algorithm  <- x$params$algorithm
     cur_goal.chase <- x$params$goal.chase
@@ -33,7 +33,7 @@ fftrees_grow_fan <- function(x,
     # msg <- paste0("Aiming to create FFTs with '", cur_algorithm, "' algorithm (chasing '", cur_goal.chase, "'):\n")
     # cat(u_f_ini(msg))
 
-    cli::cli_alert("Creating FFTs with '{cur_algorithm}' algorithm (chasing '{cur_goal.chase}'):",
+    cli::cli_alert("Create FFTs with '{cur_algorithm}' algorithm (chasing '{cur_goal.chase}'):",
               class = "alert-start")
   }
 
@@ -813,7 +813,7 @@ fftrees_grow_fan <- function(x,
 
 
   # Provide user feedback:
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.fin) {
 
     n_trees <- x$trees$n
     cur_algorithm  <- x$params$algorithm

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -30,8 +30,11 @@ fftrees_grow_fan <- function(x,
     cur_algorithm  <- x$params$algorithm
     cur_goal.chase <- x$params$goal.chase
 
-    msg <- paste0("Aiming to create FFTs with '", cur_algorithm, "' algorithm (chasing '", cur_goal.chase, "'):\n")
-    cat(u_f_ini(msg))
+    # msg <- paste0("Aiming to create FFTs with '", cur_algorithm, "' algorithm (chasing '", cur_goal.chase, "'):\n")
+    # cat(u_f_ini(msg))
+
+    cli::cli_alert("Creating FFTs with '{cur_algorithm}' algorithm (chasing '{cur_goal.chase}'):",
+              class = "alert-start")
   }
 
   # Global variables which can be changed later:
@@ -811,9 +814,19 @@ fftrees_grow_fan <- function(x,
 
   # Provide user feedback:
   if (!x$params$quiet) {
-    msg <- paste0("Successfully created ", x$trees$n, " FFTs with '", x$params$algorithm, "' algorithm.\n")
-    cat(u_f_fin(msg))
+
+    n_trees <- x$trees$n
+    cur_algorithm  <- x$params$algorithm
+    cur_goal.chase <- x$params$goal.chase
+
+    # msg <- paste0("Successfully created ", n_trees, " FFTs with '", cur_algorithm, "' algorithm.\n")
+    # cat(u_f_fin(msg))
+
+    cli::cli_alert_success("Created {n_trees} FFT{?s} with '{cur_algorithm}' algorithm (chasing '{cur_goal.chase}').")
+
   }
+
+
 
 
   # Output: ----

--- a/R/fftrees_ranktrees.R
+++ b/R/fftrees_ranktrees.R
@@ -31,13 +31,13 @@ fftrees_ranktrees <- function(x,
 
   # Provide user feedback: ----
 
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.ini) {
 
     # msg <- paste0("Aiming to rank FFTs by '", data, "' data:\n")
     # cat(u_f_ini(msg))
 
     n_trees <- x$trees$n
-    cli::cli_alert("Ranking {n_trees} FFT{?s} by '{data}' data:",
+    cli::cli_alert("Rank {n_trees} FFT{?s} by '{data}' data:",
                    class = "alert-start")
 
   }
@@ -108,7 +108,7 @@ fftrees_ranktrees <- function(x,
 
   # Provide user feedback: ----
 
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.fin) {
 
     # msg <- paste0("Successfully ranked FFTs by '", data, "' data.\n")
     # cat(u_f_fin(msg))

--- a/R/fftrees_ranktrees.R
+++ b/R/fftrees_ranktrees.R
@@ -32,8 +32,14 @@ fftrees_ranktrees <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    msg <- paste0("Aiming to rank FFTs by '", data, "' data:\n")
-    cat(u_f_ini(msg))
+
+    # msg <- paste0("Aiming to rank FFTs by '", data, "' data:\n")
+    # cat(u_f_ini(msg))
+
+    n_trees <- x$trees$n
+    cli::cli_alert("Ranking {n_trees} FFT{?s} by '{data}' data:",
+                   class = "alert-start")
+
   }
   # print(x$trees$definitions) # 4debugging
 
@@ -103,8 +109,13 @@ fftrees_ranktrees <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    msg <- paste0("Successfully ranked FFTs by '", data, "' data.\n")
-    cat(u_f_fin(msg))
+
+    # msg <- paste0("Successfully ranked FFTs by '", data, "' data.\n")
+    # cat(u_f_fin(msg))
+
+    n_trees <- x$trees$n
+    cli::cli_alert_success("Ranked {n_trees} FFT{?s} by '{data}' data.")
+
   }
   # print(x$trees$definitions) # 4debugging
 

--- a/R/fftrees_wordstofftrees.R
+++ b/R/fftrees_wordstofftrees.R
@@ -38,7 +38,11 @@ fftrees_wordstofftrees <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    cat(u_f_ini("Aiming to create an FFT from 'my.tree' description:\n"))
+
+    # cat(u_f_ini("Aiming to create an FFT from 'my.tree' description:\n"))
+
+    cli::cli_alert("Creating an FFT from 'my.tree' description:", class = "alert-start")
+
   }
 
   # Parameters / options: ------
@@ -342,8 +346,13 @@ fftrees_wordstofftrees <- function(x,
   # Provide user feedback: ----
 
   if (!x$params$quiet) {
-    cat(u_f_fin("Successfully created an FFT from 'my.tree' description.\n"))
+
+    # cat(u_f_fin("Successfully created an FFT from 'my.tree' description.\n"))
+
+    cli::cli_alert_success("Created an FFT from 'my.tree' description.")
+
   }
+
 
   # Output: ------
 

--- a/R/fftrees_wordstofftrees.R
+++ b/R/fftrees_wordstofftrees.R
@@ -345,7 +345,7 @@ fftrees_wordstofftrees <- function(x,
 
   # Provide user feedback: ----
 
-  if (!x$params$quiet) {
+  if (!x$params$quiet & !quiet.fin) {
 
     # cat(u_f_fin("Successfully created an FFT from 'my.tree' description.\n"))
 

--- a/R/util_color.R
+++ b/R/util_color.R
@@ -48,6 +48,24 @@ u_f_msg <- cli::make_ansi_style("grey50", grey = TRUE, colors = 256)  # normal m
 u_f_hig <- cli::make_ansi_style("dodgerblue4",         colors = 256)  # highlighted msg
 
 
+# Define cli themes: ----
+
+# # Color of headings, that are only active in paragraphs with an 'output' class:
+#
+#   list(
+#     "par.output h1" = list("background-color" = "red", color = "#e0e0e0"),
+#     "par.output h2" = list("background-color" = "orange", color = "#e0e0e0"),
+#     "par.output h3" = list("background-color" = "blue", color = "#e0e0e0")
+#   )
+#
+# # Create custom alert types:
+#
+#   list(
+#     ".alert-start" = list(before = symbol$play),
+#     ".alert-stop"  = list(before = symbol$stop)
+#   )
+
+
 # ToDo: ------
 
 # - etc.

--- a/R/util_const.R
+++ b/R/util_const.R
@@ -105,6 +105,88 @@ negations_v <- c("not", "is not")  # (global constant)
 exit_types <- c(0, 1, 0.5)  # (global constant)
 
 
+# quiet.ini: ----
+
+# Boolean: Should user feedback for initialization (of a command or process) be shown (i.e., NOT hidden/quiet)?
+
+quiet.ini <- TRUE # FALSE # default: TRUE
+
+
+# quiet.fin: ----
+
+# Boolean: Should user feedback for finalization/success (of a command or process) be shown (i.e., NOT hidden/quiet)?
+
+quiet.fin <- FALSE # TRUE # default: FALSE
+
+
+# quiet.set: ----
+
+# Boolean: Should user feedback for parameter settings be shown (i.e., NOT hidden/quiet)?
+
+quiet.set <- FALSE # TRUE # FALSE # default: FALSE
+
+
+# feed_types: ----
+
+feed_types <- 0L:3L  # options: 4 levels
+
+
+# ufeed: ----
+
+# #' @param ufeed User feedback level (as an integer from \code{0} to \code{3},
+# #' with higher values implying more detailed user feedback).
+# #' Setting \code{ufeed = 0} provides no user feedback.
+# #' Default: \code{ufeed = 2} (show parameter settings and success alerts).
+
+
+ufeed <- 3L  # user feedback level (from feed_types 0:3)
+
+
+if (ufeed %in% feed_types == FALSE){
+
+  msg <- paste0("The value of 'ufeed' must be in: ", paste(feed_types, collapse = ", "))
+
+  stop(msg)
+
+}
+
+
+# Define custom ufeed categories (from 0 to 3):
+
+if (ufeed == 0){ # most basic/elementary/sparse:
+
+  # quiet <- TRUE  # hide progress
+
+  quiet.ini <- TRUE  # hide initials
+  quiet.set <- TRUE  # hide settings
+  quiet.fin <- TRUE  # hide success
+
+} else if (ufeed == 1){ # show success/warnings:
+
+  # quiet <- FALSE  # show progress
+
+  quiet.ini <- TRUE   # hide initials
+  quiet.set <- TRUE   # hide settings
+  quiet.fin <- FALSE  # show success
+
+} else if (ufeed == 2){ # add settings:
+
+  # quiet <- FALSE  # show progress
+
+  quiet.ini <- TRUE   # hide initials
+  quiet.set <- FALSE  # show settings
+  quiet.fin <- FALSE  # show success
+
+} else if (ufeed == 3){ # most detailed/explicit:
+
+  # quiet <- FALSE  # show progress
+
+  quiet.ini <- FALSE  # show initials
+  quiet.set <- FALSE  # show settings
+  quiet.fin <- FALSE  # show success
+
+}
+
 
 # ToDo: ------
 

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -102,8 +102,8 @@ read_fft_df <- function(ffts_df, tree = 1){
     vlen_diffs_col <- paste(v_lengths[ixs_with_diffs], collapse = ", ")
 
     # Error message:
-    msg <- paste0("The lengths of some FFT definition parts differ from n_nodes = ", n_nodes, ":\n  names of v = (", tvec_diffs_col, "), v_lengths = (", vlen_diffs_col, ").")
-    stop(msg)
+    stop(paste0("The lengths of some FFT definition parts differ from n_nodes = ", n_nodes,
+                ":\n  names of v = (", tvec_diffs_col, "), v_lengths = (", vlen_diffs_col, ")."))
 
   }
 
@@ -230,7 +230,7 @@ write_fft_df <- function(fft, tree = -99L){
 # Output: Verified tree definitions of x$trees$definitions (as 1 df); else NA.
 
 
-add_fft_df <- function(fft, ffts_df = NULL){
+add_fft_df <- function(fft, ffts_df = NULL, quiet = FALSE){
 
   if (verify_ffts_df(fft)){   # Case 1: fft is a (set of) FFT-definitions (in 1 row per tree, as df) ----
 
@@ -248,16 +248,19 @@ add_fft_df <- function(fft, ffts_df = NULL){
 
         return(out_ffts_df)  # Output (default)
 
-      }
+      } # if ffts_df.
 
-    }
+    } # if else fft.
 
   } else if (verify_fft_as_df(fft)){ # Case 2: fft is 1 FFT (as df, 1 row per node) ----
 
     cur_fft <- write_fft_df(fft = fft, tree = 1)
 
-    # ToDo: Use quiet arg & cat(u_f_msg()) here?
-    message("Wrote 1 FFT (from df) to a 1-line definition.")
+    # Provide user feedback:
+    if (!quiet){
+      cat(u_f_msg(paste0("add_fft_df: Wrote fft to a 1-line definition\n")))
+    }
+
 
     add_fft_df(fft = cur_fft, ffts_df = ffts_df)  # re-call (with modified 1st argument)
 
@@ -272,17 +275,16 @@ add_fft_df <- function(fft, ffts_df = NULL){
 
 
 # # Check:
-# (ffts_df <- get_fft_df(x))
-# (fft <- read_fft_df(ffts_df, tree = 2))
+# (ffts <- get_fft_df(x))
+# (fft  <- read_fft_df(ffts, tree = 2))
 #
 # # Baselines:
-# add_fft_df(ffts_df)  # Case 0a: Add a set of definitions to NULL.
+# add_fft_df(ffts)  # Case 0a: Add a set of definitions to NULL.
 # add_fft_df(fft)   # Case 0c: Add 1 FFT (as df) to NULL.
 #
 # # Intended use:
-# add_fft_df(ffts_df[2, ], ffts_df)  # Case 1: Add 1 definition to a set of definitions.
-# add_fft_df(fft, ffts_df)     # Case 2: Add 1 FFT (as df) to a set of definitions.
-
+# add_fft_df(ffts[2, ], ffts)  # Case 1: Add 1 definition to a set of definitions.
+# add_fft_df(fft, ffts)        # Case 2: Add 1 FFT (as df) to a set of definitions.
 
 
 

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -1476,7 +1476,7 @@ all_exit_structures <- function(fft, quiet = FALSE){
 
 
 
-# all_node_subsets(): ------
+# all_node_subsets: ------
 
 # Goal: Get all subtrees of an FFT.
 #
@@ -1630,11 +1630,11 @@ all_fft_variants <- function(fft, quiet = FALSE){
 # (ffts <- get_fft_df(x))  # x$trees$definitions / definitions (as df)
 # (fft  <- read_fft_df(ffts, tree = 1))  # 1 FFT (as df, from above)
 #
-# (all_3 <- all_fft_variants(fft = read_fft_df(ffts, tree = 1)))
+# (all_3 <- all_fft_variants(fft = read_fft_df(ffts, tree = 1), quiet = FALSE))
 # nrow(all_3)
 # verify_ffts_df(all_3)
 #
-# (all_4 <- all_fft_variants(fft = read_fft_df(ffts, tree = 2), quiet = FALSE))
+# (all_4 <- all_fft_variants(fft = read_fft_df(ffts, tree = 2), quiet = TRUE))
 # nrow(all_4)
 # verify_ffts_df(all_4)
 

--- a/R/util_gfft.R
+++ b/R/util_gfft.R
@@ -289,7 +289,7 @@ add_fft_df <- function(fft, ffts_df = NULL, quiet = FALSE){
 
 
 
-# (B) Editing tree descriptions: --------
+# (B) Tree editing/trimming functions: --------
 
 # Goal: Functions for editing, manipulating, and trimming individual FFTs (in df format).
 
@@ -1642,7 +1642,7 @@ all_fft_variants <- function(fft, quiet = FALSE){
 
 # ToDo: ------
 
-# - Make some functions (e.g., tree editing functions) work alternative inputs of either
+# - Make some functions (e.g., tree editing functions) work for alternative inputs of either
 #   (1) FFT definitions (df, 1 row per tree) OR
 #   (2) single FFTs (as df, 1 row per node).
 #

--- a/README.Rmd
+++ b/README.Rmd
@@ -33,11 +33,13 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 
 # FFTrees `r packageVersion("FFTrees")` <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
+
 <!-- Devel badges start: --> 
 [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees)
 [![Downloads/month](https://cranlogs.r-pkg.org/badges/FFTrees?color='00a9e0')](https://www.r-pkg.org/pkg/FFTrees)
 [![R-CMD-check](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml)
 <!-- Devel badges end. -->
+
 
 
 <!-- Release badges start: -->

--- a/README.Rmd
+++ b/README.Rmd
@@ -34,11 +34,13 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 # FFTrees `r packageVersion("FFTrees")` <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 
+
 <!-- Devel badges start: --> 
 [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees)
 [![Downloads/month](https://cranlogs.r-pkg.org/badges/FFTrees?color='00a9e0')](https://www.r-pkg.org/pkg/FFTrees)
 [![R-CMD-check](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml)
 <!-- Devel badges end. -->
+
 
 
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,8 +42,6 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 <!-- Devel badges end. -->
 
 
-
-
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color='00a9e0')](https://www.r-pkg.org/pkg/FFTrees) -->

--- a/README.Rmd
+++ b/README.Rmd
@@ -146,9 +146,9 @@ Once we have created some FFTs, additional questions include:
 
 - How accurate are the predictions of a specific FFT?
 - How does its performance compare with alternative machine-learning algorithms?
-- How costly are the predictions of each algorithm?
+- How costly are the predictions of each algorithm? 
 
-The **FFTrees** package answers these questions by creating FFTs and allowing to evaluate, visualize, and compare them to alternative algorithms.
+The **FFTrees** package answers these questions by creating FFTs and allowing to evaluate, visualize, and compare them to alternative algorithms. 
 
 
 ### Creating fast-and-frugal trees (FFTs) 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.9.0.9008 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.9.0.9009 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.9.0.9009 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.9.0.9010 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -333,6 +333,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-02-23.\]
+\[File `README.Rmd` last updated on 2023-02-24.\]
 
 <!-- eof. -->

--- a/README.md
+++ b/README.md
@@ -333,6 +333,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-02-22.\]
+\[File `README.Rmd` last updated on 2023-02-23.\]
 
 <!-- eof. -->


### PR DESCRIPTION
This PR mostly improves user feedback options (for tree trimming and general functions) by using different types of alert messages (from the **cli** package) and more specific logical parameters (e.g., `quiet.ini`, `quiet.fin` and `quiet.set`).

The functionality of `ufeed` (for _user feedback level_) is currently implemented as a global constants (see `util_const.R`).  