### PR TITLE
Dealing with NA values in numeric predictors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.9.0.9014
-Date: 2023-02-28
+Version: 1.9.0.9015
+Date: 2023-03-03
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -265,7 +265,7 @@ fftrees_cuerank <- function(x = NULL,
             rem_criterion_v <- criterion_v[ix_NA_cue]
             rem_criterion_s <- paste0(rem_criterion_v, collapse = ", ")
 
-            cli::cli_alert_warning("Found {sum_NA_cue} NA value{?s} in cue {cue_i} '{cue_i_name}': Dropping from criterion '{x$criterion_name} = c({rem_criterion_s})'.")
+            cli::cli_alert_warning("Found {sum_NA_cue} NA value{?s} in {cue_i_name}: Dropping {x$criterion_name} = c({rem_criterion_s}) from cue validation.")
 
           }
 
@@ -281,7 +281,7 @@ fftrees_cuerank <- function(x = NULL,
             rem_cue_i_v <- cue_i_v[ix_NA_crit]
             rem_cue_i_s <- paste0(rem_cue_i_v, collapse = ", ")
 
-            cli::cli_alert_warning("Found {sum_NA_crit} NA value{?s} in criterion '{x$criterion_name}': Dropping from cue {cue_i}: '{cue_i_name} = c({rem_cue_i_s})'.")
+            cli::cli_alert_warning("Found {sum_NA_crit} NA value{?s} in {x$criterion_name}: Dropping {cue_i_name} = c({rem_cue_i_s}) from cue validation.")
 
           }
 

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -290,14 +290,15 @@ fftrees_cuerank <- function(x = NULL,
 
         # Main: ----
 
-        # Filter rows: Remove NA and infinite values (from cue_i_v AND criterion_v vectors):
+        # Filter rows:
+        # A: Remove NA and infinite values (from cue_i_v AND criterion_v vectors):
         # both_finite <- is.finite(cue_i_v) & is.finite(criterion_v)
 
         # cue_i_v      <- cue_i_v[both_finite]
         # criterion_v  <- criterion_v[both_finite]
 
-        # only filter NAs:
-        both_not_NA  <- !is.na(cue_i_v) & !is.na(criterion_v)
+        # B. Only filter NA cases (from either vector):
+        both_not_NA  <- !ix_NA_cue & !ix_NA_crit
 
         cue_i_v      <- cue_i_v[both_not_NA]
         criterion_v  <- criterion_v[both_not_NA]

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -291,10 +291,16 @@ fftrees_cuerank <- function(x = NULL,
         # Main: ----
 
         # Filter rows: Remove NA and infinite values (from cue_i_v AND criterion_v vectors):
-        both_finite <- is.finite(cue_i_v) & is.finite(criterion_v)
+        # both_finite <- is.finite(cue_i_v) & is.finite(criterion_v)
 
-        cue_i_v      <- cue_i_v[both_finite]
-        criterion_v  <- criterion_v[both_finite]
+        # cue_i_v      <- cue_i_v[both_finite]
+        # criterion_v  <- criterion_v[both_finite]
+
+        # only filter NAs:
+        both_not_NA  <- !is.na(cue_i_v) & !is.na(criterion_v)
+
+        cue_i_v      <- cue_i_v[both_not_NA]
+        criterion_v  <- criterion_v[both_not_NA]
 
       } # if ( allow_NA_pred | allow_NA_crit ).
 

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -288,16 +288,16 @@ fftrees_cuerank <- function(x = NULL,
         } # if (!x$params$quiet$mis).
 
 
-        # Main: ----
+        # Main: Filter vectors ----
 
-        # Filter rows:
-        # A: Remove NA and infinite values (from cue_i_v AND criterion_v vectors):
+        # # A: Remove NA and infinite values (from both):
         # both_finite <- is.finite(cue_i_v) & is.finite(criterion_v)
-
+        #
         # cue_i_v      <- cue_i_v[both_finite]
         # criterion_v  <- criterion_v[both_finite]
 
-        # B. Only filter NA cases (from either vector):
+
+        # B. Remove only NA cases (from both):
         both_not_NA  <- !ix_NA_cue & !ix_NA_crit
 
         cue_i_v      <- cue_i_v[both_not_NA]

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -217,6 +217,90 @@ fftrees_cuerank <- function(x = NULL,
       } # Step 2.
 
 
+      # Monitoring: ------
+
+      # # unequal lenghts:
+      # len_crt <- length(criterion_v)
+      # len_cue <- length(cue_i_v)
+      #
+      # if (len_crt != len_cue){
+      #   cli::cli_alert_warning("Cue {cue_i} has {len_cue} value{?s} vs. {len_crt} criterion value{?s}.")
+      # }
+
+      #       ix_NA_crt <- is.na(criterion_v)
+      #       ix_NA_cue <- is.na(cue_i_v)
+      #
+      #       nr_NA_crt <- sum(ix_NA_crt)
+      #       nr_NA_cue <- sum(ix_NA_cue)
+      #
+      #       if (nr_NA_cue > 0){
+      #        cli::cli_alert_info("Seeing {nr_NA_cue} NA value{?s} in cue {cue_i}: {cue_i_name}")
+      #       }
+      #
+      #       if (nr_NA_crt > 0){
+      #        cli::cli_alert_info("Seeing {nr_NA_crt} NA value{?s} in criterion")
+      #       }
+
+      # +++ here now +++
+
+
+      # Handle NA values: ------
+
+      if ( allow_NA_pred | allow_NA_crit ){
+
+        # Report NA values (prior to removing them): ----
+
+        quiet_mis <- FALSE  # HACK: as local constant (as object x or quiet list are not passed)
+
+
+        if (!quiet_mis) { # Provide user feedback:
+
+          # 1. NA in cue_i_v:
+          ix_NA_cue <- is.na(cue_i_v)
+
+          if (allow_NA_pred & any(ix_NA_cue)){
+
+            sum_NA_cue <- sum(ix_NA_cue)
+
+            # Which corresponding values in criterion_v will be removed?
+            rem_criterion_v <- criterion_v[ix_NA_cue]
+            rem_criterion_s <- paste0(rem_criterion_v, collapse = ", ")
+
+            cli::cli_alert_warning("Found {sum_NA_cue} NA value{?s} in cue {cue_i} {cue_i_name}: Dropping 'criterion_v = c({rem_criterion_s}).")
+
+          }
+
+          # 2. NA in criterion_v:
+          ix_NA_crit <- is.na(criterion_v)
+
+          if (allow_NA_crit & any(ix_NA_crit)){
+
+            # d_type <- typeof(criterion_v)  # logical
+            sum_NA_crit <- sum(ix_NA_crit)
+
+            # Which values in cue_i_v will be removed?
+            rem_cue_i_v <- cue_i_v[ix_NA_crit]
+            rem_cue_i_s <- paste0(rem_cue_i_v, collapse = ", ")
+
+            cli::cli_alert_warning("Found {sum_NA_crit} NA value{?s} in 'criterion_v': Dropping from cue {cue_i}: {cue_i_name} = c({rem_cue_i_s}).")
+
+          }
+
+        } # if (!quiet_mis).
+
+
+        # Main: ----
+
+        # Filter rows: Remove NA and infinite values (from cue_i_v AND criterion_v vectors):
+        both_finite <- is.finite(cue_i_v) & is.finite(criterion_v)
+
+        cue_i_v      <- cue_i_v[both_finite]
+        criterion_v  <- criterion_v[both_finite]
+
+      } # if ( allow_NA_pred | allow_NA_crit ).
+
+
+
       # Step 3: Determine best direction and threshold for cue [cue_i_best]: ----
       {
 

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -265,7 +265,7 @@ fftrees_cuerank <- function(x = NULL,
             rem_criterion_v <- criterion_v[ix_NA_cue]
             rem_criterion_s <- paste0(rem_criterion_v, collapse = ", ")
 
-            cli::cli_alert_warning("Found {sum_NA_cue} NA value{?s} in {cue_i_name}: Dropping {x$criterion_name} = c({rem_criterion_s}) from cue validation.")
+            cli::cli_alert_warning("Dropping {sum_NA_cue} NA value{?s} in {cue_i_name} and {x$criterion_name} = c({rem_criterion_s}).")
 
           }
 
@@ -281,7 +281,7 @@ fftrees_cuerank <- function(x = NULL,
             rem_cue_i_v <- cue_i_v[ix_NA_crit]
             rem_cue_i_s <- paste0(rem_cue_i_v, collapse = ", ")
 
-            cli::cli_alert_warning("Found {sum_NA_crit} NA value{?s} in {x$criterion_name}: Dropping {cue_i_name} = c({rem_cue_i_s}) from cue validation.")
+            cli::cli_alert_warning("Dropping {sum_NA_crit} NA value{?s} in {x$criterion_name} and {cue_i_name} = c({rem_cue_i_s}).")
 
           }
 

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -250,10 +250,9 @@ fftrees_cuerank <- function(x = NULL,
 
         # Report NA values (prior to removing them): ----
 
-        quiet_mis <- FALSE  # HACK: as local constant (as object x or quiet list are not passed)
+        # quiet_mis <- FALSE  # HACK: as local constant (as object x or quiet list are not passed)
 
-
-        if (!quiet_mis) { # Provide user feedback:
+        if (!x$params$quiet$mis) { # Provide user feedback:
 
           # 1. NA in cue_i_v:
           ix_NA_cue <- is.na(cue_i_v)
@@ -266,7 +265,7 @@ fftrees_cuerank <- function(x = NULL,
             rem_criterion_v <- criterion_v[ix_NA_cue]
             rem_criterion_s <- paste0(rem_criterion_v, collapse = ", ")
 
-            cli::cli_alert_warning("Found {sum_NA_cue} NA value{?s} in cue {cue_i} {cue_i_name}: Dropping 'criterion_v = c({rem_criterion_s}).")
+            cli::cli_alert_warning("Found {sum_NA_cue} NA value{?s} in cue {cue_i} '{cue_i_name}': Dropping from criterion '{x$criterion_name} = c({rem_criterion_s})'.")
 
           }
 
@@ -282,11 +281,11 @@ fftrees_cuerank <- function(x = NULL,
             rem_cue_i_v <- cue_i_v[ix_NA_crit]
             rem_cue_i_s <- paste0(rem_cue_i_v, collapse = ", ")
 
-            cli::cli_alert_warning("Found {sum_NA_crit} NA value{?s} in 'criterion_v': Dropping from cue {cue_i}: {cue_i_name} = c({rem_cue_i_s}).")
+            cli::cli_alert_warning("Found {sum_NA_crit} NA value{?s} in criterion '{x$criterion_name}': Dropping from cue {cue_i}: '{cue_i_name} = c({rem_cue_i_s})'.")
 
           }
 
-        } # if (!quiet_mis).
+        } # if (!x$params$quiet$mis).
 
 
         # Main: ----

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -217,30 +217,6 @@ fftrees_cuerank <- function(x = NULL,
       } # Step 2.
 
 
-      # Monitoring: ------
-
-      # # unequal lenghts:
-      # len_crt <- length(criterion_v)
-      # len_cue <- length(cue_i_v)
-      #
-      # if (len_crt != len_cue){
-      #   cli::cli_alert_warning("Cue {cue_i} has {len_cue} value{?s} vs. {len_crt} criterion value{?s}.")
-      # }
-
-      #       ix_NA_crt <- is.na(criterion_v)
-      #       ix_NA_cue <- is.na(cue_i_v)
-      #
-      #       nr_NA_crt <- sum(ix_NA_crt)
-      #       nr_NA_cue <- sum(ix_NA_cue)
-      #
-      #       if (nr_NA_cue > 0){
-      #        cli::cli_alert_info("Seeing {nr_NA_cue} NA value{?s} in cue {cue_i}: {cue_i_name}")
-      #       }
-      #
-      #       if (nr_NA_crt > 0){
-      #        cli::cli_alert_info("Seeing {nr_NA_crt} NA value{?s} in criterion")
-      #       }
-
       # +++ here now +++
 
 
@@ -248,15 +224,17 @@ fftrees_cuerank <- function(x = NULL,
 
       if ( allow_NA_pred | allow_NA_crit ){
 
-        # Report NA values (prior to removing them): ----
+        # Detect NA values: ----
 
-        # quiet_mis <- FALSE  # HACK: as local constant (as object x or quiet list are not passed)
+        ix_NA_cue  <- is.na(cue_i_v)      # 1. NA in cue_i_v
+        ix_NA_crit <- is.na(criterion_v)  # 2. NA in criterion_v
+
+
+        # Report NA values (prior to removing them): ----
 
         if (!x$params$quiet$mis) { # Provide user feedback:
 
-          # 1. NA in cue_i_v:
-          ix_NA_cue <- is.na(cue_i_v)
-
+          # 1. Report NA in cue_i_v:
           if (allow_NA_pred & any(ix_NA_cue)){
 
             sum_NA_cue <- sum(ix_NA_cue)
@@ -265,13 +243,11 @@ fftrees_cuerank <- function(x = NULL,
             rem_criterion_v <- criterion_v[ix_NA_cue]
             rem_criterion_s <- paste0(rem_criterion_v, collapse = ", ")
 
-            cli::cli_alert_warning("Dropping {sum_NA_cue} NA value{?s} in {cue_i_name} and {x$criterion_name} = c({rem_criterion_s}).")
+            cli::cli_alert_warning("Dropping {sum_NA_cue} NA value{?s} from {cue_i_name} and {x$criterion_name} = c({rem_criterion_s}).")
 
           }
 
-          # 2. NA in criterion_v:
-          ix_NA_crit <- is.na(criterion_v)
-
+          # 2. Report NA in criterion_v:
           if (allow_NA_crit & any(ix_NA_crit)){
 
             # d_type <- typeof(criterion_v)  # logical
@@ -281,7 +257,7 @@ fftrees_cuerank <- function(x = NULL,
             rem_cue_i_v <- cue_i_v[ix_NA_crit]
             rem_cue_i_s <- paste0(rem_cue_i_v, collapse = ", ")
 
-            cli::cli_alert_warning("Dropping {sum_NA_crit} NA value{?s} in {x$criterion_name} and {cue_i_name} = c({rem_cue_i_s}).")
+            cli::cli_alert_warning("Dropping {sum_NA_crit} NA value{?s} from {x$criterion_name} and {cue_i_name} = c({rem_cue_i_s}).")
 
           }
 
@@ -303,7 +279,8 @@ fftrees_cuerank <- function(x = NULL,
         cue_i_v      <- cue_i_v[both_not_NA]
         criterion_v  <- criterion_v[both_not_NA]
 
-      } # if ( allow_NA_pred | allow_NA_crit ).
+
+      } # Handle NA: if ( allow_NA_pred | allow_NA_crit ).
 
 
 

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -49,7 +49,7 @@ fftrees_grow_fan <- function(x,
   cases_n <- nrow(x$data$train)
   cue_df  <- x$data$train[, names(x$data$train) != criterion_name]
 
-  my_goal     <- x$params$my.goal          # (only ONCE)
+  my_goal     <- x$params$my.goal      # (only ONCE)
   my_goal_fun <- x$params$my.goal.fun  # (only ONCE)
 
 

--- a/R/fftrees_threshold_factor_grid.R
+++ b/R/fftrees_threshold_factor_grid.R
@@ -57,7 +57,9 @@ fftrees_threshold_factor_grid <- function(thresholds = NULL,
 
   }
 
-  testthat::expect_true(!any(is.na(cue_v)))  # Any NA values have been turned into <NA> level (if allow_NA_pred)
+  # No NA values (any more):
+  testthat::expect_true(!any(is.na(cue_v)), info = "Cannot compute thresholds for cues with NA values")
+  # Note: Any NA values in categorical variables have been turned into an <NA> level (if allow_NA_pred).
 
 
   # Main: ------

--- a/R/fftrees_threshold_numeric_grid.R
+++ b/R/fftrees_threshold_numeric_grid.R
@@ -60,8 +60,30 @@ fftrees_threshold_numeric_grid <- function(thresholds,
 
     threshold_i <- thresholds[i]
 
-    # Create vector of decisions:
+    # Create a logical vector of decisions:
     decisions_i <- cue_v > threshold_i
+
+
+   # ix_NA_decisions <- is.na(decisions_i)
+   # ix_NA_criterion <- is.na(criterion_v)
+   #
+   # nr_NA_decisions <- sum(ix_NA_decisions)
+   # nr_NA_criterion <- sum(ix_NA_criterion)
+
+   # len_crt <- length(criterion_v)
+   # len_dec <- length(decisions_i)
+   #
+   # if (len_crt != len_dec){
+   #   cli::cli_alert_warning("Seeing {len_dec} decision{?s} vs. {len_crt} criterion value{?s}.")
+   # }
+
+   # if (nr_NA_decisions > 0){
+   #  cli::cli_alert_info("Seeing {nr_NA_decisions} NA value{?s} in decisions")
+   # }
+   #
+   # if (nr_NA_criterion > 0){
+   #  cli::cli_alert_info("Seeing {nr_NA_criterion} NA value{?s} in criterion")
+   # }
 
     # Calculate frequency of decision outcomes:
     hi_i <- sum((decisions_i == TRUE)  & (criterion_v == TRUE),  na.rm = TRUE)

--- a/R/fftrees_threshold_numeric_grid.R
+++ b/R/fftrees_threshold_numeric_grid.R
@@ -44,12 +44,14 @@ fftrees_threshold_numeric_grid <- function(thresholds,
                                            cost.outcomes = NULL # (was "list(hi = 0, fa = 1, mi = 1, cr = 0)", but NULL enforces consistency w calling function)
 ) {
 
+  # Remove NA values in thresholds and cue_v:
   thresholds <- thresholds[!is.na(thresholds)]
-  cue_v <- cue_v[!is.na(cue_v)]
+  cue_v      <- cue_v[!is.na(cue_v)]
 
   thresholds_n <- length(thresholds)
 
   results_gt <- matrix(NA, nrow = thresholds_n, ncol = 5)
+
 
   # Loop over all thresholds: ------
   # C++

--- a/R/util_color.R
+++ b/R/util_color.R
@@ -26,6 +26,7 @@
 
 # Define cli styles: ----
 
+
 # ANSI color styles:
 
 in_grey      <- cli::make_ansi_style("grey50", grey = TRUE, colors = 256)
@@ -39,6 +40,7 @@ in_blue  <- cli::make_ansi_style("dodgerblue4", colors = 256)  # "steelblue4" "d
 in_dpnk <- cli::make_ansi_style("deeppink",    colors = 256)
 in_dsbl <- cli::make_ansi_style("deepskyblue", colors = 256)
 
+
 # User feedback messages:
 
 u_f_ini <- cli::make_ansi_style("grey33", grey = TRUE, colors = 256)  # "black"
@@ -46,24 +48,6 @@ u_f_fin <- cli::make_ansi_style("darkgreen",           colors = 256)  # "black"
 
 u_f_msg <- cli::make_ansi_style("grey50", grey = TRUE, colors = 256)  # normal message
 u_f_hig <- cli::make_ansi_style("dodgerblue4",         colors = 256)  # highlighted msg
-
-
-# Define cli themes: ----
-
-# # Color of headings, that are only active in paragraphs with an 'output' class:
-#
-#   list(
-#     "par.output h1" = list("background-color" = "red", color = "#e0e0e0"),
-#     "par.output h2" = list("background-color" = "orange", color = "#e0e0e0"),
-#     "par.output h3" = list("background-color" = "blue", color = "#e0e0e0")
-#   )
-#
-# # Create custom alert types:
-#
-#   list(
-#     ".alert-start" = list(before = symbol$play),
-#     ".alert-stop"  = list(before = symbol$stop)
-#   )
 
 
 # ToDo: ------

--- a/R/util_const.R
+++ b/R/util_const.R
@@ -13,11 +13,13 @@
 algorithm_options <- c("ifan", "dfan")  # (global constant)
 
 
+
 # - allow_NA_pred: ----
 
 # Allow NA cases in predictors (as logical)?
 
-allow_NA_pred <- TRUE  # (global constant)
+allow_NA_pred <- TRUE # FALSE  # (global constant)
+
 
 
 # - allow_NA_crit: ----
@@ -56,7 +58,12 @@ cost_cues_default <- 0  # (global constant)
 
 # - cue_classes: ----
 
-cue_classes <- c( #  (global constant)
+# FFTrees only distinguishes/uses 2 types of cues / predictors:
+# - character (converted from factor / logical)
+# - numerical (integer / double )
+# See clean_data() and handle_NA_data() in util_data.R for conversions.
+
+cue_classes <- c(            #  (global constant)
   "c",  # categorical: character, factor, logical
   "n")  # numeric: integer, double
 
@@ -133,7 +140,8 @@ stopping_rules <- c("exemplars", "levels")  # (global constant)
 
 # User feedback: ------
 #
-# Now regulated by quiet = list(ini, fin, set).
+# Now obsolete, as handled by FFTrees() argument:
+# quiet = list(ini = TRUE, fin = FALSE, mis = FALSE, set = TRUE)
 #
 # # - quiet.ini: ----
 #

--- a/R/util_stats.R
+++ b/R/util_stats.R
@@ -276,56 +276,41 @@ classtable <- function(prediction_v = NULL,
 
   if ( allow_NA_pred | allow_NA_crit ){
 
+    # Detect NA values: ----
+
+    ix_NA_pred <- is.na(prediction_v)  # 1. NA in prediction_v
+    ix_NA_crit <- is.na(criterion_v)   # 2. NA in criterion_v
+
+
     # Report NA values (prior to removing them): ----
 
     quiet_mis <- FALSE  # HACK: as local constant (as object x or quiet list are not passed)
 
-
     if (!quiet_mis) { # Provide user feedback:
 
-      # 1. NA in prediction_v:
-      ix_NA_pred <- is.na(prediction_v)
-
+      # 1. Report NA in prediction_v:
       if (allow_NA_pred & any(ix_NA_pred)){
 
-        # d_type <- typeof(prediction_v)  # logical
-        sum_NA <- sum(ix_NA_pred)
-
-        # msg_NA_p <- paste0("A prediction_v contains ", sum_NA, " NA values that will be removed.")
-        # cat(u_f_hig(msg_NA_p, "\n"))  # highlighted and non-optional
-
-        # cli::cli_alert_info("Found {sum_NA} NA value{?s} in 'prediction_v':")
+        sum_NA_pred <- sum(ix_NA_pred)
 
         # Which corresponding values in criterion_v will be removed?
         rem_criterion_v <- criterion_v[ix_NA_pred]
         rem_criterion_s <- paste0(rem_criterion_v, collapse = ", ")
 
-        # cli::cli_alert_warning("Removing {sum_NA} value{?s} from the corresponding 'criterion_v': ({rem_criterion_v}).")
-
-        cli::cli_alert_warning("Found {sum_NA} NA value{?s} in 'prediction_v': Dropping criterion_v = c({rem_criterion_s}).")
+        cli::cli_alert_warning("Dropping {sum_NA_pred} NA value{?s} from 'prediction_v' and criterion_v = c({rem_criterion_s}).")
 
       }
 
-      # 2. NA in criterion_v:
-      ix_NA_crit <- is.na(criterion_v)
-
+      # 2. Report NA in criterion_v:
       if (allow_NA_crit & any(ix_NA_crit)){
 
-        # d_type <- typeof(criterion_v)  # logical
-        sum_NA <- sum(ix_NA_crit)
-
-        # msg_NA_c <- paste0("The criterion_v contains ", sum_NA, " NA values that will be removed.")
-        # cat(u_f_hig(msg_NA_c, "\n"))  # highlighted and non-optional
-
-        # cli::cli_alert_warning("Removing {sum_NA} NA value{?s} from 'criterion_v' (and corresponding 'prediction_v').")
+        sum_NA_crit <- sum(ix_NA_crit)
 
         # Which values in prediction_v will be removed?
         rem_prediction_v <- prediction_v[ix_NA_crit]
         rem_prediction_s <- paste0(rem_prediction_v, collapse = ", ")
 
-        # cli::cli_alert_info("The values removed from 'prediction_v' are {rem_prediction_v}.")
-
-        cli::cli_alert_warning("Found {sum_NA} NA value{?s} in 'criterion_v': Dropping prediction_v = c({rem_prediction_s}).")
+        cli::cli_alert_warning("Dropping {sum_NA_crit} NA value{?s} from 'criterion_v' and prediction_v = c({rem_prediction_s}).")
 
       }
 
@@ -348,7 +333,7 @@ classtable <- function(prediction_v = NULL,
     criterion_v  <- criterion_v[both_not_NA]
 
 
-  } # if ( allow_NA_pred | allow_NA_crit ).
+  } # Handle NA: if ( allow_NA_pred | allow_NA_crit ).
 
 
   N <- min(length(criterion_v), length(prediction_v))

--- a/R/util_stats.R
+++ b/R/util_stats.R
@@ -269,6 +269,8 @@ classtable <- function(prediction_v = NULL,
 
   # Handle NA values: ------
 
+  # ToDo: Move functionality to upper function, BEFORE calling utility function.
+
   # Note: As NA values in predictors of type character / factor / logical were handled in handle_NA(),
   #       only NA values in numeric predictors or the criterion variable appear here.
 
@@ -278,21 +280,24 @@ classtable <- function(prediction_v = NULL,
 
     quiet_mis <- FALSE  # HACK: as local constant (as object x or quiet list are not passed)
 
+
     if (!quiet_mis) { # Provide user feedback:
 
       # 1. NA in prediction_v:
-      if (allow_NA_pred & any(is.na(prediction_v))){
+      ix_NA_pred <- is.na(prediction_v)
+
+      if (allow_NA_pred & any(ix_NA_pred)){
 
         # d_type <- typeof(prediction_v)  # logical
-        sum_NA <- sum(is.na(prediction_v))
+        sum_NA <- sum(ix_NA_pred)
 
         # msg_NA_p <- paste0("A prediction_v contains ", sum_NA, " NA values that will be removed.")
         # cat(u_f_hig(msg_NA_p, "\n"))  # highlighted and non-optional
 
         # cli::cli_alert_info("Found {sum_NA} NA value{?s} in 'prediction_v':")
 
-        # Which values in criterion_v will be removed?
-        rem_criterion_v <- criterion_v[is.na(prediction_v)]
+        # Which corresponding values in criterion_v will be removed?
+        rem_criterion_v <- criterion_v[ix_NA_pred]
         rem_criterion_s <- paste0(rem_criterion_v, collapse = ", ")
 
         # cli::cli_alert_warning("Removing {sum_NA} value{?s} from the corresponding 'criterion_v': ({rem_criterion_v}).")
@@ -302,10 +307,12 @@ classtable <- function(prediction_v = NULL,
       }
 
       # 2. NA in criterion_v:
-      if (allow_NA_crit & any(is.na(criterion_v))){
+      ix_NA_crit <- is.na(criterion_v)
+
+      if (allow_NA_crit & any(ix_NA_crit)){
 
         # d_type <- typeof(criterion_v)  # logical
-        sum_NA <- sum(is.na(criterion_v))
+        sum_NA <- sum(ix_NA_crit)
 
         # msg_NA_c <- paste0("The criterion_v contains ", sum_NA, " NA values that will be removed.")
         # cat(u_f_hig(msg_NA_c, "\n"))  # highlighted and non-optional
@@ -313,7 +320,7 @@ classtable <- function(prediction_v = NULL,
         # cli::cli_alert_warning("Removing {sum_NA} NA value{?s} from 'criterion_v' (and corresponding 'prediction_v').")
 
         # Which values in prediction_v will be removed?
-        rem_prediction_v <- prediction_v[is.na(criterion_v)]
+        rem_prediction_v <- prediction_v[ix_NA_crit]
         rem_prediction_s <- paste0(rem_prediction_v, collapse = ", ")
 
         # cli::cli_alert_info("The values removed from 'prediction_v' are {rem_prediction_v}.")
@@ -325,9 +332,10 @@ classtable <- function(prediction_v = NULL,
     } # if (!quiet_mis).
 
 
-    # Filter rows: Remove NA and infinite values (from prediction AND criterion vectors): ----
+    # Main: ----
 
-    both_finite <- is.finite(criterion_v) & is.finite(prediction_v)
+    # Filter rows: Remove NA and infinite values (from prediction AND criterion vectors): ----
+    both_finite <- is.finite(prediction_v) & is.finite(criterion_v)
 
     prediction_v <- prediction_v[both_finite]
     criterion_v  <- criterion_v[both_finite]

--- a/R/util_stats.R
+++ b/R/util_stats.R
@@ -332,16 +332,16 @@ classtable <- function(prediction_v = NULL,
     } # if (!quiet_mis).
 
 
-    # Main: ----
+    # Main: Filter vectors ----
 
-    # Filter rows:
-    # # A. Remove NA and infinite values (from prediction AND criterion vectors): ----
+    # # A. Remove NA and infinite values (from both):
     # both_finite <- is.finite(prediction_v) & is.finite(criterion_v)
     #
     # prediction_v <- prediction_v[both_finite]
     # criterion_v  <- criterion_v[both_finite]
 
-    # B. Only filter NA cases (from either vector):
+
+    # B. Remove only NA cases (from both):
     both_not_NA  <- !ix_NA_pred & !ix_NA_crit
 
     prediction_v <- prediction_v[both_not_NA]

--- a/R/util_stats.R
+++ b/R/util_stats.R
@@ -302,7 +302,7 @@ classtable <- function(prediction_v = NULL,
 
         # cli::cli_alert_warning("Removing {sum_NA} value{?s} from the corresponding 'criterion_v': ({rem_criterion_v}).")
 
-        cli::cli_alert_warning("Found {sum_NA} NA value{?s} in 'prediction_v': Dropping 'criterion_v = c({rem_criterion_s}).")
+        cli::cli_alert_warning("Found {sum_NA} NA value{?s} in 'prediction_v': Dropping criterion_v = c({rem_criterion_s}).")
 
       }
 
@@ -325,7 +325,7 @@ classtable <- function(prediction_v = NULL,
 
         # cli::cli_alert_info("The values removed from 'prediction_v' are {rem_prediction_v}.")
 
-        cli::cli_alert_warning("Found {sum_NA} NA value{?s} in 'criterion_v': Dropping 'prediction_v = c({rem_prediction_s}).")
+        cli::cli_alert_warning("Found {sum_NA} NA value{?s} in 'criterion_v': Dropping prediction_v = c({rem_prediction_s}).")
 
       }
 
@@ -334,11 +334,19 @@ classtable <- function(prediction_v = NULL,
 
     # Main: ----
 
-    # Filter rows: Remove NA and infinite values (from prediction AND criterion vectors): ----
-    both_finite <- is.finite(prediction_v) & is.finite(criterion_v)
+    # Filter rows:
+    # # A. Remove NA and infinite values (from prediction AND criterion vectors): ----
+    # both_finite <- is.finite(prediction_v) & is.finite(criterion_v)
+    #
+    # prediction_v <- prediction_v[both_finite]
+    # criterion_v  <- criterion_v[both_finite]
 
-    prediction_v <- prediction_v[both_finite]
-    criterion_v  <- criterion_v[both_finite]
+    # B. Only filter NA cases (from either vector):
+    both_not_NA  <- !ix_NA_pred & !ix_NA_crit
+
+    prediction_v <- prediction_v[both_not_NA]
+    criterion_v  <- criterion_v[both_not_NA]
+
 
   } # if ( allow_NA_pred | allow_NA_crit ).
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,10 +39,12 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 [![R-CMD-check](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml)
 <!-- Devel badges end. -->
 
+
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color='00a9e0')](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- Release badges end. -->
+
 
 <!-- ALL badges start: --> 
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.9.0.9014 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.9.0.9015 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -333,6 +333,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-02-28.\]
+\[File `README.Rmd` last updated on 2023-03-03.\]
 
 <!-- eof. -->


### PR DESCRIPTION
This PR fixes some bugs (due to implicit removal of `NA` values from the initial **cue evaluation** process) and adds more detailed options and user feedback messages (to handle and monitor what exactly is happening when there are `NA` values in numeric predictors).