### PR TITLE
Add `NA` to level stats & enable `stopping.rule = "statdelta"`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.9.0.9016
-Date: 2023-03-08
+Version: 1.9.0.9017
+Date: 2023-03-09
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/R/FFTrees.R
+++ b/R/FFTrees.R
@@ -57,11 +57,12 @@
 #' @param stopping.rule A character string indicating the method to stop growing trees. Available options are:
 #' \code{"levels"} means the tree grows until a certain level;
 #' \code{"exemplars"} means the tree grows until a certain number of unclassified exemplars remain;
-#' \code{"statdelta"} (currently not available) means the tree grows until the change in the criterion statistic is less than a specified level.
+#' \code{"statdelta"} means the tree grows until the change in the criterion statistic (\code{goal.chase}) is below a specified level.
 #' Default: \code{stopping.rule = "exemplars"}.
 #' @param stopping.par numeric. A numeric value indicating the parameter for the stopping rule.
 #' For stopping.rule \code{"levels"}, this is the number of levels (as an integer).
 #' For stopping rule \code{"exemplars"}, this is the smallest percentage of exemplars allowed in the last level.
+#' For stopping.rule \code{"statdelta"}, this is the minimum required increase (in the \code{goal.chase} value) to include a level.
 #' Default: \code{stopping.par = .10}.
 #'
 #' @param sens.w A numeric value from \code{0} to \code{1} indicating how to weight

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -559,7 +559,7 @@ fftrees_grow_fan <- function(x,
 
             goal_change_rnd <- round(asif_stats$goal_change[level_current], 3)
 
-            cli::cli_alert_info("Tree {tree_i}, level {level_current}: goal_change = {goal_change_rnd} (chasing {x$params$goal.chase})")
+            cli::cli_alert_info("Tree {tree_i}, level {level_current}: goal_change = {goal_change_rnd} (chasing '{x$params$goal.chase}').")
 
           }
 

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -539,13 +539,28 @@ fftrees_grow_fan <- function(x,
 
         # Calculate the goal_change value: ----
         {
-          if (level_current == 1) {
-            asif_stats$goal_change[1] <- asif_stats[[x$params$goal]][1]
+
+          if (level_current == 1) { # initialize:
+
+            goal_change <- asif_stats[[x$params$goal.chase]][1]  # changed from $goal to $goal.chase on 2023-03-09.
+
+          } else { # compute change:
+
+            goal_change <- asif_stats[[x$params$goal.chase]][level_current] - asif_stats[[x$params$goal.chase]][level_current - 1]  # difference
+
           }
 
-          if (level_current > 1) {
-            goal_change <- asif_stats[[x$params$goal.chase]][level_current] - asif_stats[[x$params$goal.chase]][level_current - 1]  # difference
-            asif_stats$goal_change[level_current] <- goal_change
+          asif_stats$goal_change[level_current] <- goal_change
+
+
+          debug <- TRUE  # 4debugging
+
+          if (debug){ # Provide user feedback:
+
+            goal_change_rnd <- round(asif_stats$goal_change[level_current], 3)
+
+            cli::cli_alert_info("Tree {tree_i}, level {level_current}: goal_change = {goal_change_rnd} (chasing {x$params$goal.chase})")
+
           }
 
         }
@@ -687,6 +702,11 @@ fftrees_grow_fan <- function(x,
         }
 
         if ((x$params$stopping.rule == "levels") & (level_current == x$params$stopping.par)) {
+          grow_tree <- FALSE
+          break
+        }
+
+        if ((x$params$stopping.rule == "statdelta") & (asif_stats$goal_change[level_current] < x$params$stopping.par)) {
           grow_tree <- FALSE
           break
         }

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -253,7 +253,7 @@ fftrees_grow_fan <- function(x,
 
       level_current <- level_current + 1
       exit_current  <- exits_i[level_current]
-      case_remaining_ix <- is.na(decision_v)
+      ix_case_remaining <- is.na(decision_v)
 
       # Step 1: Determine a cue for the current level: ------
       {
@@ -271,7 +271,7 @@ fftrees_grow_fan <- function(x,
 
         if (x$params$algorithm == "dfan") {
 
-          data_current <- x$data$train[case_remaining_ix, ]
+          data_current <- x$data$train[ix_case_remaining, ]
 
           # If cues may NOT be repeated, then remove old cues as well:
           if (repeat.cues == FALSE) {
@@ -351,9 +351,9 @@ fftrees_grow_fan <- function(x,
         asif_levelout_v <- levelout_v
         asif_cuecost_v  <- cuecost_v
 
-        asif_decision_v[case_remaining_ix] <- cue_decisions[case_remaining_ix]
-        asif_levelout_v[case_remaining_ix] <- level_current
-        asif_cuecost_v[case_remaining_ix]  <- cue_cost_new
+        asif_decision_v[ix_case_remaining] <- cue_decisions[ix_case_remaining]
+        asif_levelout_v[ix_case_remaining] <- level_current
+        asif_cuecost_v[ix_case_remaining]  <- cue_cost_new
 
         # ToDo: Pass level_current and cues_name_new to classtable() helper (to handle NA values in utility fn)
         #    OR move NA handling code to calling functions (to diagnose what happens here)?   +++ here now +++
@@ -574,7 +574,7 @@ fftrees_grow_fan <- function(x,
         if (dplyr::near(exit_current, exit_types[2]) | dplyr::near(exit_current, exit_types[3])) {
           # if (dplyr::near(exit_current, 1) | dplyr::near(exit_current, .50)) {
 
-          decide_1_index <- case_remaining_ix & cue_decisions == TRUE
+          decide_1_index <- ix_case_remaining & cue_decisions == TRUE
 
           decision_v[decide_1_index] <- TRUE
           levelout_v[decide_1_index] <- level_current
@@ -609,18 +609,18 @@ fftrees_grow_fan <- function(x,
 
       # Step 4: Update results: ------
       {
-        case_remaining_ix <- is.na(decision_v)
+        ix_case_remaining <- is.na(decision_v)
 
         # Get cumulative stats of exemplars currently classified:
 
         results_cum <- classtable(
-          prediction_v = decision_v[case_remaining_ix == FALSE],
-          criterion_v = criterion_v[case_remaining_ix == FALSE],
+          prediction_v = decision_v[ix_case_remaining  == FALSE],
+          criterion_v  = criterion_v[ix_case_remaining == FALSE],
           #
           sens.w = x$params$sens.w,
           #
           cost.outcomes = x$params$cost.outcomes,
-          cost_v = cuecost_v[case_remaining_ix == FALSE],
+          cost_v = cuecost_v[ix_case_remaining == FALSE],
           #
           my.goal = my_goal,
           my.goal.fun = my_goal_fun,
@@ -677,7 +677,7 @@ fftrees_grow_fan <- function(x,
 
         } # else:
 
-        n_case_remaining <- sum(case_remaining_ix)
+        n_case_remaining <- sum(ix_case_remaining)
         # print(n_case_remaining)  # 4debugging
 
         if ((n_case_remaining > 0) & (level_current != cues_n) & (exit_method == "fixed")) {
@@ -706,15 +706,17 @@ fftrees_grow_fan <- function(x,
           break
         }
 
-
         if ((x$params$stopping.rule == "statdelta") & (asif_stats$goal_change[level_current] < x$params$stopping.par)) {
+
           # Limitation: Works only for measures to be MAXimized (e.g., not cost).
+          #             Currently still includes the current level, even though it did not yield the required increase.
           # Also, many stats do not grow monotonically. Hence, hill-climbing heuristic here can prevent finding better solutions.
+
           grow_tree <- FALSE
           break
         }
 
-        if ((x$params$algorithm == "dfan") & sd(criterion_v[case_remaining_ix]) == 0) {
+        if ((x$params$algorithm == "dfan") & sd(criterion_v[ix_case_remaining]) == 0) {
           grow_tree <- FALSE
           break
         }
@@ -747,7 +749,8 @@ fftrees_grow_fan <- function(x,
 
         decision_index <- is.na(decision_v)
 
-        # Step B: Determine accuracy of negative and positive classification: ----
+
+        # Determine the accuracy of negative and positive classification: ----
 
         current_decisions <- apply_break(
           direction = last_cue_stats$direction,
@@ -807,6 +810,7 @@ fftrees_grow_fan <- function(x,
     level_stats_i$tree <- tree_i
 
     level_stats_ls[[tree_i]] <- level_stats_i
+
   }
 
 
@@ -892,7 +896,6 @@ fftrees_grow_fan <- function(x,
     cli::cli_alert_success("Created {n_trees} FFT{?s} with '{cur_algorithm}' algorithm (chasing '{cur_goal.chase}').")
 
   }
-
 
 
 

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -553,7 +553,7 @@ fftrees_grow_fan <- function(x,
           asif_stats$goal_change[level_current] <- goal_change
 
 
-          debug <- TRUE  # 4debugging
+          debug <- FALSE  # 4debugging
 
           if (debug){ # Provide user feedback:
 
@@ -706,7 +706,10 @@ fftrees_grow_fan <- function(x,
           break
         }
 
+
         if ((x$params$stopping.rule == "statdelta") & (asif_stats$goal_change[level_current] < x$params$stopping.par)) {
+          # Limitation: Works only for measures to be MAXimized (e.g., not cost).
+          # Also, many stats do not grow monotonically. Hence, hill-climbing heuristic here can prevent finding better solutions.
           grow_tree <- FALSE
           break
         }

--- a/R/util_const.R
+++ b/R/util_const.R
@@ -134,7 +134,7 @@ exit_types <- c(0, 1, 0.5)  # (global constant)
 # - "levels"     # ToDo: implement by allowing stopping.par > 1
 # - "statdelta"  # ToDo: implement with stopping.par for goal.chase
 
-stopping_rules <- c("exemplars", "levels")  # (global constant)
+stopping_rules <- c("exemplars", "levels", "statdelta")  # (global constant)
 
 
 

--- a/R/util_stats.R
+++ b/R/util_stats.R
@@ -841,7 +841,7 @@ comp_pred <- function(formula,
 
         n_train <- nrow(data.train)
 
-        cli::cli_alert_warning("Aiming to fit {toupper(algorithm)}: Found {nr_NA} NA{?s} in 'data.train': Using na.omit() to remove incomplete cases left {n_train} case{?s}.")
+        cli::cli_alert_warning("Fitting {toupper(algorithm)}: Found {nr_NA} NA{?s} in 'data.train'. Removing incomplete cases left {n_train} case{?s}.")
 
       }
 
@@ -851,7 +851,7 @@ comp_pred <- function(formula,
 
         n_train <- nrow(data.train)
 
-        cli::cli_alert_warning("Aiming to fit {toupper(algorithm)}: Found {nr_NA} NA{?s} in 'data.train': Keeping all {n_train} case{?s}, but applying default algorithms may yield errors.")
+        cli::cli_alert_warning("Fitting {toupper(algorithm)}: Found {nr_NA} NA{?s} in 'data.train': Keeping all {n_train} case{?s}, but applying default algorithms may yield errors.")
 
       }
     }
@@ -1026,7 +1026,7 @@ comp_pred <- function(formula,
 
           n_test <- nrow(data.test)
 
-          cli::cli_alert_warning("Aiming to predict {toupper(algorithm)}: Found {nr_NA} NA{?s} in 'data.test': Using na.omit() to remove incomplete cases left {n_test} case{?s}.")
+          cli::cli_alert_warning("Predicting {toupper(algorithm)}: Found {nr_NA} NA{?s} in 'data.test'. Removing incomplete cases left {n_test} case{?s}.")
 
         }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -33,11 +33,13 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 
 # FFTrees `r packageVersion("FFTrees")` <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
+
 <!-- Devel badges start: --> 
 [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees)
 [![Downloads/month](https://cranlogs.r-pkg.org/badges/FFTrees?color='00a9e0')](https://www.r-pkg.org/pkg/FFTrees)
 [![R-CMD-check](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ndphillips/FFTrees/actions/workflows/R-CMD-check.yaml)
 <!-- Devel badges end. -->
+
 
 <!-- Release badges start: -->
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.9.0.9016 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.9.0.9017 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -333,6 +333,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-03-04.\]
+\[File `README.Rmd` last updated on 2023-03-09.\]
 
 <!-- eof. -->

--- a/man/FFTrees.Rd
+++ b/man/FFTrees.Rd
@@ -87,12 +87,13 @@ Default: \code{repeat.cues = TRUE}.}
 \item{stopping.rule}{A character string indicating the method to stop growing trees. Available options are:
 \code{"levels"} means the tree grows until a certain level;
 \code{"exemplars"} means the tree grows until a certain number of unclassified exemplars remain;
-\code{"statdelta"} (currently not available) means the tree grows until the change in the criterion statistic is less than a specified level.
+\code{"statdelta"} means the tree grows until the change in the criterion statistic (\code{goal.chase}) is below a specified level.
 Default: \code{stopping.rule = "exemplars"}.}
 
 \item{stopping.par}{numeric. A numeric value indicating the parameter for the stopping rule.
 For stopping.rule \code{"levels"}, this is the number of levels (as an integer).
 For stopping rule \code{"exemplars"}, this is the smallest percentage of exemplars allowed in the last level.
+For stopping.rule \code{"statdelta"}, this is the minimum required increase (in the \code{goal.chase} value) to include a level.
 Default: \code{stopping.par = .10}.}
 
 \item{sens.w}{A numeric value from \code{0} to \code{1} indicating how to weight


### PR DESCRIPTION
This PR adds `NA` counts (nr. of `NA` cue values and nr. of `NA` decision / indecisions) to each level

and enables (a rudimentary version of) `stopping.rule = "statdelta"` (currently stopping 1 level too late).