### PR TITLE
Handling NAs in competition

### DIFF
--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -511,11 +511,13 @@ fftrees_apply <- function(x,
         #
         sens.w = x$params$sens.w,
         #
-        cost.outcomes = x$params$cost.outcomes,              # outcome cost (per outcome type)
+        cost.outcomes = x$params$cost.outcomes,          # outcome cost (per outcome type)
         cost_v = decisions_df$cost_cue[ix_non_NA_deci],  # cue cost (per decision at level)
         #
         my.goal = x$params$my.goal,
-        my.goal.fun = x$params$my.goal.fun
+        my.goal.fun = x$params$my.goal.fun,
+        #
+        quiet_mis = x$params$quiet$mis  # passed to hide/show NA user feedback
       )
 
       # level_stats_i$costc <- sum(cost_cue[,tree_i], na.rm = TRUE)

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -378,7 +378,7 @@ fftrees_apply <- function(x,
 
             sum_NA_cur <- sum(ix_na_classify_now)
 
-            cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Seeing {sum_NA_cur} NA value{?s} in intermediate cue '{cue_i}' and proceed.")
+            cli::cli_alert_warning("Tree {tree_i} node {level_i}: Seeing {sum_NA_cur} NA value{?s} in intermediate cue '{cue_i}' and proceed.")
 
           }
 
