### PR TITLE
Bug fix: Treat `NA` values in logical like those in factors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.9.0.9012
-Date: 2023-02-25
+Version: 1.9.0.9013
+Date: 2023-02-26
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),
@@ -20,10 +20,10 @@ Imports:
     randomForest,
     e1071,
     cli,
-    scales,
     dplyr,
     knitr,
     magrittr,
+    scales,
     stringr,
     testthat,
     tibble,

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -205,7 +205,7 @@ fftrees_create <- function(formula = NULL,
 
     if (any(sapply(quiet, isFALSE))) {
 
-      wrn_msg <- "\u2014 User set 'goal = wacc', but 'sens.w = 0.50': Setting 'goal = bacc'"
+      wrn_msg <- "User set 'goal = wacc', but 'sens.w = 0.50': Setting 'goal = bacc'"
 
       # cat(u_f_hig(wrn_msg, "\n"))
 
@@ -243,8 +243,11 @@ fftrees_create <- function(formula = NULL,
   } else { # feedback user setting:
 
     if (!quiet$set) {
+
       msg <- paste0("\u2014 User set 'goal.chase = ", goal.chase, "'\n")
+
       cat(u_f_msg(msg))
+
     }
 
   }
@@ -258,7 +261,7 @@ fftrees_create <- function(formula = NULL,
 
     if (any(sapply(quiet, isFALSE))) {
 
-      wrn_msg <- "\u2014 User set 'goal.chase = wacc', but 'sens.w = 0.50': Setting 'goal.chase = bacc'"
+      wrn_msg <- "User set 'goal.chase = wacc', but 'sens.w = 0.50': Setting 'goal.chase = bacc'"
 
       # cat(u_f_hig(wrn_msg, "\n"))
 
@@ -283,6 +286,7 @@ fftrees_create <- function(formula = NULL,
     } else { # set to 'bacc' (as bacc == wacc):
 
       goal.threshold <- "bacc"
+
       if (!quiet$set) { cat(u_f_msg("\u2014 Setting 'goal.threshold = bacc'\n")) }
 
     }
@@ -290,8 +294,11 @@ fftrees_create <- function(formula = NULL,
   } else { # feedback user setting:
 
     if (!quiet$set) {
+
       msg <- paste0("\u2014 User set 'goal.threshold = ", goal.threshold, "'\n")
+
       cat(u_f_msg(msg))
+
     }
 
   }
@@ -331,7 +338,7 @@ fftrees_create <- function(formula = NULL,
 
     if (any(sapply(quiet, isFALSE))) {
 
-      wrn_msg <- "\u2014 User set 'goal.threshold = wacc', but 'sens.w = 0.50': Setting 'goal.threshold = bacc'"
+      wrn_msg <- "User set 'goal.threshold = wacc', but 'sens.w = 0.50': Setting 'goal.threshold = bacc'"
 
       # cat(u_f_hig(wrn_msg, "\n"))
 
@@ -377,6 +384,7 @@ fftrees_create <- function(formula = NULL,
       invalid_avec <- paste(invalid_args, collapse = ", ")
 
       stop("my.goal.fun must contain 4 arguments (hi, fa, mi, cr), but not ", invalid_avec)
+
     }
 
     if (any(my_goal_arg_valid %in% fn_arg_names == FALSE)){
@@ -385,7 +393,8 @@ fftrees_create <- function(formula = NULL,
       missing_avec <- paste(missing_args, collapse = ", ")
       if (length(missing_args) < 2) {be <- "is"} else { be <- "are"}
 
-      message("my.goal.fun usually contains 4 arguments (hi, fa, mi, cr), but (", missing_avec, ") ", be, " missing")
+      cli::cli_alert_warning("my.goal.fun usually contains 4 arguments (hi, fa, mi, cr), but (", missing_avec, ") ", be, " missing")
+
     }
 
   } # if (my.goal).
@@ -442,14 +451,19 @@ fftrees_create <- function(formula = NULL,
     max.levels <- 4  # default
 
     if (!quiet$set) {
+
       cat(u_f_msg("\u2014 Setting 'max.levels = 4'\n"))
+
     }
 
   } else { # user set max.levels:
 
     if (!quiet$set) {
+
       msg <- paste0("\u2014 User set 'max.levels = ", max.levels, "'\n")
+
       cat(u_f_msg(msg))
+
     }
 
   }
@@ -469,6 +483,7 @@ fftrees_create <- function(formula = NULL,
       if (!quiet$set){
 
         msg <- paste0("\u2014 User set 'cost.outcomes' = (", cos, ")\n")
+
         cat(u_f_msg(msg))
 
       }
@@ -519,6 +534,7 @@ fftrees_create <- function(formula = NULL,
       if (!quiet$set){
 
         msg <- paste0("\u2014 User set 'cost.cues' = (", ccs, ")")
+
         cat(u_f_msg(msg, "\n"))
 
       }
@@ -541,6 +557,7 @@ fftrees_create <- function(formula = NULL,
     if (!quiet$set) {
 
       msg <- paste0("\u2014 Using default 'cost.cues' = (", cost_cues_default, " per cue)\n")
+
       cat(u_f_msg(msg))
 
     }
@@ -632,6 +649,7 @@ fftrees_create <- function(formula = NULL,
   # Check that criterion is in data.test: ----
 
   if (!is.null(data.test)) {
+
     testthat::expect_true(is.data.frame(data),
                           info = "Object is not a dataframe."
     )
@@ -639,6 +657,7 @@ fftrees_create <- function(formula = NULL,
     testthat::expect_true(criterion_name %in% names(data.test),
                           info = paste("The criterion", criterion_name, "is not in data.test")
     )
+
   }
 
 

--- a/R/util_data.R
+++ b/R/util_data.R
@@ -146,7 +146,7 @@ handle_NA <- function(data, criterion_name){
 
     # Replace NA values:
     data[ix_pred_chr] <- data[ix_pred_chr] %>%
-      dplyr::mutate_if(is.character, addNA)
+      dplyr::mutate_if(is.character, addNA)  # add NA as a new factor level
 
     # Provide user feedback:
     cli::cli_alert_success("Converted {sum(nr_pred_chr_NA)} NA case{?s} in {sum(ix_pred_chr_NA)} character predictor{?s} to <NA>.")
@@ -157,28 +157,27 @@ handle_NA <- function(data, criterion_name){
 
     # Replace NA values:
     data[ix_pred_fct] <- data[ix_pred_fct] %>%
-      dplyr::mutate_if(is.factor, addNA)
+      dplyr::mutate_if(is.factor, addNA)  # add NA as a new factor level
 
     # Provide user feedback:
     cli::cli_alert_success("Converted {sum(nr_pred_fct_NA)} NA case{?s} in {sum(ix_pred_fct_NA)} factor predictor{?s} to <NA>.")
 
   }
 
+  if (any(ix_pred_log_NA)){ # NA values in logical predictors: ----
+
+    # Replace NA values:
+    data[ix_pred_log] <- data[ix_pred_log] %>%
+      dplyr::mutate_if(is.logical, addNA)  # add NA as a new factor level
+
+    # Provide user feedback:
+    cli::cli_alert_success("Converted {sum(nr_pred_log_NA)} NA case{?s} in {sum(ix_pred_log_NA)} logical predictor{?s} to <NA>.")
+
+  }
+
 
   # +++ here now +++
 
-
-  if (any(ix_pred_log_NA)){ # NA values in logical predictors: ----
-
-    # Idea: Simply convert to character:
-    data[ix_pred_log_NA] <- as.character(data[ix_pred_log_NA])
-
-    # ToDo: Consider adding same treatment as for character values (above)?
-
-    # Provide user feedback:
-    cli::cli_alert_success("Converted {sum(ix_pred_log_NA)} logical predictor{?s} to character, due to {sum(nr_pred_log_NA)} NA case{?s}.")
-
-  }
 
   if (any(ix_pred_num_NA)){ # NA values in numeric predictors: ----
 
@@ -199,7 +198,7 @@ handle_NA <- function(data, criterion_name){
   }
 
 
-  # print(data)  # 4debugging
+  print(tibble::as_tibble(data))  # 4debugging
 
 
   # Output: ------

--- a/R/util_data.R
+++ b/R/util_data.R
@@ -170,10 +170,10 @@ handle_NA <- function(data, criterion_name){
 
   if (any(ix_pred_log_NA)){ # NA values in logical predictors: ----
 
-    # ToDo: What to do about NA values in logical variables?
-
     # Idea: Simply convert to character:
     data[ix_pred_log_NA] <- as.character(data[ix_pred_log_NA])
+
+    # ToDo: Consider adding same treatment as for character values (above)?
 
     # Provide user feedback:
     cli::cli_alert_success("Converted {sum(ix_pred_log_NA)} logical predictor{?s} to character, due to {sum(nr_pred_log_NA)} NA case{?s}.")

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,10 +40,12 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 <!-- Devel badges end. -->
 
 
+
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color='00a9e0')](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- Release badges end. -->
+
 
 
 <!-- ALL badges start: --> 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.9.0.9012 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.9.0.9013 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -333,6 +333,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-02-25.\]
+\[File `README.Rmd` last updated on 2023-02-26.\]
 
 <!-- eof. -->


### PR DESCRIPTION
This PR primarily fixes a bug in the previous one:  Rather than converting logical predictors with `NA` values to character or factors, the `NA` values in logical predictors are now treated by `addNA()` (i.e., creating a new factor level), just as it's done when handling character and factor predictors 

(plus some cosmetic changes to user feedback).