### PR TITLE
Add pkg anchor when linking to external function in documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: FFTrees
 Type: Package
 Title: Generate, Visualise, and Evaluate Fast-and-Frugal Decision Trees
 Version: 2.0.0.9000
-Date: 2024-04-22
+Date: 2024-07-15
 Authors@R: c(person("Nathaniel", "Phillips", role = c("aut"), email = "Nathaniel.D.Phillips.is@gmail.com", comment = c(ORCID = "0000-0002-8969-7013")),
              person("Hansjoerg", "Neth", role = c("aut", "cre"), email = "h.neth@uni.kn", comment = c(ORCID = "0000-0001-5427-3141")),
              person("Jan", "Woike", role = "aut", comment = c(ORCID = "0000-0002-6816-121X")),

--- a/R/util_stats.R
+++ b/R/util_stats.R
@@ -200,7 +200,7 @@ add_stats <- function(data, # df with frequency counts of classification outcome
 #'
 #' The main input are 2 logical vectors of prediction and criterion values.
 #'
-#' The primary confusion matrix is computed by \code{\link{caret::confusionMatrix}}.
+#' The primary confusion matrix is computed by \code{\link[caret]{confusionMatrix}}.
 #'
 #' @param prediction_v logical. A logical vector of predictions.
 #' @param criterion_v logical. A logical vector of (TRUE) criterion values.

--- a/R/util_stats.R
+++ b/R/util_stats.R
@@ -200,7 +200,7 @@ add_stats <- function(data, # df with frequency counts of classification outcome
 #'
 #' The main input are 2 logical vectors of prediction and criterion values.
 #'
-#' The primary confusion matrix is computed by \code{\link{confusionMatrix}} of the \strong{caret} package.
+#' The primary confusion matrix is computed by \code{\link{caret::confusionMatrix}}.
 #'
 #' @param prediction_v logical. A logical vector of predictions.
 #' @param criterion_v logical. A logical vector of (TRUE) criterion values.

--- a/man/classtable.Rd
+++ b/man/classtable.Rd
@@ -52,5 +52,5 @@ Default: \code{quiet_mis = FALSE} (i.e., show user feedback).}
 The main input are 2 logical vectors of prediction and criterion values.
 }
 \details{
-The primary confusion matrix is computed by \code{\link{caret::confusionMatrix}}.
+The primary confusion matrix is computed by \code{\link[caret]{confusionMatrix}}.
 }

--- a/man/classtable.Rd
+++ b/man/classtable.Rd
@@ -52,5 +52,5 @@ Default: \code{quiet_mis = FALSE} (i.e., show user feedback).}
 The main input are 2 logical vectors of prediction and criterion values.
 }
 \details{
-The primary confusion matrix is computed by \code{\link{confusionMatrix}} of the \strong{caret} package.
+The primary confusion matrix is computed by \code{\link{caret::confusionMatrix}}.
 }


### PR DESCRIPTION
Edited documentation of classtable() function to provide package anchor (using "\link[caret]{confusionMatrix}" syntax) to prevent current CRAN Note when checking cross-references.