### PR TITLE
Enable stopping rule "statdelta"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
-Version: 1.9.0.9017
-Date: 2023-03-09
+Version: 1.9.0.9018
+Date: 2023-03-10
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # FFTrees 1.9
 
-## 1.9.0.9014
+## 1.9.0.9018
 
 This is the current development version of **FFTrees**, available at <https://github.com/ndphillips/FFTrees>.
 
@@ -15,12 +15,16 @@ Changes since last release:
 
 ### Major changes 
 
-- Allowing for missing data values:
+- Allowing for missing inputs (`NA` values) in data:
     - `NA` values in character/factor/logical predictors are treated as `<NA>` factor levels. 
     - `NA` values in numeric predictors are ignored when using FFTs to decide/predict (if possible). 
     - `NA` values in criterion are yet to be dealt with.  
     
-- Fixed a bug in `fftrees_grow_fan()` that prevented `ifan` algorithm from stopping when finding a perfect FFT (given current `goal.chase` parameter).  
+<!-- Blank line. --> 
+
+- Enabled `stopping.rule = "statdelta"`. 
+
+- Fixed a bug in `fftrees_grow_fan()` that prevented `ifan` algorithm from stopping when finding a perfect FFT (given current `goal.chase` parameter). 
 
 
 <!-- Minor: --> 
@@ -458,6 +462,6 @@ Thus, the main tree building function is now `FFTrees()` and the new tree object
 
 ------ 
 
-[File `NEWS.md` last updated on 2023-02-28.]
+[File `NEWS.md` last updated on 2023-03-10.]
 
 <!-- eof. -->

--- a/R/FFTrees.R
+++ b/R/FFTrees.R
@@ -47,22 +47,30 @@
 #'
 #' @param max.levels integer. The maximum number of nodes (or levels) considered for an FFT.
 #' As all combinations of possible exit structures are considered, larger values of \code{max.levels} will create larger sets of FFTs.
-#' @param numthresh.method character. How should thresholds for numeric cues be determined?
-#' \code{"o"} will optimize thresholds (for \code{goal.threshold}), while \code{"m"} will always use the median.
+#'
+#' @param numthresh.method How should thresholds for numeric cues be determined (as character)?
+#' \code{"o"} will optimize thresholds (for \code{goal.threshold}), while \code{"m"} will use the median.
 #' Default: \code{numthresh.method = "o"}.
 #' @param numthresh.n The number of numeric thresholds to try (as integer).
 #' Default: \code{numthresh.n = 10}.
+#'
 #' @param repeat.cues May cues occur multiple times within a tree (as logical)?
 #' Default: \code{repeat.cues = TRUE}.
-#' @param stopping.rule A character string indicating the method to stop growing trees. Available options are:
-#' \code{"levels"} means the tree grows until a certain level;
-#' \code{"exemplars"} means the tree grows until a certain number of unclassified exemplars remain;
-#' \code{"statdelta"} means the tree grows until the change in the criterion statistic (\code{goal.chase}) is below a specified level.
+#'
+#' @param stopping.rule A character string indicating the method to stop growing trees.
+#' Available options are:
+#' \itemize{
+#'   \item{\code{"exemplars"}: A tree grows until only a small proportion of unclassified exemplars remain;}
+#'   \item{\code{"levels"}: A tree grows until a certain level is reached;}
+#'   \item{\code{"statdelta"} (experimental): A tree grows until the change in the criterion statistic \code{goal.chase}
+#'   reaches some specified level.}
+#'   }
+#' All stopping methods use \code{stopping.par} to define a numeric threshold.
 #' Default: \code{stopping.rule = "exemplars"}.
-#' @param stopping.par numeric. A numeric value indicating the parameter for the stopping rule.
-#' For stopping.rule \code{"levels"}, this is the number of levels (as an integer).
+#' @param stopping.par numeric. A numeric parameter indicating the criterion value for the current \code{stopping.rule}.
+#' For stopping.rule \code{"levels"}, this is the number of desired levels (as an integer).
 #' For stopping rule \code{"exemplars"}, this is the smallest percentage of exemplars allowed in the last level.