@@ -410,7 +410,7 @@ fftrees_apply <- function(x,
 
             if (!x$params$quiet$mis & any(ix_na_current_decision)) { # Provide user feedback:
 
-              cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Making {nr_NA} baseline prediction{?s} (with a 'train' base rate p(TRUE) = {crit_br}): {cur_decisions}.")
+              cli::cli_alert_warning("Tree {tree_i} node {level_i}: Making {nr_NA} baseline prediction{?s} (with a 'train' base rate p(TRUE) = {crit_br}): {cur_decisions}.")
 
             }
 
@@ -428,11 +428,11 @@ fftrees_apply <- function(x,
 
             if (!x$params$quiet$mis & any(ix_na_current_decision)) { # Provide user feedback:
 
-              cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Making {nr_NA} majority prediction{?s} (with a 'train' base rate p(TRUE) = {crit_br}): {cur_decisions}.")
+              cli::cli_alert_warning("Tree {tree_i} node {level_i}: Making {nr_NA} majority prediction{?s} (with a 'train' base rate p(TRUE) = {crit_br}): {cur_decisions}.")
 
             }
 
-          } else {
+          } else { # unknown option (not in finNA_options):
 
             finNA_options <- c("noise", "signal", "baseline", "majority")
             finNA_opt_s <- paste0(finNA_options, collapse = ", ")
@@ -441,12 +441,18 @@ fftrees_apply <- function(x,
 
           }
 
-          if (!x$params$quiet$mis & any(ix_na_current_decision)) { # Provide user feedback:
+          be_redundantly_explicit <- FALSE # TRUE  # allow hiding/showing redundant user feedback:
 
-            sum_NA_fin <- sum(ix_na_current_decision)
-            cur_dec_n1 <- decisions_df$current_decision[ix_na_current_decision][1]  # 1st decision
+          if (be_redundantly_explicit){ # Classification of final node is reported as "Making..." (above):
 
-            cli::cli_alert_warning("Tree {tree_i}, node {level_i}: Seeing {sum_NA_fin} NA value{?s} in final cue '{cue_i}': Predict {finNA.pred} (e.g., {x$criterion_name} = {cur_dec_n1}).")
+            if (!x$params$quiet$mis & any(ix_na_current_decision)) { # Provide user feedback:
+
+              sum_NA_fin <- sum(ix_na_current_decision)
+              cur_dec_n1 <- decisions_df$current_decision[ix_na_current_decision][1]  # 1st decision
+
+              cli::cli_alert_warning("Tree {tree_i} node {level_i}: Seeing {sum_NA_fin} NA value{?s} in final cue '{cue_i}': Predict {finNA.pred} (e.g., {x$criterion_name} = {cur_dec_n1}).")
+
+            }
 
           }
 
@@ -457,7 +463,7 @@ fftrees_apply <- function(x,
         # ToDo:
         # - Add user feedback
         # - Examine alternative policies for indecision / doxastic abstention:
-        #   - predict either TRUE or FALSE (according to allNA.pred or finNA.pred)
+        #   - predict either TRUE or FALSE (according to finNA.pred)
         #   - predict the most common category (overall baseline or baseline at this level)
         #   - predict a 3rd category (tertium datur: abstention / dnk: "do not know" / NA decision)
         #   Corresponding results will depend on the costs of errors.

--- a/R/fftrees_fitcomp.R
+++ b/R/fftrees_fitcomp.R
@@ -86,7 +86,8 @@ fftrees_fitcomp <- function(x) {
         data.test = x$data$test,
         algorithm = "lr",
         model = NULL,
-        sens.w = sens.w
+        sens.w = sens.w,
+        quiet_mis = x$params$quiet$mis
       )
 
       lr_stats <- lr_acc$accuracy
@@ -120,7 +121,8 @@ fftrees_fitcomp <- function(x) {
         data.test = x$data$test,
         algorithm = "cart",
         model = NULL,
-        sens.w = sens.w
+        sens.w = sens.w,
+        quiet_mis = x$params$quiet$mis
       )
 
       cart_stats <- cart_acc$accuracy
@@ -154,7 +156,8 @@ fftrees_fitcomp <- function(x) {
         data.test = x$data$test,
         algorithm = "rf",
         model = NULL,
-        sens.w = sens.w
+        sens.w = sens.w,
+        quiet_mis = x$params$quiet$mis
       )
 
 
@@ -189,7 +192,8 @@ fftrees_fitcomp <- function(x) {
         data.test = x$data$test,
         algorithm = "svm",
         model = NULL,
-        sens.w = sens.w
+        sens.w = sens.w,
+        quiet_mis = x$params$quiet$mis
       )
 
       svm_stats <- svm_acc$accuracy

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -355,7 +355,8 @@ fftrees_grow_fan <- function(x,
         asif_levelout_v[case_remaining_ix] <- level_current
         asif_cuecost_v[case_remaining_ix]  <- cue_cost_new
 
-        # ToDo: Pass level_current and cues_name_new to classtable() (to handle NA values)? +++ here now +++
+        # ToDo: Pass level_current and cues_name_new to classtable() helper (to handle NA values in utility fn)
+        #    OR move NA handling code to calling functions (to diagnose what happens here)?   +++ here now +++
 
         # Get results for ASIF classifications:
         asif_results <- classtable(
@@ -368,7 +369,9 @@ fftrees_grow_fan <- function(x,
           cost_v = asif_cuecost_v,                 # add cue cost
           #
           my.goal = my_goal,
-          my.goal.fun = my_goal_fun
+          my.goal.fun = my_goal_fun,
+          #
+          quiet_mis = x$params$quiet$mis  # passed to hide/show NA user feedback
         )
         # Note: The 2 cost arguments cost.outcomes and cost_v were NOT being used to compute asif_results.
         # DONE: ADDED asif_cuecost_v to call to classtable() here (on 2023-01-19)     +++ here now +++
@@ -605,7 +608,9 @@ fftrees_grow_fan <- function(x,
           cost_v = cuecost_v[case_remaining_ix == FALSE],
           #
           my.goal = my_goal,
-          my.goal.fun = my_goal_fun
+          my.goal.fun = my_goal_fun,
+          #
+          quiet_mis = x$params$quiet$mis  # passed to hide/show NA user feedback
         )
 
         # Update level stats:
@@ -748,7 +753,9 @@ fftrees_grow_fan <- function(x,
           cost_v = cuecost_v,
           #
           my.goal = my_goal,
-          my.goal.fun = my_goal_fun
+          my.goal.fun = my_goal_fun,
+          #
+          quiet_mis = x$params$quiet$mis  # passed to hide/show NA user feedback
         )
 
         level_stats_i$exit[last_level_nr] <- exit_types[3]  # .5

--- a/R/util_data.R
+++ b/R/util_data.R
@@ -313,7 +313,7 @@ handle_NA_data <- function(data, criterion_name, mydata, quiet){
     # Keep NA values in numeric predictors (but remove in classtable() of 'util_stats.R').
 
     if (!quiet$mis) { # Provide user feedback:
-      cli::cli_alert_warning("Keeping the {sum(nr_pred_num_NA)} NA case{?s} in {sum(ix_pred_num_NA)} numeric predictor{?s}.")
+      cli::cli_alert_warning("Keeping {sum(nr_pred_num_NA)} NA case{?s} in {sum(ix_pred_num_NA)} numeric predictor{?s}.")
     }
 
   }
@@ -323,7 +323,7 @@ handle_NA_data <- function(data, criterion_name, mydata, quiet){
     # ToDo: What to do about NA values in criterion?
 
     if (!quiet$mis) { # Provide user feedback:
-      cli::cli_alert_warning("Keeping the {sum(nr_crit_NA)} NA case{?s} in the criterion {nm_crit_NA}.")
+      cli::cli_alert_warning("Keeping {sum(nr_crit_NA)} NA case{?s} in the criterion {nm_crit_NA}.")
     }
 
   }

--- a/R/util_stats.R
+++ b/R/util_stats.R
@@ -299,7 +299,7 @@ classtable <- function(prediction_v = NULL,
         rem_criterion_v <- criterion_v[ix_NA_pred]
         rem_criterion_s <- paste0(rem_criterion_v, collapse = ", ")
 
-        cli::cli_alert_warning("2x2: Ignoring {sum_NA_pred} NA value{?s} in 'prediction_v' and corresponding criterion_v = c({rem_criterion_s}).")
+        cli::cli_alert_warning("2x2: Ignoring {sum_NA_pred} NA value{?s} in prediction_v and corresponding criterion_v = c({rem_criterion_s}).")
 
       }
 
@@ -312,7 +312,7 @@ classtable <- function(prediction_v = NULL,
         rem_prediction_v <- prediction_v[ix_NA_crit]
         rem_prediction_s <- paste0(rem_prediction_v, collapse = ", ")
 
-        cli::cli_alert_warning("2x2: Ignoring {sum_NA_crit} NA value{?s} in 'criterion_v' and corresponding prediction_v = c({rem_prediction_s}).")
+        cli::cli_alert_warning("2x2: Ignoring {sum_NA_crit} NA value{?s} in criterion_v and corresponding prediction_v = c({rem_prediction_s}).")
 
       }
 

--- a/R/util_stats.R
+++ b/R/util_stats.R
@@ -222,6 +222,9 @@ add_stats <- function(data, # df with frequency counts of classification outcome
 #' @param my.goal Name of an optional, user-defined goal (as character string). Default: \code{my.goal = NULL}.
 #' @param my.goal.fun User-defined goal function (with 4 arguments \code{hi fa mi cr}). Default: \code{my.goal.fun = NULL}.
 #'
+#' @param quiet_mis A logical value passed to hide/show \code{NA} user feedback
+#' (usually \code{x$params$quiet$mis} of calling function).
+#' Default: \code{quiet_mis = FALSE} (i.e., show user feedback).
 #' @param na_prediction_action What happens when no prediction is possible? (experimental).
 #'
 #' @importFrom stats qnorm
@@ -240,6 +243,7 @@ classtable <- function(prediction_v = NULL,
                        my.goal = NULL,
                        my.goal.fun = NULL,
                        #
+                       quiet_mis = FALSE,               # logical arg passed to hide/show NA user feedback
                        na_prediction_action = "ignore"  # is NOT used anywhere?
 ){
 
@@ -284,8 +288,6 @@ classtable <- function(prediction_v = NULL,
 
     # Report NA values (prior to removing them): ----
 
-    quiet_mis <- FALSE  # HACK: as local constant (as object x or quiet list are not passed)
-
     if (!quiet_mis) { # Provide user feedback:
 
       # 1. Report NA in prediction_v:
@@ -297,7 +299,7 @@ classtable <- function(prediction_v = NULL,
         rem_criterion_v <- criterion_v[ix_NA_pred]
         rem_criterion_s <- paste0(rem_criterion_v, collapse = ", ")
 
-        cli::cli_alert_warning("Dropping {sum_NA_pred} NA value{?s} from 'prediction_v' and criterion_v = c({rem_criterion_s}).")
+        cli::cli_alert_warning("2x2: Ignoring {sum_NA_pred} NA value{?s} in 'prediction_v' and corresponding criterion_v = c({rem_criterion_s}).")
 
       }
 
@@ -310,7 +312,7 @@ classtable <- function(prediction_v = NULL,
         rem_prediction_v <- prediction_v[ix_NA_crit]
         rem_prediction_s <- paste0(rem_prediction_v, collapse = ", ")
 
-        cli::cli_alert_warning("Dropping {sum_NA_crit} NA value{?s} from 'criterion_v' and prediction_v = c({rem_prediction_s}).")
+        cli::cli_alert_warning("2x2: Ignoring {sum_NA_crit} NA value{?s} in 'criterion_v' and corresponding prediction_v = c({rem_prediction_s}).")
 
       }
 

--- a/R/util_stats.R
+++ b/R/util_stats.R
@@ -273,8 +273,6 @@ classtable <- function(prediction_v = NULL,
 
   # Handle NA values: ------
 
-  # ToDo: Consider moving functionality to calling functions, BEFORE calling the classtable() utility function.
-
   # Note: As NA values in predictors of type character / factor / logical were handled in handle_NA(),
   #       only NA values in numeric predictors or the criterion variable appear here.
 
@@ -1190,7 +1188,8 @@ comp_pred <- function(formula,
     acc_train <- classtable(
       prediction_v = as.logical(pred_train),
       criterion_v = as.logical(crit_train),
-      sens.w = sens.w
+      sens.w = sens.w,
+      quiet_mis = quiet_mis
     )
   }
 
@@ -1199,7 +1198,8 @@ comp_pred <- function(formula,
     acc_train <- classtable(
       prediction_v = c(TRUE, TRUE, FALSE),
       criterion_v =  c(FALSE, FALSE, TRUE),
-      sens.w = sens.w
+      sens.w = sens.w,
+      quiet_mis = quiet_mis
     )
 
     acc_train[1, ] <- NA
@@ -1219,7 +1219,8 @@ comp_pred <- function(formula,
     acc_test <- classtable(
       prediction_v = as.logical(pred_test),
       criterion_v = as.logical(crit_test),
-      sens.w = sens.w
+      sens.w = sens.w,
+      quiet_mis = quiet_mis
     )
 
   } else {
@@ -1227,7 +1228,8 @@ comp_pred <- function(formula,
     acc_test <- classtable(
       prediction_v = c(TRUE, FALSE, TRUE),
       criterion_v = c(TRUE, TRUE, FALSE),
-      sens.w = sens.w
+      sens.w = sens.w,
+      quiet_mis = quiet_mis
     )
 
     acc_test[1, ] <- NA
@@ -1240,7 +1242,8 @@ comp_pred <- function(formula,
     acc_train <- classtable(
       prediction_v = c(TRUE, FALSE, TRUE),
       criterion_v = c(FALSE, TRUE, TRUE),
-      sens.w = sens.w
+      sens.w = sens.w,
+      quiet_mis = quiet_mis
     )
 
     acc_train[1, ] <- NA
@@ -1248,7 +1251,8 @@ comp_pred <- function(formula,
     acc_test <- classtable(
       prediction_v = c(TRUE, FALSE, TRUE),
       criterion_v = c(FALSE, TRUE, TRUE),
-      sens.w = sens.w
+      sens.w = sens.w,
+      quiet_mis = quiet_mis
     )
 
     acc_test[1, ] <- NA

--- a/R/util_stats.R
+++ b/R/util_stats.R
@@ -683,7 +683,7 @@ comp_pred <- function(formula,
                       sens.w = NULL,
                       new.factors = "exclude",
                       quiet_mis = FALSE         # logical arg passed to hide/show NA user feedback
-                      ) {
+) {
 
   #   formula = x$formula
   #   data.train = x$data$train
@@ -717,13 +717,13 @@ comp_pred <- function(formula,
     # data_all <- rbind(data.train, data.test)  # Note: fails when both dfs have different variables!
     data_all <- dplyr::bind_rows(data.train, data.test)  # fills any non-matching columns with NAs.
     train_cases <- 1:nrow(data.train)
-    test_cases <- (nrow(data.train) + 1):nrow(data_all)
+    test_cases  <- (nrow(data.train) + 1):nrow(data_all)
   }
 
-  if (is.null(data.train) & is.null(data.test) == FALSE) {
+  if (is.null(data.train) & (is.null(data.test) == FALSE)) {
     data_all <- data.test
     train_cases <- c()
-    test_cases <- 1:nrow(data_all)
+    test_cases  <- 1:nrow(data_all)
   }
 
   data_all <- model.frame(
@@ -774,7 +774,10 @@ comp_pred <- function(formula,
   } # if (do_test).
 
 
-  # Get data, cue, crit objects: ----
+  # print(data.train)  # 4debugging: NA cases are still present.
+
+
+  # Get training data (data.train): ----
 
   if (is.null(train_cases) == FALSE) {
 
@@ -790,6 +793,8 @@ comp_pred <- function(formula,
 
   }
 
+  # print(data.train)  # 4debugging: NA cases have been removed.
+
 
   # Build models for training data: ------
 
@@ -800,9 +805,9 @@ comp_pred <- function(formula,
 
     if (!quiet_mis) { # Provide user feedback:
 
-    nr_NA <- sum(is.na(data.train))
+      nr_NA <- sum(is.na(data.train))
 
-    cli::cli_alert_warning("Aiming to fit {toupper(algorithm)}: Found {nr_NA} NA value{?s} in 'data.train' and using na.omit() to remove incomplete cases.")
+      cli::cli_alert_warning("Aiming to fit {toupper(algorithm)}: Found {nr_NA} NA value{?s} in 'data.train' and using na.omit() to remove incomplete cases.")
 
     }
 
@@ -816,6 +821,14 @@ comp_pred <- function(formula,
     data.train <- stats::na.omit(data.train)
 
   }
+
+  # } else {
+  #
+  #   cli::cli_alert_info("Aiming to fit {toupper(algorithm)}: Found zero NA value{?s} in 'data.train'.")
+  #
+  #   print(data.train)
+  #
+  # }
 
 
   # 1. LR: binomial LR ----
@@ -954,7 +967,7 @@ comp_pred <- function(formula,
 
 
 
-  # Get testing data: ------
+  # Get testing data (data.test): ------
 
   pred_test <- NULL
 
@@ -971,9 +984,9 @@ comp_pred <- function(formula,
 
       if (!quiet_mis) { # Provide user feedback:
 
-      nr_NA <- sum(is.na(data.test))
+        nr_NA <- sum(is.na(data.test))
 
-      cli::cli_alert_warning("Aiming to predict {toupper(algorithm)}: Found {nr_NA} NA value{?s} in 'data.test'.")
+        cli::cli_alert_warning("Aiming to predict {toupper(algorithm)}: Found {nr_NA} NA value{?s} in 'data.test'.")
 
       }
 

--- a/man/classtable.Rd
+++ b/man/classtable.Rd
@@ -13,6 +13,7 @@ classtable(
   cost_v = NULL,
   my.goal = NULL,
   my.goal.fun = NULL,
+  quiet_mis = FALSE,
   na_prediction_action = "ignore"
 )
 }
@@ -40,6 +41,10 @@ Default: \code{cost_v = NULL} (to ensure that values are passed by calling funct
 \item{my.goal}{Name of an optional, user-defined goal (as character string). Default: \code{my.goal = NULL}.}
 
 \item{my.goal.fun}{User-defined goal function (with 4 arguments \code{hi fa mi cr}). Default: \code{my.goal.fun = NULL}.}
+
+\item{quiet_mis}{A logical value passed to hide/show \code{NA} user feedback
+(usually \code{x$params$quiet$mis} of calling function).
+Default: \code{quiet_mis = FALSE} (i.e., show user feedback).}
 
 \item{na_prediction_action}{What happens when no prediction is possible? (experimental).}
 }

--- a/man/comp_pred.Rd
+++ b/man/comp_pred.Rd
@@ -11,7 +11,8 @@ comp_pred(
   algorithm = NULL,
   model = NULL,
   sens.w = NULL,
-  new.factors = "exclude"
+  new.factors = "exclude",
+  quiet_mis = FALSE
 )
 }
 \arguments{
@@ -40,6 +41,10 @@ Available options:
   \item{\code{"exclude"}: exclude case (i.e., remove these cases, used by default);}
   \item{\code{"base"}: predict the base rate of the criterion.}
 }}
+
+\item{quiet_mis}{A logical value passed to hide/show \code{NA} user feedback
+(usually \code{x$params$quiet$mis} of calling function).
+Default: \code{quiet_mis = FALSE} (i.e., show user feedback).}
 }
 \description{
 \code{comp_pred} provides the main wrapper for running alternative classification algorithms, such as CART (\code{rpart::rpart}),


### PR DESCRIPTION
This PR adds some handling of `NA` values in **competition** (primarily adding user feedback, but an error in RF is prevented by using `na.omit()` on training data), plus various minor improvements on user feedback on `NA` handling.