### PR TITLE
Handle NA cases when applying trees to data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.9.0.9015
-Date: 2023-03-03
+Version: 1.9.0.9016
+Date: 2023-03-04
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -15,7 +15,7 @@
 #'
 #' @param finNA.pred What outcome should be predicted if the \emph{final} node in a tree has a cue value of \code{NA}
 #' (as character)?
-#' Default: \code{finNA.pred = TRUE}.
+#' Default: \code{finNA.pred = "noise"}.
 #' Options to implement include:
 #' - "noise"  (predict FALSE/0/left),
 #' - "signal" (predict TRUE/1/right),
@@ -40,7 +40,7 @@ fftrees_apply <- function(x,
                           mydata = NULL,   # data type (either "train" or "test")
                           newdata = NULL,
                           #
-                          finNA.pred = "signal"  # Options available: c("noise", "signal")
+                          finNA.pred = "noise"  # Options available: c("noise", "signal")
 ) {
 
   # Prepare: ------
@@ -358,7 +358,7 @@ fftrees_apply <- function(x,
 
             sum_NA_cur <- sum(ix_na_classify_now)
 
-            cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Seeing {sum_NA_cur} NA value{?s} in intermediate cue {cue_i} and go on.")
+            cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Seeing {sum_NA_cur} NA value{?s} in intermediate cue {cue_i} and proceed.")
 
           }
 

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -15,13 +15,15 @@
 #'
 #' @param finNA.pred What outcome should be predicted if the \emph{final} node in a tree has a cue value of \code{NA}
 #' (as character)?
-#' Default: \code{finNA.pred = "noise"}.
-#' Options (yet to implement) include:
-#' - "noise"  (predict FALSE/0/left),
-#' - "signal" (predict TRUE/1/right),
-#' - "baseline" (flip a random coin that is biased by the criterion baseline/base rate),
-#' - "majority" (predict 'signal' if its baseline/base rate > 0.50, else predict 'noise'),
-#' - "dnk" (decide to 'do not know'/tertium datur).
+#' Valid options are:
+#' \describe{
+#'   \item{'noise'}{predict \code{FALSE} (0/left/signal) for all corresponding cases}
+#'   \item{'signal'}{predict \code{TRUE} (1/right/noise) for all corresponding cases}
+#'   \item{'majority'}{predict more common criterion (i.e., \code{TRUE} if base rate \code{p(TRUE) > .50} in 'train' data) for all corresponding cases}
+#'   \item{'baseline'}{flip a random coin that is biased by the criterion baseline of \code{p(TRUE)} (in 'train' data) for all corresponding cases}
+#'   \item{'dnk'}{yet ToDo: decide to 'do not know' / tertium datur}
+#'   }
+#' Default: \code{finNA.pred = "majority"}.
 #'
 #' @return A modified \code{FFTrees} object (with lists in \code{x$trees} containing information on FFT decisions and statistics).
 #'
@@ -39,7 +41,7 @@ fftrees_apply <- function(x,
                           mydata = NULL,   # data type (either "train" or "test")
                           newdata = NULL,
                           #
-                          finNA.pred = "baseline"  # Options available: c("noise", "signal", "baseline", "majority")
+                          finNA.pred = "majority"  # Options available: c("noise", "signal", "baseline", "majority")
 ) {
 
   # Prepare: ------

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -24,7 +24,7 @@
 #' Options to implement include:
 #' - "noise"  (predict FALSE/0/left),
 #' - "signal" (predict TRUE/1/right),
-#' - "majority" (predict the more common baseline case, else noise),
+#' - "majority" (predict the more common baseline case, else predict noise),
 #' - "baseline" (flip a coin using the criterion baseline),
 #' - "dnk" (decide to 'do not know'/tertium datur).
 #'
@@ -45,7 +45,8 @@ fftrees_apply <- function(x,
                           newdata = NULL,
                           #
                           allNA.pred = FALSE,   # ToDo: deprecate, as "all" in name is misleading
-                          finNA.pred = "noise") {
+                          finNA.pred = "noise"  # Options available: c("noise", "signal")
+) {
 
   # Prepare: ------
 
@@ -297,7 +298,7 @@ fftrees_apply <- function(x,
       decisions_df$current_cue_values <- cue_values
 
 
-      # threshold_i:
+      # threshold_i: ----
 
       if (is.character(threshold_i)) {
         threshold_i <- unlist(strsplit(threshold_i, ","))
@@ -308,7 +309,7 @@ fftrees_apply <- function(x,
       }
 
 
-      # current_decision:
+      # current_decision: ----
 
       if (direction_i == "!=") {
         decisions_df$current_decision <- (decisions_df$current_cue_values %in% threshold_i) == FALSE
@@ -330,7 +331,7 @@ fftrees_apply <- function(x,
       }
 
 
-      # classify_now:
+      # classify_now: ----
 
       if (isTRUE(all.equal(exit_i, exit_types[1]))) { # exit_i 0:
         classify_now <- decisions_df$current_decision == FALSE & is.na(decisions_df$decision)
@@ -379,6 +380,14 @@ fftrees_apply <- function(x,
 
           }
 
+          if (!x$params$quiet$mis) { # Provide user feedback:
+
+            sum_NA_fin <- sum(ix_na_current_decision)
+            cur_dec_n1 <- decisions_df$current_decision[ix_na_current_decision][1]  # 1st decision
+
+            cli::cli_alert_warning("Found {sum_NA_fin} NA value{?s} in final node {cue_i}: Predict {finNA.pred} (e.g., {x$criterion_name} = {cur_dec_n1}).")
+
+          }
 
         }
 

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -367,24 +367,24 @@ fftrees_apply <- function(x,
 
       if ( allow_NA_pred | allow_NA_crit ){
 
-        # 1. If this is NOT the final node, then don't classify NA cases:
+        # 1. If this is an intermediate / NOT the final node, then don't classify NA cases:
         if (exit_i %in% exit_types[1:2]) {  # exit_types in c(0, 1)
 
           ix_na_classify_now <- is.na(classify_now)
 
           classify_now[ix_na_classify_now] <- FALSE  # Do NOT classify NA cases (which is NOT "classify as FALSE")!
 
-          if (!x$params$quiet$mis) { # Provide user feedback:
+          if (!x$params$quiet$mis & any(ix_na_classify_now)) { # Provide user feedback:
 
             sum_NA_cur <- sum(ix_na_classify_now)
 
-            cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Seeing {sum_NA_cur} NA value{?s} in intermediate cue {cue_i} and proceed.")
+            cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Seeing {sum_NA_cur} NA value{?s} in intermediate cue '{cue_i}' and proceed.")
 
           }
 
         }
 
-        # 2. If this IS the final node, then classify all NA cases according to finNA.pred:
+        # 2. If this IS the final / terminal node, then classify all NA cases according to finNA.pred:
         if (exit_i %in% exit_types[3]) {  # exit_types = .5:
 
           ix_na_current_decision <- is.na(decisions_df$current_decision)
@@ -408,9 +408,9 @@ fftrees_apply <- function(x,
 
             decisions_df$current_decision[ix_na_current_decision] <- cur_decisions
 
-            if (!x$params$quiet$mis) { # Provide user feedback:
+            if (!x$params$quiet$mis & any(ix_na_current_decision)) { # Provide user feedback:
 
-              cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Made {nr_NA} baseline prediction{?s} (with a 'train' base rate p(TRUE) = {crit_br}): {cur_decisions}.")
+              cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Making {nr_NA} baseline prediction{?s} (with a 'train' base rate p(TRUE) = {crit_br}): {cur_decisions}.")
 
             }
 
@@ -426,9 +426,9 @@ fftrees_apply <- function(x,
 
             decisions_df$current_decision[ix_na_current_decision] <- cur_decisions
 
-            if (!x$params$quiet$mis) { # Provide user feedback:
+            if (!x$params$quiet$mis & any(ix_na_current_decision)) { # Provide user feedback:
 
-              cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Made {nr_NA} majority prediction{?s} (with a 'train' base rate p(TRUE) = {crit_br}): {cur_decisions}.")
+              cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Making {nr_NA} majority prediction{?s} (with a 'train' base rate p(TRUE) = {crit_br}): {cur_decisions}.")
 
             }
 
@@ -441,12 +441,12 @@ fftrees_apply <- function(x,
 
           }
 
-          if (!x$params$quiet$mis) { # Provide user feedback:
+          if (!x$params$quiet$mis & any(ix_na_current_decision)) { # Provide user feedback:
 
             sum_NA_fin <- sum(ix_na_current_decision)
             cur_dec_n1 <- decisions_df$current_decision[ix_na_current_decision][1]  # 1st decision
 
-            cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Seeing {sum_NA_fin} NA value{?s} in terminal cue {cue_i}: Predict {finNA.pred} (e.g., {x$criterion_name} = {cur_dec_n1}).")
+            cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Seeing {sum_NA_fin} NA value{?s} in final cue '{cue_i}': Predict {finNA.pred} (e.g., {x$criterion_name} = {cur_dec_n1}).")
 
           }
 

--- a/R/fftrees_cuerank.R
+++ b/R/fftrees_cuerank.R
@@ -64,6 +64,9 @@ fftrees_cuerank <- function(x = NULL,
   # Verify: Make sure there is variance in the criterion!
   testthat::expect_true(length(unique(criterion_v)) > 1)
 
+  # Store safe copy:
+  criterion_v_org <- criterion_v
+
   # Determine current goal.threshold:
   goal.threshold <- x$params$goal.threshold  # (assign ONCE here and then use below)
 
@@ -102,6 +105,7 @@ fftrees_cuerank <- function(x = NULL,
   }
 
 
+
   # Main: Loop over cues: ------
 
   for (cue_i in 1:cue_n) {
@@ -117,8 +121,10 @@ fftrees_cuerank <- function(x = NULL,
 
     }
 
-    # Get key information of the current cue:
+    # Re-store from safe copy (to allow dropping NA cases for every cue_i):
+    criterion_v  <- criterion_v_org
 
+    # Get key information of the current cue:
     cue_i_name  <- names(cue_df)[cue_i]
     cue_i_class <- class(cue_df %>% dplyr::pull(cue_i))
     cue_i_v     <- unlist(cue_df[, cue_i])

--- a/R/plotFFTrees_function.R
+++ b/R/plotFFTrees_function.R
@@ -533,10 +533,14 @@ plot.FFTrees <- function(x = NULL,
     criterion_name <- x$criterion_name  # (only ONCE)
 
     # Compute criterion baseline/base rate:
-    crit_br <- mean(x$data[[data]][[criterion_name]])  # (from logical, i.e., proportion of TRUE values)
+    if (allow_NA_crit){
+      crit_br <- mean(x$data[[data]][[criterion_name]], na.rm = TRUE)
+    } else { # default:
+      crit_br <- mean(x$data[[data]][[criterion_name]])  # (from logical, i.e., proportion of TRUE values)
+    }
 
     n_exemplars <- nrow(x$data[[data]])
-    n_pos_cases <- sum(x$data[[data]][[criterion_name]])
+    n_pos_cases <- sum(x$data[[data]][[criterion_name]] == TRUE)
     n_neg_cases <- sum(x$data[[data]][[criterion_name]] == FALSE)
     mcu <- x$trees$stats[[data]]$mcu[tree]
 

--- a/R/summaryFFTrees_function.R
+++ b/R/summaryFFTrees_function.R
@@ -227,7 +227,13 @@ summary.FFTrees <- function(object,
 
   # Compute criterion baseline/base rate:
   criterion_name <- object$criterion_name
-  crit_br <- mean(object$data$train[[criterion_name]])
+
+  if (allow_NA_crit){
+    crit_br <- mean(object$data$train[[criterion_name]], na.rm = TRUE)
+  } else { # default:
+    crit_br <- mean(object$data$train[[criterion_name]])
+  }
+
   crit_val <- scales::percent(crit_br)
   crit_lbl <- object$params$decision.labels[2]
 

--- a/R/util_data.R
+++ b/R/util_data.R
@@ -54,6 +54,17 @@ clean_data <- function(data, criterion_name, formula,
                            mydata = mydata,  # indicate data type
                            quiet = quiet)
 
+  } else {
+
+    # Mention NA cases (if present):
+    if (any(is.na(data))){
+
+      sum_NA_all <- sum(is.na(data))
+
+      cli::cli_alert_danger("Found {sum_NA_all} NA value{?s} in '{mydata}' data.")
+
+    }
+
   }
 
 

--- a/R/util_stats.R
+++ b/R/util_stats.R
@@ -269,7 +269,7 @@ classtable <- function(prediction_v = NULL,
 
   # Handle NA values: ------
 
-  # ToDo: Move functionality to upper function, BEFORE calling utility function.
+  # ToDo: Consider moving functionality to calling functions, BEFORE calling the classtable() utility function.
 
   # Note: As NA values in predictors of type character / factor / logical were handled in handle_NA(),
   #       only NA values in numeric predictors or the criterion variable appear here.

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,12 +39,10 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 [![R-CMD-check](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml)
 <!-- Devel badges end. -->
 
-
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color='00a9e0')](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- Release badges end. -->
-
 
 <!-- ALL badges start: --> 
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.9.0.9015 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.9.0.9016 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -333,6 +333,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-03-03.\]
+\[File `README.Rmd` last updated on 2023-03-04.\]
 
 <!-- eof. -->

--- a/man/fftrees_apply.Rd
+++ b/man/fftrees_apply.Rd
@@ -4,7 +4,7 @@
 \alias{fftrees_apply}
 \title{Apply an FFT to data and generate accuracy statistics}
 \usage{
-fftrees_apply(x, mydata = NULL, newdata = NULL, finNA.pred = "noise")
+fftrees_apply(x, mydata = NULL, newdata = NULL, finNA.pred = "majority")
 }
 \arguments{
 \item{x}{An object with FFT definitions which are to be applied to current data (as an \code{FFTrees} object).}
@@ -15,14 +15,15 @@ fftrees_apply(x, mydata = NULL, newdata = NULL, finNA.pred = "noise")
 
 \item{finNA.pred}{What outcome should be predicted if the \emph{final} node in a tree has a cue value of \code{NA}
 (as character)?
-Default: \code{finNA.pred = "noise"}.
-Options to implement include:
-- "noise"  (predict FALSE/0/left),
-- "signal" (predict TRUE/1/right),
-Yet ToDo:
-- "majority" (predict the more common baseline case, else predict noise),
-- "baseline" (flip a coin using the criterion baseline),
-- "dnk" (decide to 'do not know'/tertium datur).}
+Valid options are:
+\describe{
+  \item{'noise'}{predict \code{FALSE} (0/left/signal) for all corresponding cases}
+  \item{'signal'}{predict \code{TRUE} (1/right/noise) for all corresponding cases}
+  \item{'majority'}{predict more common criterion (i.e., \code{TRUE} if base rate \code{p(TRUE) > .50} in 'train' data) for all corresponding cases}
+  \item{'baseline'}{flip a random coin that is biased by the criterion baseline of \code{p(TRUE)} (in 'train' data) for all corresponding cases}
+  \item{'dnk'}{yet ToDo: decide to 'do not know' / tertium datur}
+  }
+Default: \code{finNA.pred = "majority"}.}
 }
 \value{
 A modified \code{FFTrees} object (with lists in \code{x$trees} containing information on FFT decisions and statistics).

--- a/man/fftrees_apply.Rd
+++ b/man/fftrees_apply.Rd
@@ -4,7 +4,13 @@
 \alias{fftrees_apply}
 \title{Apply an FFT to data and generate accuracy statistics}
 \usage{
-fftrees_apply(x, mydata = NULL, newdata = NULL, allNA.pred = FALSE)
+fftrees_apply(
+  x,
+  mydata = NULL,
+  newdata = NULL,
+  allNA.pred = FALSE,
+  finNA.pred = "noise"
+)
 }
 \arguments{
 \item{x}{An object with FFT definitions which are to be applied to current data (as an \code{FFTrees} object).}
@@ -13,8 +19,20 @@ fftrees_apply(x, mydata = NULL, newdata = NULL, allNA.pred = FALSE)
 
 \item{newdata}{New data to which an FFT should be applied (as a data frame).}
 
-\item{allNA.pred}{What should be predicted if all cue values in tree are \code{NA} (as logical)?
-Default: \code{allNA.pred = FALSE}.}
+\item{allNA.pred}{What outcome should be predicted if \emph{all} cue values in tree nodes are \code{NA} (as logical)?
+Default: \code{allNA.pred = FALSE}.
+(Note: The name of this arg is misleading, as it is used whenever the \emph{final} node of a tree encounters a cue value of \code{NA}.
+The cue values of earlier nodes just need not to have pointed to an exit to reach the final node.
+Hence, the case that \emph{all} cue values are \code{NA} is only a rare special case of this particular one.)}
+
+\item{finNA.pred}{What outcome should be predicted if the \emph{final} node in a tree has a cue value of \code{NA} (as logical)?
+Default: \code{finNA.pred = TRUE}.
+Options to implement include:
+- "noise"  (predict FALSE/0/left),
+- "signal" (predict TRUE/1/right),
+- "majority" (predict the more common baseline case, else predict noise),
+- "baseline" (flip a coin using the criterion baseline),
+- "dnk" (decide to 'do not know'/tertium datur).}
 }
 \value{
 A modified \code{FFTrees} object (with lists in \code{x$trees} containing information on FFT decisions and statistics).

--- a/man/fftrees_apply.Rd
+++ b/man/fftrees_apply.Rd
@@ -4,13 +4,7 @@
 \alias{fftrees_apply}
 \title{Apply an FFT to data and generate accuracy statistics}
 \usage{
-fftrees_apply(
-  x,
-  mydata = NULL,
-  newdata = NULL,
-  allNA.pred = FALSE,
-  finNA.pred = "noise"
-)
+fftrees_apply(x, mydata = NULL, newdata = NULL, finNA.pred = "noise")
 }
 \arguments{
 \item{x}{An object with FFT definitions which are to be applied to current data (as an \code{FFTrees} object).}
@@ -19,17 +13,13 @@ fftrees_apply(
 
 \item{newdata}{New data to which an FFT should be applied (as a data frame).}
 
-\item{allNA.pred}{What outcome should be predicted if \emph{all} cue values in tree nodes are \code{NA} (as logical)?
-Default: \code{allNA.pred = FALSE}.
-(Note: The name of this arg is misleading, as it is used whenever the \emph{final} node of a tree encounters a cue value of \code{NA}.
-The cue values of earlier nodes just need not to have pointed to an exit to reach the final node.
-Hence, the case that \emph{all} cue values are \code{NA} is only a rare special case of this particular one.)}
-
-\item{finNA.pred}{What outcome should be predicted if the \emph{final} node in a tree has a cue value of \code{NA} (as logical)?
-Default: \code{finNA.pred = TRUE}.
+\item{finNA.pred}{What outcome should be predicted if the \emph{final} node in a tree has a cue value of \code{NA}
+(as character)?
+Default: \code{finNA.pred = "noise"}.
 Options to implement include:
 - "noise"  (predict FALSE/0/left),
 - "signal" (predict TRUE/1/right),
+Yet ToDo:
 - "majority" (predict the more common baseline case, else predict noise),
 - "baseline" (flip a coin using the criterion baseline),
 - "dnk" (decide to 'do not know'/tertium datur).}


### PR DESCRIPTION
This PR mostly explicates the handling of `NA` cases (and adds corresponding options and user feedback) when applying trees to data by `fftrees_apply()` (partially addressing some points currently discussed in Issue #160). 

Additionally, computations of `crit_br` (in plot and summary) now allow for `allow_NA_crit`.