-#' For stopping.rule \code{"statdelta"}, this is the minimum required increase (in the \code{goal.chase} value) to include a level.
+#' For stopping.rule \code{"statdelta"}, this is the minimum required change (in the \code{goal.chase} value) to include a level.
 #' Default: \code{stopping.par = .10}.
 #'
 #' @param sens.w A numeric value from \code{0} to \code{1} indicating how to weight

--- a/R/FFTrees.R
+++ b/R/FFTrees.R
@@ -62,14 +62,15 @@
 #' \itemize{
 #'   \item{\code{"exemplars"}: A tree grows until only a small proportion of unclassified exemplars remain;}
 #'   \item{\code{"levels"}: A tree grows until a certain level is reached;}
-#'   \item{\code{"statdelta"} (experimental): A tree grows until the change in the criterion statistic \code{goal.chase}
-#'   reaches some specified level.}
+#'   \item{\code{"statdelta"}: A tree grows until the change in the criterion statistic \code{goal.chase} exceeds some threshold level.
+#'   (This setting is currently experimental and includes the first level beyond threshold.
+#'   As tree statistics can be non-monotonic, this option may yield inconsistent results.)}
 #'   }
-#' All stopping methods use \code{stopping.par} to define a numeric threshold.
+#' All stopping methods use \code{stopping.par} to set a numeric threshold value.
 #' Default: \code{stopping.rule = "exemplars"}.
 #' @param stopping.par numeric. A numeric parameter indicating the criterion value for the current \code{stopping.rule}.
 #' For stopping.rule \code{"levels"}, this is the number of desired levels (as an integer).
-#' For stopping rule \code{"exemplars"}, this is the smallest percentage of exemplars allowed in the last level.
+#' For stopping rule \code{"exemplars"}, this is the smallest proportion of exemplars allowed in the last level.
 #' For stopping.rule \code{"statdelta"}, this is the minimum required change (in the \code{goal.chase} value) to include a level.
 #' Default: \code{stopping.par = .10}.
 #'
@@ -110,12 +111,12 @@
 #' Instead, the tree definitions provided are used to re-evaluate the current \code{FFTrees} object on current data.
 #'
 #' @param do.comp,do.lr,do.cart,do.svm,do.rf Should alternative algorithms be used for comparison (as logical)?
-#' All options set to \code{TRUE} by default. Available options correspond to:
+#' All options are set to \code{TRUE} by default. Available options correspond to:
 #' \itemize{
-#'   \item{\code{do.lr}: Logistic regression (using \code{\link{glm}} from \strong{stats} with \code{family = "binomial"});}
-#'   \item{\code{do.cart}: Decision trees (using \code{rpart} from \strong{rpart});}
-#'   \item{\code{do.svm}: Support vector machines (using \code{svm} from \strong{e1071});}
-#'   \item{\code{do.rf}: Random forests (using \code{randomForest} from \strong{randomForest}.}
+#'   \item{\code{do.lr}: Logistic regression (LR, using \code{\link{glm}} from \strong{stats} with \code{family = "binomial"});}
+#'   \item{\code{do.cart}: Classification and regression trees (CART, using \code{rpart} from \strong{rpart});}
+#'   \item{\code{do.svm}: Support vector machines (SVM, using \code{svm} from \strong{e1071});}
+#'   \item{\code{do.rf}: Random forests (RF, using \code{randomForest} from \strong{randomForest}.}
 #' }
 #' Specifying \code{do.comp = FALSE} sets all available options to \code{FALSE}.
 #'
@@ -135,7 +136,8 @@
 #'   \item{trees}{A list of FFTs created, with further details contained in \code{n}, \code{best}, \code{definitions}, \code{inwords}, \code{stats}, \code{level_stats}, and \code{decisions}.}
 #'   \item{data}{The original training and test data (if available).}
 #'   \item{params}{A list of defined control parameters (e.g.; \code{algorithm}, \code{goal}, \code{sens.w}, as well as various thresholds, stopping rule, and cost parameters).}
-#'   \item{competition}{Models and classification statistics for competitive classification algorithms: Logistic regression, CART, random forests RF, and SVM.}
+#'   \item{competition}{Models and classification statistics for competitive classification algorithms:
+#'   Logistic regression (\code{lr}), classification and regression trees (\code{cart}), random forests (\code{rf}), and support vector machines (\code{svm}).}
 #'   \item{cues}{A list of cue information, with further details contained in \code{thresholds} and \code{stats}.}
 #' }
 #'

