### PR TITLE
Bug fix:  Prevent `fftrees_grow_fan()` from overlooking perfect/ideal FFTs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
 Version: 1.9.0.9013
-Date: 2023-02-26
+Date: 2023-02-27
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.9
 
-## 1.9.0.9012
+## 1.9.0.9013
 
 This is the current development version of **FFTrees**, available at <https://github.com/ndphillips/FFTrees>.
 
@@ -18,7 +18,9 @@ Changes since last release:
 - Added utility functions (and corresponding verification functions):
     - `get_best_tree()` retrieves the ID of the best tree in an `FFTrees` object (given `goal`)
     - `get_exit_type()` converts a vector of exit descriptions into FFT exits (given `exit_types`)
-    - `get_fft_df()` retrieves the tree definitions of an `FFTrees` object
+    - `get_fft_df()` retrieves the tree definitions of an `FFTrees` object  
+    
+- Fixed a bug in `fftrees_grow_fan()` that prevented `ifan` algorithm from stopping when finding a perfect FFT (given current `goal.chase` parameter).  
 
 
 <!-- Minor: --> 
@@ -449,6 +451,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2023-02-25.]
+[File `NEWS.md` last updated on 2023-02-27.]
 
 <!-- eof. -->

--- a/R/FFTrees.R
+++ b/R/FFTrees.R
@@ -48,19 +48,21 @@
 #' @param max.levels integer. The maximum number of nodes (or levels) considered for an FFT.
 #' As all combinations of possible exit structures are considered, larger values of \code{max.levels} will create larger sets of FFTs.
 #' @param numthresh.method character. How should thresholds for numeric cues be determined?
-#' \code{"o"} will optimize thresholds, while \code{"m"} will always use the median.
-#' @param numthresh.n integer. The number of numeric thresholds to try.
-#' @param repeat.cues logical. May cues occur multiple times within a tree?
+#' \code{"o"} will optimize thresholds (for \code{goal.threshold}), while \code{"m"} will always use the median.
+#' Default: \code{numthresh.method = "o"}.
+#' @param numthresh.n The number of numeric thresholds to try (as integer).
+#' Default: \code{numthresh.n = 10}.
+#' @param repeat.cues May cues occur multiple times within a tree (as logical)?
 #' Default: \code{repeat.cues = TRUE}.
-#' A value of \code{0} rounds all possible thresholds to the nearest integer, \code{1} rounds to the nearest decade (.10), etc.
+#' @param stopping.rule A character string indicating the method to stop growing trees. Available options are:
+#' \code{"levels"} means the tree grows until a certain level;
+#' \code{"exemplars"} means the tree grows until a certain number of unclassified exemplars remain;
+#' \code{"statdelta"} (currently not available) means the tree grows until the change in the criterion statistic is less than a specified level.
+#' Default: \code{stopping.rule = "exemplars"}.
 #' @param stopping.par numeric. A numeric value indicating the parameter for the stopping rule.
 #' For stopping.rule \code{"levels"}, this is the number of levels.
 #' For stopping rule \code{"exemplars"}, this is the smallest percentage of exemplars allowed in the last level.
 #' Default: \code{stopping.par = .10}.
-#' @param stopping.rule character. A character string indicating the method to stop growing trees. Available options are:
-#' \code{"levels"} means the tree grows until a certain level;
-#' \code{"exemplars"} means the tree grows until a certain number of unclassified exemplars remain;
-#' \code{"statdelta"} means the tree grows until the change in the criterion statistic is less than a specified level.
 #'
 #' @param sens.w A numeric value from \code{0} to \code{1} indicating how to weight
 #' sensitivity relative to specificity when optimizing \emph{weighted} accuracy (e.g., \code{goal = 'wacc'}).
@@ -75,7 +77,9 @@
 #' Cues in \code{data} that are not present in \code{cost.cues} are assumed to have no costs (i.e., a cost value of \code{0}).
 #'
 #' @param main string. An optional label for the dataset. Passed on to other functions, like \code{\link{plot.FFTrees}}, and \code{\link{print.FFTrees}}.