--- a/R/fftrees_apply.R
+++ b/R/fftrees_apply.R
@@ -347,29 +347,27 @@ fftrees_apply <- function(x,
 
       # classify_now: ----
 
-      if (isTRUE(all.equal(exit_i, exit_types[1]))) { # exit_i 0:
-        classify_now <- (decisions_df$current_decision == FALSE) & is.na(decisions_df$decision)
+      if (isTRUE(all.equal(exit_i, exit_types[1]))) { # 1: exit_i 0:
+        classify_now <- (decisions_df$current_decision == FALSE) & is.na(decisions_df$decision) # FALSE or NA
       }
-      if (isTRUE(all.equal(exit_i, exit_types[2]))) { # exit_i 1:
-        classify_now <- (decisions_df$current_decision == TRUE) & is.na(decisions_df$decision)
+      if (isTRUE(all.equal(exit_i, exit_types[2]))) { # 2: exit_i 1:
+        classify_now <- (decisions_df$current_decision == TRUE) & is.na(decisions_df$decision)  # FALSE or NA
       }
-      if (isTRUE(all.equal(exit_i, exit_types[3]))) { # exit_i .5:
-        classify_now <- is.na(decisions_df$decision)
+      if (isTRUE(all.equal(exit_i, exit_types[3]))) { # 3: exit_i .5:
+        classify_now <- is.na(decisions_df$decision)  # TRUE for NA only
       }
 
 
       # Handle NA values: ------
 
-      # +++ here now +++
-
-      # What to DO with NA cases at a tree node?
-
       if ( allow_NA_pred | allow_NA_crit ){
+
+        # Goal: Deal with NA cases at a tree node.
 
         # 1. If this is an intermediate / NOT the final node, then don't classify NA cases:
         if (exit_i %in% exit_types[1:2]) {  # exit_types in c(0, 1)
 
-          # NAs on level (based on classify_now):
+          # NAs on current level (based on classify_now):
           ix_NA_classify_now <- is.na(classify_now)
           nr_NA_lvl <- sum(ix_NA_classify_now)
 
@@ -386,7 +384,7 @@ fftrees_apply <- function(x,
         # 2. If this IS the final / terminal node, then classify all NA cases according to fin_NA_pred:
         if (exit_i %in% exit_types[3]) {  # exit_types = .5:
 
-          # NAs on level (based on current_decision):
+          # NAs on current level (based on current_decision):
           ix_NA_current_decision <- is.na(decisions_df$current_decision)
           nr_NA_lvl <- sum(ix_NA_current_decision)
 
@@ -453,17 +451,15 @@ fftrees_apply <- function(x,
 
             }
 
-          }
+          } # if debug().
 
-        }
+        } # if final exit.
 
-        # [2. was:] If this IS the final node, then classify NA cases into the most common class [?: seems not done here]
+        # +++ here now +++
 
         # ToDo:
-        # - Add user feedback
-        # - Examine alternative policies for indecision / doxastic abstention:
-        #   - predict either TRUE or FALSE (according to fin_NA_pred)
-        #   - predict the most common category (overall baseline or baseline at this level)
+        # - Consider alternative policies for indecision / doxastic abstention:
+        #   - predict the most common category OF NA CASES in training data (rather than OVERALL baseline or baseline at this level)
         #   - predict a 3rd category (tertium datur: abstention / dnk: "do not know" / NA decision)
         #   Corresponding results will depend on the costs of errors.
 
@@ -551,7 +547,12 @@ fftrees_apply <- function(x,
         level_stats_i$cue_NA[level_i] <- nr_NA_lvl  # nr. of NA in cue values on current level_i
         level_stats_i$dec_NA[level_i] <- nr_NA_dec  # nr. of NA values in decisions / indecisions on level_i
 
-      } # +++ here now +++
+        # +++ here now +++
+
+        # ToDo:
+        # - Add number of TRUE vs. FALSE decisions for NAs in final node?
+
+      } # Handle NA: if ( allow_NA_pred | allow_NA_crit ).
 
 
     } # Loop 2: level_i.

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -604,17 +604,27 @@ fftrees_create <- function(formula = NULL,
 
   # stopping.par: ----
 
-  if (stopping.rule == "levels"){ # stopping.par must be a positive integer:
+  if (stopping.rule == "exemplars"){ # default: 0 < stopping.par < 1:
+
+    testthat::expect_gt(stopping.par, expected = 0)
+    testthat::expect_lt(stopping.par, expected = 1)
+
+  } else if (stopping.rule == "levels"){ # stopping.par must be a positive integer:
 
     stopping.par <- as.integer(stopping.par)  # aim to coerce to integer
 
     testthat::expect_true(is.integer(stopping.par))
     testthat::expect_gt(stopping.par, expected = 0)
 
-  } else { # e.g., stopping.rule == "exemplars": 0 < stopping.par < 1:
+  } else if (stopping.rule == "statdelta"){ # stopping.par must numeric:
 
-    testthat::expect_gt(stopping.par, expected = 0)
-    testthat::expect_lt(stopping.par, expected = 1)
+    stopping.par <- as.numeric(stopping.par)  # aim to coerce to numeric
+
+    testthat::expect_true(is.numeric(stopping.par))
+
+  } else { # unknown stopping.rule:
+
+    warning(paste0("Unknown stopping.par constraints for 'stopping.rule = ", stopping.rule, "'"))
 
   }
 
@@ -627,12 +637,12 @@ fftrees_create <- function(formula = NULL,
 
   }
 
-  # Disallow some combination:
-  if (stopping.rule == "statdelta" & goal.chase == "cost"){
-
-    stop("The stopping.rule 'statdelta' requires an accuracy measure as its 'goal.chase' value (e.g., 'bacc')")
-
-  }
+  # # Disallow some combination:
+  # if (stopping.rule == "statdelta" & goal.chase == "cost"){
+  #
+  #   stop("The stopping.rule 'statdelta' requires an accuracy measure as its 'goal.chase' value (e.g., 'bacc')")
+  #
+  # }
 
 
   # decision.labels: ----

--- a/R/fftrees_create.R
+++ b/R/fftrees_create.R
@@ -169,6 +169,7 @@ fftrees_create <- function(formula = NULL,
 
       goal <- "cost"
 
+      # Provide user feedback:
       if (!quiet$set) { cat(u_f_msg("\u2014 Setting 'goal = cost'\n")) }
 
     } else { # use accuracy defaults (bacc/wacc):
@@ -177,12 +178,14 @@ fftrees_create <- function(formula = NULL,
 
         goal <- "wacc"
 
+        # Provide user feedback:
         if (!quiet$set) { cat(u_f_msg("\u2014 Setting 'goal = wacc'\n")) }
 
       } else { # use bacc (as bacc == wacc):
 
         goal <- "bacc"
 
+        # Provide user feedback:
         if (!quiet$set) { cat(u_f_msg("\u2014 Setting 'goal = bacc'\n")) }
 
       }
@@ -191,7 +194,7 @@ fftrees_create <- function(formula = NULL,
 
   } else { # feedback user setting:
 
-    if (!quiet$set) {
+    if (!quiet$set) { # Provide user feedback:
 
       msg <- paste0("\u2014 User set 'goal = ", goal, "'\n")
 
@@ -207,7 +210,7 @@ fftrees_create <- function(formula = NULL,
 
   if ((goal == "wacc") & (!enable_wacc(sens.w))){ # correct to "bacc":
 
-    if (any(sapply(quiet, isFALSE))) {
+    if (any(sapply(quiet, isFALSE))) { # Provide user feedback:
 
       wrn_msg <- "User set 'goal = wacc', but 'sens.w = 0.50': Setting 'goal = bacc'"
 
@@ -228,25 +231,33 @@ fftrees_create <- function(formula = NULL,
 
     goal.chase <- "cost"
 
-    if (!quiet$set) { cat(u_f_msg("\u2014 Setting 'goal.chase = cost'\n")) }
+    if (!quiet$set) { # Provide user feedback:
+
+      cat(u_f_msg("\u2014 Setting 'goal.chase = cost'\n"))
+
+    }
 
   } else if (is.null(goal.chase)) { # use accuracy defaults (bacc/wacc):
 
     if (enable_wacc(sens.w)){ # set to 'wacc':
 
       goal.chase <- "wacc"
+
+      # Provide user feedback:
       if (!quiet$set) { cat(u_f_msg("\u2014 Setting 'goal.chase = wacc'\n")) }
 
     } else { # set to 'bacc' (as bacc == wacc):
 
       goal.chase <- "bacc"
+
+      # Provide user feedback:
       if (!quiet$set) { cat(u_f_msg("\u2014 Setting 'goal.chase = bacc'\n")) }
 
     }
 
-  } else { # feedback user setting:
+  } else { # Note user setting:
 
-    if (!quiet$set) {
+    if (!quiet$set) { # Provide user feedback:
 
       msg <- paste0("\u2014 User set 'goal.chase = ", goal.chase, "'\n")
 
@@ -263,7 +274,7 @@ fftrees_create <- function(formula = NULL,
 
   if ((goal.chase == "wacc") & (!enable_wacc(sens.w))){ # correct to "bacc":
 
-    if (any(sapply(quiet, isFALSE))) {
+    if (any(sapply(quiet, isFALSE))) { # Provide user feedback:
 
       wrn_msg <- "User set 'goal.chase = wacc', but 'sens.w = 0.50': Setting 'goal.chase = bacc'"
 
@@ -285,19 +296,25 @@ fftrees_create <- function(formula = NULL,
     if (enable_wacc(sens.w)){ # set to 'wacc':
 
       goal.threshold <- "wacc"
-      if (!quiet$set) { cat(u_f_msg("\u2014 Setting 'goal.threshold = wacc'\n")) }
+
+      if (!quiet$set) { # Provide user feedback:
+
+        cat(u_f_msg("\u2014 Setting 'goal.threshold = wacc'\n"))
+
+      }
 
     } else { # set to 'bacc' (as bacc == wacc):
 
       goal.threshold <- "bacc"
 
+      # Provide user feedback:
       if (!quiet$set) { cat(u_f_msg("\u2014 Setting 'goal.threshold = bacc'\n")) }
 
     }
 
-  } else { # feedback user setting:
+  } else { # Note user setting:
 
-    if (!quiet$set) {
+    if (!quiet$set) { # Provide user feedback:
 
       msg <- paste0("\u2014 User set 'goal.threshold = ", goal.threshold, "'\n")
 
@@ -340,7 +357,7 @@ fftrees_create <- function(formula = NULL,
 
   if ((goal.threshold == "wacc") & (!enable_wacc(sens.w))){ # correct to "bacc":
 
-    if (any(sapply(quiet, isFALSE))) {
+    if (any(sapply(quiet, isFALSE))) { # Provide user feedback:
 
       wrn_msg <- "User set 'goal.threshold = wacc', but 'sens.w = 0.50': Setting 'goal.threshold = bacc'"
 
@@ -356,7 +373,7 @@ fftrees_create <- function(formula = NULL,
 
   if (goal.threshold == "cost") { # note that this only makes sense for outcome costs:
 
-    if (any(sapply(quiet, isFALSE))) {
+    if (any(sapply(quiet, isFALSE))) { # Provide user feedback:
 
       wrn_msg <- "Optimizing cue thresholds for 'cost' only uses 'cost.outcomes', as 'cost.cues' are constant per cue."
 
@@ -412,7 +429,7 @@ fftrees_create <- function(formula = NULL,
   # If a non-default sens.w has been set, but 'wacc' is not a goal:
   if ((enable_wacc(sens.w)) & (!"wacc" %in% cur_goals)) { # provide feedback:
 
-    if (any(sapply(quiet, isFALSE))) {
+    if (any(sapply(quiet, isFALSE))) { # Provide user feedback:
 
       wrn_msg <- paste0("You set 'sens.w = ", sens.w, "': Did you mean to set a goal to 'wacc'?")
 
@@ -453,7 +470,7 @@ fftrees_create <- function(formula = NULL,
 
     max.levels <- 4  # default
 
-    if (!quiet$set) {
+    if (!quiet$set) { # Provide user feedback:
 
       cat(u_f_msg("\u2014 Setting 'max.levels = 4'\n"))
 
@@ -461,7 +478,7 @@ fftrees_create <- function(formula = NULL,
 
   } else { # user set max.levels:
 
-    if (!quiet$set) {
+    if (!quiet$set) { # Provide user feedback:
 
       msg <- paste0("\u2014 User set 'max.levels = ", max.levels, "'\n")
 
@@ -483,7 +500,7 @@ fftrees_create <- function(formula = NULL,
 
       cos <- paste(unlist(cost.outcomes), collapse = " ")
 
-      if (!quiet$set){
+      if (!quiet$set){ # Provide user feedback:
 
         msg <- paste0("\u2014 User set 'cost.outcomes' = (", cos, ")\n")
 
@@ -509,7 +526,7 @@ fftrees_create <- function(formula = NULL,
     # cost.outcomes <- list(hi = 0, fa = 1, mi = 1, cr = 0)  # default values (analogous to accuracy: r = -1)
     cost.outcomes <- cost_outcomes_default  # use global default
 
-    if (!quiet$set) {
+    if (!quiet$set) { # Provide user feedback:
 
       cos <- paste(unlist(cost.outcomes), collapse = " ")
       msg <- paste0("\u2014 Using default 'cost.outcomes' = (", cos, ")\n")
@@ -534,7 +551,7 @@ fftrees_create <- function(formula = NULL,
 
       ccs <- paste(unlist(cost.cues), collapse = " ")
 
-      if (!quiet$set){
+      if (!quiet$set){ # Provide user feedback:
 
         msg <- paste0("\u2014 User set 'cost.cues' = (", ccs, ")")
 
@@ -557,7 +574,7 @@ fftrees_create <- function(formula = NULL,
 
   } else { # B: use default cost.cues:
 
-    if (!quiet$set) {
+    if (!quiet$set) { # Provide user feedback:
 
       msg <- paste0("\u2014 Using default 'cost.cues' = (", cost_cues_default, " per cue)\n")
 
@@ -598,6 +615,22 @@ fftrees_create <- function(formula = NULL,
 
     testthat::expect_gt(stopping.par, expected = 0)
     testthat::expect_lt(stopping.par, expected = 1)
+
+  }
+
+
+  if (!quiet$set) { # Provide user feedback:
+
+    msg <- paste0("\u2014 Using 'stopping.rule = ", stopping.rule, "' (with 'stopping.par = ", stopping.par, "')\n")
+
+    cat(u_f_msg(msg))
+
+  }
+
+  # Disallow some combination:
+  if (stopping.rule == "statdelta" & goal.chase == "cost"){
+
+    stop("The stopping.rule 'statdelta' requires an accuracy measure as its 'goal.chase' value (e.g., 'bacc')")
 
   }
 

--- a/R/fftrees_grow_fan.R
+++ b/R/fftrees_grow_fan.R
@@ -555,7 +555,7 @@ fftrees_grow_fan <- function(x,
 
           debug <- FALSE  # 4debugging
 
-          if (debug){ # Provide user feedback:
+          if (debug){ # Provide debugging feedback:
 
             goal_change_rnd <- round(asif_stats$goal_change[level_current], 3)
 

--- a/R/summaryFFTrees_function.R
+++ b/R/summaryFFTrees_function.R
@@ -94,10 +94,14 @@ summary.FFTrees <- function(object,
 
   # Parameter summary: ------
 
-  # General information: Current algorithm, goals, numerical parameters, etc.:
+  # General information: Current algorithm, max levels, stopping rule, goals:
 
-  params_txt <- paste0("algorithm = '", object$params$algorithm, "'")
-  params_num <- paste0("max.levels = ", object$params$max.levels)
+  params_algo <- paste0("algorithm = '", object$params$algorithm, "'")
+
+  params_mxlv <- paste0("max.levels = ", object$params$max.levels)
+
+  params_stop <- paste0("stopping.rule = '", object$params$stopping.rule,
+                        "', stopping.par = ", object$params$stopping.par)
 
   params_goal <- paste0("goal = '", object$params$goal,
                         "', goal.chase = '", object$params$goal.chase,
@@ -116,8 +120,9 @@ summary.FFTrees <- function(object,
 
   # General user feedback (in all settings): ----
   cat("- Parameters: ",
-      params_txt, ", ", # "              ",
-      params_num, ",\n",   "              ",
+      params_algo, ", ", # "              ",
+      params_mxlv, ",\n",   "              ",
+      params_stop, ",\n",   "              ",
       params_goal, ".",
       sep = "")
   cat("\n")

--- a/README.Rmd
+++ b/README.Rmd
@@ -46,6 +46,7 @@ url_JDM_doi <- "https://doi.org/10.1017/S1930297500006239"
 <!-- [![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/FFTrees?color='00a9e0')](https://www.r-pkg.org/pkg/FFTrees) -->
 <!-- Release badges end. -->
 
+
 <!-- ALL badges start: --> 
 <!-- [![CRAN status](https://www.r-pkg.org/badges/version/FFTrees)](https://CRAN.R-project.org/package=FFTrees) -->
 <!-- [![Build Status](https://travis-ci.org/ndphillips/FFTrees.svg?branch=master)](https://travis-ci.org/ndphillips/FFTrees) -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- README.md is generated from README.Rmd. Please only edit the .Rmd file! -->
 <!-- Title, version and logo: -->
 
-# FFTrees 1.9.0.9017 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
+# FFTrees 1.9.0.9018 <img src = "./inst/FFTrees_Logo.jpg" align = "right" alt = "FFTrees" width = "225" />
 
 <!-- Devel badges start: -->
 
@@ -333,6 +333,6 @@ Examples include:
 
 ------------------------------------------------------------------------
 
-\[File `README.Rmd` last updated on 2023-03-09.\]
+\[File `README.Rmd` last updated on 2023-03-10.\]
 
 <!-- eof. -->

--- a/man/FFTrees.Rd
+++ b/man/FFTrees.Rd
@@ -89,15 +89,16 @@ Available options are:
 \itemize{
   \item{\code{"exemplars"}: A tree grows until only a small proportion of unclassified exemplars remain;}
   \item{\code{"levels"}: A tree grows until a certain level is reached;}
-  \item{\code{"statdelta"} (experimental): A tree grows until the change in the criterion statistic \code{goal.chase}
-  reaches some specified level.}
+  \item{\code{"statdelta"}: A tree grows until the change in the criterion statistic \code{goal.chase} exceeds some threshold level.
+  (This setting is currently experimental and includes the first level beyond threshold.
+  As tree statistics can be non-monotonic, this option may yield inconsistent results.)}
   }
-All stopping methods use \code{stopping.par} to define a numeric threshold.
+All stopping methods use \code{stopping.par} to set a numeric threshold value.
 Default: \code{stopping.rule = "exemplars"}.}
 
 \item{stopping.par}{numeric. A numeric parameter indicating the criterion value for the current \code{stopping.rule}.
 For stopping.rule \code{"levels"}, this is the number of desired levels (as an integer).
-For stopping rule \code{"exemplars"}, this is the smallest percentage of exemplars allowed in the last level.
+For stopping rule \code{"exemplars"}, this is the smallest proportion of exemplars allowed in the last level.
 For stopping.rule \code{"statdelta"}, this is the minimum required change (in the \code{goal.chase} value) to include a level.
 Default: \code{stopping.par = .10}.}
 
@@ -142,12 +143,12 @@ If specified, no new FFTs are being fitted (i.e., \code{algorithm} and functions
 Instead, the tree definitions provided are used to re-evaluate the current \code{FFTrees} object on current data.}
 
 \item{do.comp, do.lr, do.cart, do.svm, do.rf}{Should alternative algorithms be used for comparison (as logical)?
-All options set to \code{TRUE} by default. Available options correspond to:
+All options are set to \code{TRUE} by default. Available options correspond to:
 \itemize{
-  \item{\code{do.lr}: Logistic regression (using \code{\link{glm}} from \strong{stats} with \code{family = "binomial"});}
-  \item{\code{do.cart}: Decision trees (using \code{rpart} from \strong{rpart});}
-  \item{\code{do.svm}: Support vector machines (using \code{svm} from \strong{e1071});}
-  \item{\code{do.rf}: Random forests (using \code{randomForest} from \strong{randomForest}.}
+  \item{\code{do.lr}: Logistic regression (LR, using \code{\link{glm}} from \strong{stats} with \code{family = "binomial"});}
+  \item{\code{do.cart}: Classification and regression trees (CART, using \code{rpart} from \strong{rpart});}
+  \item{\code{do.svm}: Support vector machines (SVM, using \code{svm} from \strong{e1071});}
+  \item{\code{do.rf}: Random forests (RF, using \code{randomForest} from \strong{randomForest}.}
 }
 Specifying \code{do.comp = FALSE} sets all available options to \code{FALSE}.}
 
@@ -168,7 +169,8 @@ An \code{FFTrees} object with the following elements:
   \item{trees}{A list of FFTs created, with further details contained in \code{n}, \code{best}, \code{definitions}, \code{inwords}, \code{stats}, \code{level_stats}, and \code{decisions}.}
   \item{data}{The original training and test data (if available).}
   \item{params}{A list of defined control parameters (e.g.; \code{algorithm}, \code{goal}, \code{sens.w}, as well as various thresholds, stopping rule, and cost parameters).}
-  \item{competition}{Models and classification statistics for competitive classification algorithms: Logistic regression, CART, random forests RF, and SVM.}
+  \item{competition}{Models and classification statistics for competitive classification algorithms:
+  Logistic regression (\code{lr}), classification and regression trees (\code{cart}), random forests (\code{rf}), and support vector machines (\code{svm}).}
   \item{cues}{A list of cue information, with further details contained in \code{thresholds} and \code{stats}.}
 }
 }

--- a/man/FFTrees.Rd
+++ b/man/FFTrees.Rd
@@ -74,8 +74,8 @@ All default goals are set in \code{\link{fftrees_create}}.}
 \item{max.levels}{integer. The maximum number of nodes (or levels) considered for an FFT.
 As all combinations of possible exit structures are considered, larger values of \code{max.levels} will create larger sets of FFTs.}
 
-\item{numthresh.method}{character. How should thresholds for numeric cues be determined?
-\code{"o"} will optimize thresholds (for \code{goal.threshold}), while \code{"m"} will always use the median.
+\item{numthresh.method}{How should thresholds for numeric cues be determined (as character)?
+\code{"o"} will optimize thresholds (for \code{goal.threshold}), while \code{"m"} will use the median.
 Default: \code{numthresh.method = "o"}.}
 
 \item{numthresh.n}{The number of numeric thresholds to try (as integer).
@@ -84,16 +84,21 @@ Default: \code{numthresh.n = 10}.}
 \item{repeat.cues}{May cues occur multiple times within a tree (as logical)?
 Default: \code{repeat.cues = TRUE}.}
 
-\item{stopping.rule}{A character string indicating the method to stop growing trees. Available options are:
-\code{"levels"} means the tree grows until a certain level;
-\code{"exemplars"} means the tree grows until a certain number of unclassified exemplars remain;
-\code{"statdelta"} means the tree grows until the change in the criterion statistic (\code{goal.chase}) is below a specified level.
+\item{stopping.rule}{A character string indicating the method to stop growing trees.
+Available options are:
+\itemize{
+  \item{\code{"exemplars"}: A tree grows until only a small proportion of unclassified exemplars remain;}
+  \item{\code{"levels"}: A tree grows until a certain level is reached;}
+  \item{\code{"statdelta"} (experimental): A tree grows until the change in the criterion statistic \code{goal.chase}
+  reaches some specified level.}
+  }
+All stopping methods use \code{stopping.par} to define a numeric threshold.
 Default: \code{stopping.rule = "exemplars"}.}
 
-\item{stopping.par}{numeric. A numeric value indicating the parameter for the stopping rule.
-For stopping.rule \code{"levels"}, this is the number of levels (as an integer).
+\item{stopping.par}{numeric. A numeric parameter indicating the criterion value for the current \code{stopping.rule}.
+For stopping.rule \code{"levels"}, this is the number of desired levels (as an integer).
 For stopping rule \code{"exemplars"}, this is the smallest percentage of exemplars allowed in the last level.
-For stopping.rule \code{"statdelta"}, this is the minimum required increase (in the \code{goal.chase} value) to include a level.
+For stopping.rule \code{"statdelta"}, this is the minimum required change (in the \code{goal.chase} value) to include a level.
 Default: \code{stopping.par = .10}.}
 
 \item{sens.w}{A numeric value from \code{0} to \code{1} indicating how to weight


### PR DESCRIPTION
This PR enables `stopping.rule = "statdelta"` even for `goal.chase = "cost"` (but the functionality remains experimental and somewhat dubious, as many stats seem to change in a non-monotonic fashion).  

+ corresponding updates of code comments and documentation