-#' @param decision.labels string. A vector of strings of length 2 indicating labels for negative and positive cases. E.g.; \code{decision.labels = c("Healthy", "Diseased")}.
+#' @param decision.labels A vector of strings of length 2 for the text labels for negative and positive decision/prediction outcomes
+#' (i.e., left vs. right, noise vs. signal, 0 vs. 1, respectively, as character).
+#' E.g.; \code{decision.labels = c("Healthy", "Diseased")}.
 #'
 #' @param my.goal The name of an optimization measure defined by \code{my.goal.fun} (as a character string).
 #' Example: \code{my.goal = "my_acc"} (see \code{my.goal.fun} for corresponding function).
@@ -189,8 +193,8 @@ FFTrees <- function(formula = NULL,
                     numthresh.method = "o",
                     numthresh.n = 10,
                     repeat.cues = TRUE,
-                    stopping.par = .10,
                     stopping.rule = "exemplars",
+                    stopping.par = .10,
                     #
                     sens.w = .50,
                     #

--- a/R/FFTrees.R
+++ b/R/FFTrees.R
@@ -60,7 +60,7 @@
 #' \code{"statdelta"} (currently not available) means the tree grows until the change in the criterion statistic is less than a specified level.
 #' Default: \code{stopping.rule = "exemplars"}.
 #' @param stopping.par numeric. A numeric value indicating the parameter for the stopping rule.
-#' For stopping.rule \code{"levels"}, this is the number of levels.
+#' For stopping.rule \code{"levels"}, this is the number of levels (as an integer).
 #' For stopping rule \code{"exemplars"}, this is the smallest percentage of exemplars allowed in the last level.
 #' Default: \code{stopping.par = .10}.
 #'

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -138,9 +138,8 @@ fftrees_create <- function(formula = NULL,
 
   # algorithm: ----
 
-  # algorithm_options <- c("ifan", "dfan")  # as (local) constant
   testthat::expect_true(!is.null(algorithm), info = "algorithm is NULL")
-  testthat::expect_true(algorithm %in% algorithm_options)
+  testthat::expect_true(algorithm %in% algorithm_options)  # use global constant
 
 
   # sens.w: ----
@@ -156,7 +155,7 @@ fftrees_create <- function(formula = NULL,
   if (!is.null(my.goal)){
     valid_goal <- c(goal_options, my.goal)  # add my.goal (name) to default
   } else { # default:
-    valid_goal <- goal_options  # use (global constant)
+    valid_goal <- goal_options  # use global constant
   }
 
   if (is.null(goal)) { # goal NOT set by user:
@@ -579,16 +578,21 @@ fftrees_create <- function(formula = NULL,
 
   # stopping.rule: ----
 
-  stopping_rule_valid <- c("exemplars", "levels")
-
-  testthat::expect_true(stopping.rule %in% stopping_rule_valid)
+  testthat::expect_true(stopping.rule %in% stopping_rules)  # use global constant
 
 
   # stopping.par: ----
 
+  if (stopping.rule == "levels"){
+
+    testthat::expect_true(is.integer(stopping.par))
+
+  } else { # 0 < stopping.par < 1:
+
   testthat::expect_gt(stopping.par, expected = 0)
   testthat::expect_lt(stopping.par, expected = 1)
 
+  }
 
   # decision.labels: ----
 

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -583,9 +583,12 @@ fftrees_create <- function(formula = NULL,
 
   # stopping.par: ----
 
-  if (stopping.rule == "levels"){
+  if (stopping.rule == "levels"){ # stopping.par must be positive integer:
+
+    stopping.par <- as.integer(stopping.par)  # aim to coerce to integer
 
     testthat::expect_true(is.integer(stopping.par))
+    testthat::expect_gt(stopping.par, expected = 0)
 
   } else { # 0 < stopping.par < 1:
 
@@ -593,6 +596,7 @@ fftrees_create <- function(formula = NULL,
   testthat::expect_lt(stopping.par, expected = 1)
 
   }
+
 
   # decision.labels: ----
 

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -868,7 +868,11 @@ fftrees_grow_fan <- function(x,
 
   return(x)
 
-
 } # fftrees_grow_fan().
+
+
+# ToDo: ------
+
+# - implement stopping.rule = "statdelta"
 
 # eof.

--- a/R/util_const.R
+++ b/R/util_const.R
@@ -105,87 +105,93 @@ negations_v <- c("not", "is not")  # (global constant)
 exit_types <- c(0, 1, 0.5)  # (global constant)
 
 
-# quiet.ini: ----
 
-# Boolean: Should user feedback for initialization (of a command or process) be shown (i.e., NOT hidden/quiet)?
+# User feedback: ------
+#
+# Now regulated by quiet = list(ini, fin, set).
+#
+# # - quiet.ini: ----
+#
+# # Boolean: Should user feedback for initialization (of a command or process) be shown (i.e., NOT hidden/quiet)?
+#
+# quiet.ini <- TRUE # FALSE # default: TRUE
+#
+#
+# # - quiet.fin: ----
+#
+# # Boolean: Should user feedback for finalization/success (of a command or process) be shown (i.e., NOT hidden/quiet)?
+#
+# quiet.fin <- FALSE # TRUE # default: FALSE
+#
+#
+# # - quiet.set: ----
+#
+# # Boolean: Should user feedback for parameter settings be shown (i.e., NOT hidden/quiet)?
+#
+# quiet.set <- FALSE # TRUE # FALSE # default: FALSE
+#
+#
+# # - feed_types: ----
+#
+# feed_types <- 0L:3L  # options: 4 levels
+#
+#
+# # - ufeed: ----
+#
+# # #' @param ufeed User feedback level (as an integer from \code{0} to \code{3},
+# # #' with higher values implying more detailed user feedback).
+# # #' Setting \code{ufeed = 0} provides no user feedback.
+# # #' Default: \code{ufeed = 2} (show parameter settings and success alerts).
+#
+#
+# ufeed <- 3L  # user feedback level (from feed_types 0:3)
+#
+#
+# if (ufeed %in% feed_types == FALSE){
+#
+#   msg <- paste0("The value of 'ufeed' must be in: ", paste(feed_types, collapse = ", "))
+#
+#   stop(msg)
+#
+# }
+#
+#
+# # Define custom ufeed categories (from 0 to 3):
+#
+# if (ufeed == 0){ # most basic/elementary/sparse:
+#
+#   # quiet <- TRUE  # hide progress
+#
+#   quiet.ini <- TRUE  # hide initials
+#   quiet.set <- TRUE  # hide settings
+#   quiet.fin <- TRUE  # hide success
+#
+# } else if (ufeed == 1){ # show success/warnings:
+#
+#   # quiet <- FALSE  # show progress
+#
+#   quiet.ini <- TRUE   # hide initials
+#   quiet.set <- TRUE   # hide settings
+#   quiet.fin <- FALSE  # show success
+#
+# } else if (ufeed == 2){ # add settings:
+#
+#   # quiet <- FALSE  # show progress
+#
+#   quiet.ini <- TRUE   # hide initials
+#   quiet.set <- FALSE  # show settings
+#   quiet.fin <- FALSE  # show success
+#
+# } else if (ufeed == 3){ # most detailed/explicit:
+#
+#   # quiet <- FALSE  # show progress
+#
+#   quiet.ini <- FALSE  # show initials
+#   quiet.set <- FALSE  # show settings
+#   quiet.fin <- FALSE  # show success
+#
+# }
 
-quiet.ini <- TRUE # FALSE # default: TRUE
-
-
-# quiet.fin: ----
-
-# Boolean: Should user feedback for finalization/success (of a command or process) be shown (i.e., NOT hidden/quiet)?
-
-quiet.fin <- FALSE # TRUE # default: FALSE
-
-
-# quiet.set: ----
-
-# Boolean: Should user feedback for parameter settings be shown (i.e., NOT hidden/quiet)?
-
-quiet.set <- FALSE # TRUE # FALSE # default: FALSE
-
-
-# feed_types: ----
-
-feed_types <- 0L:3L  # options: 4 levels
-
-
-# ufeed: ----
-
-# #' @param ufeed User feedback level (as an integer from \code{0} to \code{3},
-# #' with higher values implying more detailed user feedback).
-# #' Setting \code{ufeed = 0} provides no user feedback.
-# #' Default: \code{ufeed = 2} (show parameter settings and success alerts).
-
-
-ufeed <- 3L  # user feedback level (from feed_types 0:3)
-
-
-if (ufeed %in% feed_types == FALSE){
-
-  msg <- paste0("The value of 'ufeed' must be in: ", paste(feed_types, collapse = ", "))
-
-  stop(msg)
-
-}
-
-
-# Define custom ufeed categories (from 0 to 3):
-
-if (ufeed == 0){ # most basic/elementary/sparse:
-
-  # quiet <- TRUE  # hide progress
-
-  quiet.ini <- TRUE  # hide initials
-  quiet.set <- TRUE  # hide settings
-  quiet.fin <- TRUE  # hide success
-
-} else if (ufeed == 1){ # show success/warnings:
-
-  # quiet <- FALSE  # show progress
-
-  quiet.ini <- TRUE   # hide initials
-  quiet.set <- TRUE   # hide settings
-  quiet.fin <- FALSE  # show success
-
-} else if (ufeed == 2){ # add settings:
-
-  # quiet <- FALSE  # show progress
-
-  quiet.ini <- TRUE   # hide initials
-  quiet.set <- FALSE  # show settings
-  quiet.fin <- FALSE  # show success
-
-} else if (ufeed == 3){ # most detailed/explicit:
-
-  # quiet <- FALSE  # show progress
-
-  quiet.ini <- FALSE  # show initials
-  quiet.set <- FALSE  # show settings
-  quiet.fin <- FALSE  # show success
-
-}
 
 
 # ToDo: ------

--- a/R/util_const.R
+++ b/R/util_const.R
@@ -106,6 +106,17 @@ exit_types <- c(0, 1, 0.5)  # (global constant)
 
 
 
+# - stopping_rules: ----
+
+# Stopping rules for (as character string):
+# - "exemplars"  #
+# - "levels"     # ToDo: implement by allowing stopping.par > 1
+# - "statdelta"  # ToDo: implement with stopping.par for goal.chase
+
+stopping_rules <- c("exemplars", "levels")  # (global constant)
+
+
+
 # User feedback: ------
 #
 # Now regulated by quiet = list(ini, fin, set).

--- a/R/util_data.R
+++ b/R/util_data.R
@@ -198,7 +198,7 @@ handle_NA <- function(data, criterion_name){
   }
 
 
-  print(tibble::as_tibble(data))  # 4debugging
+  # print(tibble::as_tibble(data))  # 4debugging
 
 
   # Output: ------

--- a/man/FFTrees.Rd
+++ b/man/FFTrees.Rd
@@ -18,8 +18,8 @@ FFTrees(
   numthresh.method = "o",
   numthresh.n = 10,
   repeat.cues = TRUE,
-  stopping.par = 0.1,
   stopping.rule = "exemplars",
+  stopping.par = 0.1,
   sens.w = 0.5,
   cost.outcomes = NULL,
   cost.cues = NULL,
@@ -75,23 +75,25 @@ All default goals are set in \code{\link{fftrees_create}}.}
 As all combinations of possible exit structures are considered, larger values of \code{max.levels} will create larger sets of FFTs.}
 
 \item{numthresh.method}{character. How should thresholds for numeric cues be determined?
-\code{"o"} will optimize thresholds, while \code{"m"} will always use the median.}
+\code{"o"} will optimize thresholds (for \code{goal.threshold}), while \code{"m"} will always use the median.
+Default: \code{numthresh.method = "o"}.}
 
-\item{numthresh.n}{integer. The number of numeric thresholds to try.}
+\item{numthresh.n}{The number of numeric thresholds to try (as integer).
+Default: \code{numthresh.n = 10}.}
 
-\item{repeat.cues}{logical. May cues occur multiple times within a tree?
-Default: \code{repeat.cues = TRUE}.
-A value of \code{0} rounds all possible thresholds to the nearest integer, \code{1} rounds to the nearest decade (.10), etc.}
+\item{repeat.cues}{May cues occur multiple times within a tree (as logical)?
+Default: \code{repeat.cues = TRUE}.}
 
-\item{stopping.par}{numeric. A numeric value indicating the parameter for the stopping rule.
-For stopping.rule \code{"levels"}, this is the number of levels.
-For stopping rule \code{"exemplars"}, this is the smallest percentage of exemplars allowed in the last level.
-Default: \code{stopping.par = .10}.}
-
-\item{stopping.rule}{character. A character string indicating the method to stop growing trees. Available options are:
+\item{stopping.rule}{A character string indicating the method to stop growing trees. Available options are:
 \code{"levels"} means the tree grows until a certain level;
 \code{"exemplars"} means the tree grows until a certain number of unclassified exemplars remain;
-\code{"statdelta"} means the tree grows until the change in the criterion statistic is less than a specified level.}
+\code{"statdelta"} (currently not available) means the tree grows until the change in the criterion statistic is less than a specified level.
+Default: \code{stopping.rule = "exemplars"}.}
+
+\item{stopping.par}{numeric. A numeric value indicating the parameter for the stopping rule.
+For stopping.rule \code{"levels"}, this is the number of levels (as an integer).
+For stopping rule \code{"exemplars"}, this is the smallest percentage of exemplars allowed in the last level.
+Default: \code{stopping.par = .10}.}
 
 \item{sens.w}{A numeric value from \code{0} to \code{1} indicating how to weight
 sensitivity relative to specificity when optimizing \emph{weighted} accuracy (e.g., \code{goal = 'wacc'}).
@@ -108,7 +110,9 @@ Cues in \code{data} that are not present in \code{cost.cues} are assumed to have
 
 \item{main}{string. An optional label for the dataset. Passed on to other functions, like \code{\link{plot.FFTrees}}, and \code{\link{print.FFTrees}}.}
 
-\item{decision.labels}{string. A vector of strings of length 2 indicating labels for negative and positive cases. E.g.; \code{decision.labels = c("Healthy", "Diseased")}.}
+\item{decision.labels}{A vector of strings of length 2 for the text labels for negative and positive decision/prediction outcomes
+(i.e., left vs. right, noise vs. signal, 0 vs. 1, respectively, as character).
+E.g.; \code{decision.labels = c("Healthy", "Diseased")}.}
 
 \item{my.goal}{The name of an optimization measure defined by \code{my.goal.fun} (as a character string).
 Example: \code{my.goal = "my_acc"} (see \code{my.goal.fun} for corresponding function).


### PR DESCRIPTION
This PR mostly fixes a bug in `fftrees_grow_fan()` that prevented the `ifan` algorithm from **stopping** when finding a **perfect**/**ideal** FFT (given the current `goal.chase` parameter). 

- Essentially, `grow_tree == FALSE` was set, but not being used before evaluating current stopping rule (e.g., computing `n_case_remaining` for `stopping.rule = "exemplars"`).

- In practice, this led to growing multi-node FFTs even though a subset was already perfect (given the current `goal.chase` parameter).

Also adding some user feedback, updating documentation, an noting that `stopping.rule = "statdelta"` is currently not implemented).